### PR TITLE
fix(release): redact signing keychain failures

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -102,10 +102,12 @@ environment after rehearsal succeeds.
 
 Distribution imports the Developer ID certificate into a per-job local
 keychain using a random keychain password, grants non-interactive Apple tool
-access with that keychain password, and removes both the keychain and decoded
-credentials in an `always()` cleanup step. Electron Builder discovers the
-installed identity but does not own credential import or temporary-keychain
-creation.
+access with that keychain password, masks the generated password before any
+security command can log it, and removes both the keychain and decoded
+credentials in an `always()` cleanup step. Command failures report only the
+failed Security.framework operation, never its arguments. Electron Builder
+discovers the installed identity but does not own credential import or
+temporary-keychain creation.
 
 If a release must intentionally omit Sentry source maps, change the production
 workflow input to `false` in a reviewed foundation commit; do not silently

--- a/scripts/ci/macos-signing-keychain.test.ts
+++ b/scripts/ci/macos-signing-keychain.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, test } from "vitest";
 
-import { macosSigningSecurityCommands } from "./macos-signing-keychain";
+import {
+  configureMacosSigningKeychain,
+  githubActionsMaskCommand,
+  macosSigningSecurityCommands,
+} from "./macos-signing-keychain";
+
+const options = {
+  certificatePassword: "certificate-password",
+  keychainPassword: "keychain-password",
+  paths: {
+    apiKey: "/tmp/AuthKey.p8",
+    certificate: "/tmp/certificate.p12",
+    keychain: "/tmp/signing.keychain-db",
+  },
+} as const;
 
 describe("macOS signing keychain", () => {
   test("keeps the PKCS#12 and temporary keychain passwords in their distinct security commands", () => {
-    const commands = macosSigningSecurityCommands({
-      certificatePassword: "certificate-password",
-      keychainPassword: "keychain-password",
-      paths: {
-        apiKey: "/tmp/AuthKey.p8",
-        certificate: "/tmp/certificate.p12",
-        keychain: "/tmp/signing.keychain-db",
-      },
-    });
+    const commands = macosSigningSecurityCommands(options);
 
     expect(commands).toContainEqual([
       "import",
@@ -39,5 +45,43 @@ describe("macOS signing keychain", () => {
       "keychain-password",
       "/tmp/signing.keychain-db",
     ]);
+  });
+
+  test("masks the generated keychain password before invoking security", () => {
+    const events: string[] = [];
+
+    configureMacosSigningKeychain(options, {
+      maskValue: (value) => events.push(`mask:${value}`),
+      runCommand: (command) => events.push(`security:${command[0]}`),
+    });
+
+    expect(events[0]).toBe("mask:keychain-password");
+    expect(events.slice(1)).toEqual([
+      "security:create-keychain",
+      "security:set-keychain-settings",
+      "security:unlock-keychain",
+      "security:import",
+      "security:set-key-partition-list",
+      "security:list-keychains",
+    ]);
+  });
+
+  test("redacts security arguments from command failures", () => {
+    expect(() =>
+      configureMacosSigningKeychain(options, {
+        maskValue: () => undefined,
+        runCommand: (command) => {
+          if (command[0] === "unlock-keychain") throw new Error(command.join(" "));
+        },
+      }),
+    ).toThrowError(
+      "Failed to configure the macOS signing keychain during security unlock-keychain.",
+    );
+  });
+
+  test("escapes GitHub workflow-command delimiters when registering a mask", () => {
+    expect(githubActionsMaskCommand("secret%value\r\nnext")).toBe(
+      "::add-mask::secret%25value%0D%0Anext\n",
+    );
   });
 });

--- a/scripts/ci/macos-signing-keychain.ts
+++ b/scripts/ci/macos-signing-keychain.ts
@@ -16,6 +16,11 @@ interface MacosSigningSecurityOptions {
   readonly paths: MacosSigningPaths;
 }
 
+interface MacosSigningSecurityDependencies {
+  readonly maskValue: (value: string) => void;
+  readonly runCommand: (command: readonly string[]) => void;
+}
+
 const scriptPath = fileURLToPath(import.meta.url);
 
 export const macosSigningSecurityCommands = (
@@ -51,6 +56,31 @@ export const macosSigningSecurityCommands = (
   ],
   ["list-keychains", "-d", "user", "-s", options.paths.keychain],
 ];
+
+export const githubActionsMaskCommand = (value: string): string => {
+  if (!value) throw new Error("Cannot mask an empty GitHub Actions value.");
+  const escaped = value
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  return `::add-mask::${escaped}\n`;
+};
+
+export const configureMacosSigningKeychain = (
+  options: MacosSigningSecurityOptions,
+  dependencies: MacosSigningSecurityDependencies,
+): void => {
+  dependencies.maskValue(options.keychainPassword);
+  for (const command of macosSigningSecurityCommands(options)) {
+    try {
+      dependencies.runCommand(command);
+    } catch {
+      throw new Error(
+        `Failed to configure the macOS signing keychain during security ${command[0]}.`,
+      );
+    }
+  }
+};
 
 const requiredEnvironmentValue = (name: string): string => {
   const value = process.env[name]?.trim();
@@ -136,13 +166,14 @@ const prepare = (): void => {
   chmodSync(paths.certificate, 0o600);
 
   try {
-    for (const command of macosSigningSecurityCommands({
-      certificatePassword,
-      keychainPassword,
-      paths,
-    })) {
-      execFileSync("/usr/bin/security", [...command], { stdio: "inherit" });
-    }
+    configureMacosSigningKeychain(
+      { certificatePassword, keychainPassword, paths },
+      {
+        maskValue: (value) => process.stdout.write(githubActionsMaskCommand(value)),
+        runCommand: (command) =>
+          execFileSync("/usr/bin/security", [...command], { stdio: "inherit" }),
+      },
+    );
   } catch (error) {
     cleanupPaths(paths);
     throw error;


### PR DESCRIPTION
## Summary

- register each generated signing-keychain password with GitHub Actions masking before any `security` command runs
- replace `execFileSync` failures with operation-only diagnostics that never preserve command arguments
- escape workflow-command delimiters and prove masking order and redaction in focused tests
- document the signing-log boundary in the release runbook

## Security context

Follow-up to the valid security review on #29. Node child-process errors can include the complete command and argv. The per-job keychain password is generated at runtime, so GitHub does not know to mask it automatically unless the workflow registers it before use. The password is ephemeral and the keychain is deleted in `always()` cleanup, but it should still never appear in Actions logs.

This change applies both defenses: GitHub masking for any downstream output and a redacted exception boundary for our own diagnostics.

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/ci/macos-signing-keychain.test.ts` (4 passed)
- `pnpm run ci:workflow-contracts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

The in-flight no-promotion rehearsal for #29 remains useful distribution evidence. After this PR merges, a final rehearsal must run against the new protected-main SHA before v0.2.0 metadata is prepared.
