### PR TITLE
fix(release): unblock signed distribution rehearsal

### DIFF
--- a/crates/nodex-core-protocol/src/client.rs
+++ b/crates/nodex-core-protocol/src/client.rs
@@ -41,7 +41,9 @@ const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024;
 const MAX_AUTH_BYTES: u64 = 128;
 const MAX_HTTP_RESPONSE_HEADER_BYTES: usize = 64 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+// Cold selection includes one-time Store backup and migration before Core can
+// publish its runtime descriptor, which can exceed ten seconds on Intel Macs.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 
 const CONNECTION_HEADER: &str = "x-nodex-connection-id";
 const CONNECTION_BINDING_HEADER: &str = "x-nodex-connection-binding";

--- a/scripts/prepared-electron-build.test.ts
+++ b/scripts/prepared-electron-build.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, test } from "vitest";
 import {
@@ -140,6 +141,36 @@ const makeFixture = (): {
   };
 };
 
+const initializeGitFixture = (repositoryRoot: string): {
+  commit: string;
+  tree: string;
+} => {
+  fs.writeFileSync(
+    path.join(repositoryRoot, ".gitignore"),
+    ".generated/prepared.json\n",
+    "utf8",
+  );
+  execFileSync("git", ["init"], { cwd: repositoryRoot });
+  execFileSync("git", ["config", "user.email", "prepared-build@example.invalid"], {
+    cwd: repositoryRoot,
+  });
+  execFileSync("git", ["config", "user.name", "Prepared Build Test"], {
+    cwd: repositoryRoot,
+  });
+  execFileSync("git", ["add", "."], { cwd: repositoryRoot });
+  execFileSync("git", ["commit", "-m", "test fixture"], { cwd: repositoryRoot });
+  return {
+    commit: execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+    }).trim(),
+    tree: execFileSync("git", ["rev-parse", "HEAD^{tree}"], {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+    }).trim(),
+  };
+};
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -147,6 +178,21 @@ afterEach(() => {
 });
 
 describe("prepared Electron build", () => {
+  test("records clean and dirty Git source state without conflating empty status output with failure", () => {
+    const fixture = makeFixture();
+    const source = initializeGitFixture(fixture.repositoryRoot);
+
+    const clean = recordPreparedElectronBuild(fixture);
+    expect(clean.source).toMatchObject({
+      baseCommit: source.commit,
+      baseTree: source.tree,
+      state: "clean",
+    });
+
+    fs.appendFileSync(path.join(fixture.repositoryRoot, "src/value.ts"), "changed\n");
+    expect(recordPreparedElectronBuild(fixture).source.state).toBe("dirty");
+  });
+
   test("reuses only the exact recorded inputs and output closure", () => {
     const fixture = makeFixture();
     const recorded = recordPreparedElectronBuild(fixture);

--- a/scripts/prepared-electron-build.ts
+++ b/scripts/prepared-electron-build.ts
@@ -265,12 +265,20 @@ const readSource = (root: string, snapshotDigest: string): PreparedBuildSource =
       state: "snapshot",
     };
   }
-  const status = readGitValue(root, ["status", "--porcelain", "--untracked-files=normal"]);
+  const status = spawnSync(
+    "git",
+    ["status", "--porcelain", "--untracked-files=normal"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
   return {
     baseCommit,
     baseTree,
     snapshotDigest,
-    state: status === null || status.length > 0 ? "dirty" : "clean",
+    state: status.status === 0 && status.stdout.trim().length === 0 ? "clean" : "dirty",
   };
 };
 


### PR DESCRIPTION
## What changed

- distinguish a successful empty `git status --porcelain` result from a failed Git command
- record clean release sources as `clean` in the prepared Electron build manifest
- cover clean and dirty worktrees with a real temporary Git repository regression test
- allow the native CLI a bounded 60-second Core startup window for one-time Store backup and migration on slower Intel Macs

## Why

Distribution Rehearsal completed Developer ID signing and Apple notarization for both architectures. It exposed two independent final-gate failures:

1. The arm64 architecture-bundle identity gate rejected the build because clean Git status output was normalized to `null` and incorrectly recorded as `dirty`.
2. The x64 packaged CLI reached its fixed 10-second Core selection timeout while migrating the legacy-profile smoke fixture. Electron already uses a much larger bounded startup window; 60 seconds keeps the CLI finite while accommodating slower Intel cold starts.

Rehearsal evidence: https://github.com/junyudev/nodex/actions/runs/30692418555

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/prepared-electron-build.test.ts` (6 passed)
- `pnpm run typecheck`
- `pnpm run lint`
- `cargo fmt --check`
- `cargo test -p nodex-core-protocol` (12 passed)
