### PR TITLE
fix(release): compile Intel Swift helpers for x86_64

### DIFF
--- a/scripts/build-macos-appshot-helper.ts
+++ b/scripts/build-macos-appshot-helper.ts
@@ -12,8 +12,13 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import {
+  swiftTargetForNativeRuntime,
+  type NativeRuntimeArchitecture,
+} from "./native-runtime-manifest";
+
 interface BuildStamp {
-  readonly architecture: "arm64" | "x64";
+  readonly architecture: NativeRuntimeArchitecture;
   readonly minimumMacOS: "12.0";
   readonly sourceSha256: string;
 }
@@ -90,7 +95,7 @@ function main(): void {
       "-O",
       "-parse-as-library",
       "-target",
-      `${architecture}-apple-macos12.0`,
+      swiftTargetForNativeRuntime(architecture),
       sourcePath,
       "-o",
       temporaryBinary,

--- a/scripts/native-runtime-manifest.test.ts
+++ b/scripts/native-runtime-manifest.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 
-import { parseNativeRuntimeManifest } from "./native-runtime-manifest";
+import {
+  parseNativeRuntimeManifest,
+  swiftTargetForNativeRuntime,
+} from "./native-runtime-manifest";
 
 const manifest = {
   schemaVersion: 3,
@@ -49,6 +52,11 @@ const manifest = {
 };
 
 describe("native runtime manifest", () => {
+  test("maps package architectures to valid Swift target triples", () => {
+    expect(swiftTargetForNativeRuntime("arm64")).toBe("arm64-apple-macos12.0");
+    expect(swiftTargetForNativeRuntime("x64")).toBe("x86_64-apple-macos12.0");
+  });
+
   test("accepts the complete architecture-bound package inventory", () => {
     expect(parseNativeRuntimeManifest(manifest)).toEqual(manifest);
   });

--- a/scripts/native-runtime-manifest.ts
+++ b/scripts/native-runtime-manifest.ts
@@ -3,6 +3,13 @@ import { readFileSync } from "node:fs";
 
 export type NativeRuntimeArchitecture = "arm64" | "x64";
 
+export const swiftTargetForNativeRuntime = (
+  architecture: NativeRuntimeArchitecture,
+): "arm64-apple-macos12.0" | "x86_64-apple-macos12.0" =>
+  architecture === "arm64"
+    ? "arm64-apple-macos12.0"
+    : "x86_64-apple-macos12.0";
+
 export type NativeRuntimeBinaryName =
   | "nodex"
   | "nodex-appshot-helper"

--- a/scripts/stage-rust-core.ts
+++ b/scripts/stage-rust-core.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import {
   NATIVE_RUNTIME_BINARY_PATHS,
   sha256File,
+  swiftTargetForNativeRuntime,
   type NativeRuntimeArchitecture,
   type NativeRuntimeBinaryName,
   type NativeRuntimeManifest,
@@ -36,9 +37,6 @@ const TARGETS = {
 
 const expectedFileArchitecture = (architecture: TargetArchitecture): string =>
   architecture === "arm64" ? "arm64" : "x86_64";
-
-const swiftTarget = (architecture: TargetArchitecture): string =>
-  `${architecture === "arm64" ? "arm64" : "x86_64"}-apple-macos12.0`;
 
 const parseArguments = (argv: readonly string[]): Arguments => {
   let targetArch: TargetArchitecture | null = null;
@@ -121,7 +119,7 @@ const stage = ({ targetArch, outputRoot, signIdentity }: Arguments): void => {
       "-O",
       "-parse-as-library",
       "-target",
-      swiftTarget(targetArch),
+      swiftTargetForNativeRuntime(targetArch),
       serviceSource,
       "-o",
       serviceBuild,
@@ -141,7 +139,7 @@ const stage = ({ targetArch, outputRoot, signIdentity }: Arguments): void => {
       "-O",
       "-parse-as-library",
       "-target",
-      swiftTarget(targetArch),
+      swiftTargetForNativeRuntime(targetArch),
       appshotHelperSource,
       "-o",
       appshotHelperBuild,


### PR DESCRIPTION
## What changed

- translate the Node/Electron `x64` architecture to Swift's `x86_64` target triple
- share that mapping between prepared Appshot helper builds and release native staging
- cover both macOS architectures with a native-runtime contract test

## Why

The no-side-effect Distribution Rehearsal reached the real Intel build and failed before packaging because `swiftc` rejected `x64-apple-macos12.0`. Swift expects `x86_64-apple-macos12.0` while Nodex manifests correctly continue to use `x64`.

Rehearsal evidence: https://github.com/junyudev/nodex/actions/runs/30677869828

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/native-runtime-manifest.test.ts` (4 passed)
- `pnpm run typecheck`
- `pnpm run lint`
- scoped ESLint for all four changed scripts

After merge and protected-main CI, Distribution Rehearsal will be rerun before v0.2.0 metadata is prepared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS native runtime builds by consistently selecting the correct Swift compilation target for ARM64 and x64 architectures.
  * Added validation to ensure architecture-specific package builds use the expected macOS targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->