### PR TITLE
fix(release): own macOS signing keychain

### DIFF
--- a/.github/workflows/_macos-distribution.yml
+++ b/.github/workflows/_macos-distribution.yml
@@ -85,7 +85,7 @@ jobs:
             }
           ' "${RUNNER_TEMP}/source.json"
 
-      - name: Materialize App Store Connect API key
+      - name: Materialize macOS signing credentials
         env:
           APPLE_API_ISSUER: ${{ secrets.apple_api_issuer }}
           APPLE_API_KEY_B64: ${{ secrets.apple_api_key_b64 }}
@@ -99,17 +99,12 @@ jobs:
             echo "Missing macOS signing or App Store Connect credentials." >&2
             exit 1
           fi
-          key_path="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY_ID}.p8"
-          node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.APPLE_API_KEY_B64, "base64"))' "${key_path}"
-          chmod 600 "${key_path}"
-          echo "APPLE_API_KEY=${key_path}" >> "${GITHUB_ENV}"
+          pnpm exec tsx scripts/ci/macos-signing-keychain.ts prepare
 
       - name: Build and verify signed distribution
         env:
           APPLE_API_ISSUER: ${{ secrets.apple_api_issuer }}
           APPLE_API_KEY_ID: ${{ secrets.apple_api_key_id }}
-          CSC_KEY_PASSWORD: ${{ secrets.csc_key_password }}
-          CSC_LINK: ${{ secrets.csc_link }}
           NODE_OPTIONS: --max-old-space-size=6144
           SENTRY_AUTH_TOKEN: ${{ inputs.upload_sentry_sourcemaps && secrets.sentry_auth_token || '' }}
           SENTRY_ORG: ${{ inputs.upload_sentry_sourcemaps && secrets.sentry_org || '' }}
@@ -139,12 +134,19 @@ jobs:
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Remove App Store Connect API key
+      - name: Remove macOS signing credentials
         if: always()
         shell: bash
         run: |
-          if [[ -n "${APPLE_API_KEY:-}" && -f "${APPLE_API_KEY}" ]]; then
+          if [[ -n "${NODEX_SIGNING_KEYCHAIN:-}" ]]; then
+            security delete-keychain "${NODEX_SIGNING_KEYCHAIN}" >/dev/null 2>&1 || true
+            rm -f "${NODEX_SIGNING_KEYCHAIN}"
+          fi
+          if [[ -n "${APPLE_API_KEY:-}" ]]; then
             rm -f "${APPLE_API_KEY}"
+          fi
+          if [[ -n "${NODEX_SIGNING_CERTIFICATE:-}" ]]; then
+            rm -f "${NODEX_SIGNING_CERTIFICATE}"
           fi
 
       - name: Upload arm64 architecture bundle
@@ -194,7 +196,7 @@ jobs:
             }
           ' "${RUNNER_TEMP}/source.json"
 
-      - name: Materialize App Store Connect API key
+      - name: Materialize macOS signing credentials
         env:
           APPLE_API_ISSUER: ${{ secrets.apple_api_issuer }}
           APPLE_API_KEY_B64: ${{ secrets.apple_api_key_b64 }}
@@ -208,17 +210,12 @@ jobs:
             echo "Missing macOS signing or App Store Connect credentials." >&2
             exit 1
           fi
-          key_path="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY_ID}.p8"
-          node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.APPLE_API_KEY_B64, "base64"))' "${key_path}"
-          chmod 600 "${key_path}"
-          echo "APPLE_API_KEY=${key_path}" >> "${GITHUB_ENV}"
+          pnpm exec tsx scripts/ci/macos-signing-keychain.ts prepare
 
       - name: Build and verify signed distribution
         env:
           APPLE_API_ISSUER: ${{ secrets.apple_api_issuer }}
           APPLE_API_KEY_ID: ${{ secrets.apple_api_key_id }}
-          CSC_KEY_PASSWORD: ${{ secrets.csc_key_password }}
-          CSC_LINK: ${{ secrets.csc_link }}
           NODE_OPTIONS: --max-old-space-size=6144
           SENTRY_AUTH_TOKEN: ''
           SENTRY_ORG: ''
@@ -243,12 +240,19 @@ jobs:
             echo '```'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Remove App Store Connect API key
+      - name: Remove macOS signing credentials
         if: always()
         shell: bash
         run: |
-          if [[ -n "${APPLE_API_KEY:-}" && -f "${APPLE_API_KEY}" ]]; then
+          if [[ -n "${NODEX_SIGNING_KEYCHAIN:-}" ]]; then
+            security delete-keychain "${NODEX_SIGNING_KEYCHAIN}" >/dev/null 2>&1 || true
+            rm -f "${NODEX_SIGNING_KEYCHAIN}"
+          fi
+          if [[ -n "${APPLE_API_KEY:-}" ]]; then
             rm -f "${APPLE_API_KEY}"
+          fi
+          if [[ -n "${NODEX_SIGNING_CERTIFICATE:-}" ]]; then
+            rm -f "${NODEX_SIGNING_CERTIFICATE}"
           fi
 
       - name: Upload x64 architecture bundle

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -85,7 +85,7 @@ Configure these repository Action secrets:
 
 | Secret | Required authority |
 | --- | --- |
-| `CSC_LINK`, `CSC_KEY_PASSWORD` | Developer ID Application certificate and its password |
+| `CSC_LINK`, `CSC_KEY_PASSWORD` | Base64 Developer ID Application `.p12` certificate and its export password |
 | `APPLE_API_KEY_B64`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER` | App Store Connect notarization key |
 | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` | Release/source-map upload for the Nodex project |
 | `NODEX_SKILLS_GITHUB_TOKEN` | Fine-grained Contents read/write on `NodexApp/skills` only |
@@ -99,6 +99,13 @@ implicit environment-secret resolution or same-name precedence inside nested
 reusable workflows. Record PAT expiry dates in release operations and rotate
 them before expiry. Remove duplicate credentials from the legacy `release`
 environment after rehearsal succeeds.
+
+Distribution imports the Developer ID certificate into a per-job local
+keychain using a random keychain password, grants non-interactive Apple tool
+access with that keychain password, and removes both the keychain and decoded
+credentials in an `always()` cleanup step. Electron Builder discovers the
+installed identity but does not own credential import or temporary-keychain
+creation.
 
 If a release must intentionally omit Sentry source maps, change the production
 workflow input to `false` in a reviewed foundation commit; do not silently

--- a/scripts/ci/macos-signing-keychain.test.ts
+++ b/scripts/ci/macos-signing-keychain.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { macosSigningSecurityCommands } from "./macos-signing-keychain";
+
+describe("macOS signing keychain", () => {
+  test("keeps the PKCS#12 and temporary keychain passwords in their distinct security commands", () => {
+    const commands = macosSigningSecurityCommands({
+      certificatePassword: "certificate-password",
+      keychainPassword: "keychain-password",
+      paths: {
+        apiKey: "/tmp/AuthKey.p8",
+        certificate: "/tmp/certificate.p12",
+        keychain: "/tmp/signing.keychain-db",
+      },
+    });
+
+    expect(commands).toContainEqual([
+      "import",
+      "/tmp/certificate.p12",
+      "-P",
+      "certificate-password",
+      "-t",
+      "cert",
+      "-f",
+      "pkcs12",
+      "-k",
+      "/tmp/signing.keychain-db",
+      "-T",
+      "/usr/bin/codesign",
+      "-T",
+      "/usr/bin/productbuild",
+    ]);
+    expect(commands).toContainEqual([
+      "set-key-partition-list",
+      "-S",
+      "apple-tool:,apple:",
+      "-s",
+      "-k",
+      "keychain-password",
+      "/tmp/signing.keychain-db",
+    ]);
+  });
+});

--- a/scripts/ci/macos-signing-keychain.ts
+++ b/scripts/ci/macos-signing-keychain.ts
@@ -1,0 +1,174 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { appendFileSync, chmodSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface MacosSigningPaths {
+  readonly apiKey: string;
+  readonly certificate: string;
+  readonly keychain: string;
+}
+
+interface MacosSigningSecurityOptions {
+  readonly certificatePassword: string;
+  readonly keychainPassword: string;
+  readonly paths: MacosSigningPaths;
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+
+export const macosSigningSecurityCommands = (
+  options: MacosSigningSecurityOptions,
+): readonly (readonly string[])[] => [
+  ["create-keychain", "-p", options.keychainPassword, options.paths.keychain],
+  ["set-keychain-settings", "-lut", "21600", options.paths.keychain],
+  ["unlock-keychain", "-p", options.keychainPassword, options.paths.keychain],
+  [
+    "import",
+    options.paths.certificate,
+    "-P",
+    options.certificatePassword,
+    "-t",
+    "cert",
+    "-f",
+    "pkcs12",
+    "-k",
+    options.paths.keychain,
+    "-T",
+    "/usr/bin/codesign",
+    "-T",
+    "/usr/bin/productbuild",
+  ],
+  [
+    "set-key-partition-list",
+    "-S",
+    "apple-tool:,apple:",
+    "-s",
+    "-k",
+    options.keychainPassword,
+    options.paths.keychain,
+  ],
+  ["list-keychains", "-d", "user", "-s", options.paths.keychain],
+];
+
+const requiredEnvironmentValue = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (value) return value;
+  throw new Error(`Missing required macOS signing environment variable: ${name}`);
+};
+
+const decodeBase64Secret = (value: string, label: string): Buffer => {
+  const payload = value.startsWith("data:")
+    ? value.slice(value.indexOf(",") + 1)
+    : value;
+  const normalized = payload.replaceAll(/\s/gu, "");
+  if (!normalized || !/^[A-Za-z0-9+/]+={0,2}$/u.test(normalized)) {
+    throw new Error(`${label} must be a base64 payload or base64 data URL.`);
+  }
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.length > 0) return decoded;
+  throw new Error(`${label} decoded to an empty file.`);
+};
+
+const pathsFor = (runnerTemp: string, apiKeyId: string): MacosSigningPaths => {
+  if (!/^[A-Za-z0-9]+$/u.test(apiKeyId)) {
+    throw new Error("APPLE_API_KEY_ID must be alphanumeric.");
+  }
+  return {
+    apiKey: path.join(runnerTemp, `AuthKey_${apiKeyId}.p8`),
+    certificate: path.join(runnerTemp, "nodex-developer-id.p12"),
+    keychain: path.join(runnerTemp, "nodex-signing.keychain-db"),
+  };
+};
+
+const deleteKeychain = (keychainPath: string): void => {
+  if (process.platform === "darwin") {
+    spawnSync("/usr/bin/security", ["delete-keychain", keychainPath], {
+      stdio: "ignore",
+    });
+  }
+  rmSync(keychainPath, { force: true });
+};
+
+const cleanupPaths = (paths: MacosSigningPaths): void => {
+  deleteKeychain(paths.keychain);
+  rmSync(paths.apiKey, { force: true });
+  rmSync(paths.certificate, { force: true });
+};
+
+const appendJobEnvironment = (
+  environmentFile: string,
+  entries: Readonly<Record<string, string>>,
+): void => {
+  const lines = Object.entries(entries).map(([name, value]) => {
+    if (value.includes("\n") || value.includes("\r")) {
+      throw new Error(`GitHub Actions environment value ${name} contains a newline.`);
+    }
+    return `${name}=${value}`;
+  });
+  appendFileSync(environmentFile, `${lines.join("\n")}\n`, "utf8");
+};
+
+const prepare = (): void => {
+  if (process.platform !== "darwin") {
+    throw new Error("macOS signing credentials can only be prepared on macOS.");
+  }
+  const runnerTemp = requiredEnvironmentValue("RUNNER_TEMP");
+  const environmentFile = requiredEnvironmentValue("GITHUB_ENV");
+  const apiKeyId = requiredEnvironmentValue("APPLE_API_KEY_ID");
+  const paths = pathsFor(runnerTemp, apiKeyId);
+  const certificatePassword = requiredEnvironmentValue("CSC_KEY_PASSWORD");
+  const keychainPassword = randomBytes(32).toString("hex");
+
+  cleanupPaths(paths);
+  writeFileSync(
+    paths.apiKey,
+    decodeBase64Secret(requiredEnvironmentValue("APPLE_API_KEY_B64"), "APPLE_API_KEY_B64"),
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    paths.certificate,
+    decodeBase64Secret(requiredEnvironmentValue("CSC_LINK"), "CSC_LINK"),
+    { mode: 0o600 },
+  );
+  chmodSync(paths.apiKey, 0o600);
+  chmodSync(paths.certificate, 0o600);
+
+  try {
+    for (const command of macosSigningSecurityCommands({
+      certificatePassword,
+      keychainPassword,
+      paths,
+    })) {
+      execFileSync("/usr/bin/security", [...command], { stdio: "inherit" });
+    }
+  } catch (error) {
+    cleanupPaths(paths);
+    throw error;
+  }
+
+  appendJobEnvironment(environmentFile, {
+    APPLE_API_KEY: paths.apiKey,
+    CSC_IDENTITY_AUTO_DISCOVERY: "true",
+    NODEX_SIGNING_CERTIFICATE: paths.certificate,
+    NODEX_SIGNING_KEYCHAIN: paths.keychain,
+  });
+};
+
+const main = (): void => {
+  const [command, ...extraArguments] = process.argv.slice(2);
+  if (extraArguments.length > 0 || command !== "prepare") {
+    throw new Error("Usage: macos-signing-keychain.ts prepare");
+  }
+  prepare();
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- import the Developer ID certificate into a workflow-owned, per-job keychain
- use separate PKCS#12 and keychain passwords for their correct Security.framework operations
- let electron-builder discover the prepared signing identity without managing credentials
- always remove the temporary keychain, certificate, and App Store Connect API key

## Why

[Distribution Rehearsal #30694635461](https://github.com/junyudev/nodex/actions/runs/30694635461) completed the arm64 distribution successfully, but the x64 runner failed in electron-builder's temporary-keychain setup because `set-key-partition-list` received the certificate export password instead of the generated keychain password. The same repository credentials signed and notarized the preceding x64 attempt and this run's arm64 build, so this is a keychain-lifecycle issue rather than a secret-value issue.

This change follows the GitHub-hosted macOS runner contract explicitly: the workflow creates and unlocks its own local keychain, imports the `.p12`, configures non-interactive Apple tool access with the keychain password, and removes all materialized credentials in `always()` cleanup.

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/ci/macos-signing-keychain.test.ts`
- `pnpm run ci:workflow-contracts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

After merge, run a new no-promotion dual-architecture Distribution Rehearsal before preparing v0.2.0 release metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS release signing setup with temporary, isolated keychains and secure credential handling.
  * Added automatic cleanup of temporary signing credentials and keychains after builds.
* **Documentation**
  * Clarified required certificate encoding and signing-keychain procedures for macOS releases.
* **Tests**
  * Added coverage for macOS signing command generation and credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->