### PR TITLE
fix(release): assemble macOS updater manifest

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -29,7 +29,7 @@ manifests only when they describe one source and one Skill artifact, then emits:
 - `Nodex-latest-arm64.dmg`
 - `Nodex-latest-x64.dmg`
 - versioned arm64/x64 ZIPs and blockmaps
-- merged `latest-mac.yml`
+- merged `latest-mac.yml` containing only the two published versioned ZIPs
 - `release-bundle.json`
 - `SHA256SUMS`
 - `release-notes.md` for the publisher (not a public asset)

--- a/scripts/release/bundle.test.ts
+++ b/scripts/release/bundle.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { dump } from "js-yaml";
+import { dump, load } from "js-yaml";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import {
   assembleReleaseBundle,
@@ -26,10 +26,14 @@ const makeArchitecture = (architecture: MacArchitecture, sourceSha = "1".repeat(
     `Nodex-${version}-${architecture}.zip.blockmap`,
   ];
   for (const name of names) writeFileSync(join(root, name), `${architecture}:${name}`);
+  const dmgName = names[0];
   const zipName = names[1];
   writeFileSync(join(root, "latest-mac.yml"), dump({
     version,
-    files: [{ url: zipName, sha512: sha512(join(root, zipName)) }],
+    files: [
+      { url: zipName, sha512: sha512(join(root, zipName)) },
+      { url: dmgName, sha512: sha512(join(root, dmgName)) },
+    ],
     path: zipName,
     sha512: sha512(join(root, zipName)),
   }));
@@ -68,6 +72,21 @@ const makeArchitecture = (architecture: MacArchitecture, sourceSha = "1".repeat(
   return root;
 };
 
+const replaceUpdateManifest = (root: string, manifestValue: unknown): void => {
+  const updatePath = join(root, "latest-mac.yml");
+  writeFileSync(updatePath, dump(manifestValue));
+  const architecturePath = join(root, "architecture-build.json");
+  const manifest = JSON.parse(readFileSync(architecturePath, "utf8")) as ArchitectureBuildManifest;
+  const artifacts = manifest.artifacts.map((artifact) => artifact.name === "latest-mac.yml"
+    ? {
+        ...artifact,
+        bytes: readFileSync(updatePath).byteLength,
+        sha256: sha256File(updatePath),
+      }
+    : artifact);
+  writeFileSync(architecturePath, `${JSON.stringify({ ...manifest, artifacts }, null, 2)}\n`);
+};
+
 beforeEach(() => { fixture = mkdtempSync(join(tmpdir(), "nodex-release-bundle-")); });
 afterEach(() => rmSync(fixture, { recursive: true, force: true }));
 
@@ -87,7 +106,13 @@ test("assembleReleaseBundle binds both architectures and publishes one canonical
     "Nodex-latest-arm64.dmg",
     "Nodex-latest-x64.dmg",
   ]);
-  expect(readFileSync(join(output, "latest-mac.yml"), "utf8")).toContain("Nodex-0.2.0-x64.zip");
+  const updateManifest = load(readFileSync(join(output, "latest-mac.yml"), "utf8")) as {
+    readonly files: readonly { readonly url: string }[];
+  };
+  expect(updateManifest.files.map(({ url }) => url)).toEqual([
+    "Nodex-0.2.0-arm64.zip",
+    "Nodex-0.2.0-x64.zip",
+  ]);
   expect(bundle.agentSkills).toEqual({
     manifestSha256: "9".repeat(64),
     treeSha256: "a".repeat(64),
@@ -137,15 +162,17 @@ test("assembleReleaseBundle rejects different Agent Skills identities", () => {
 test("assembleReleaseBundle rejects updater hashes that do not match the ZIP", () => {
   const arm64 = makeArchitecture("arm64");
   const x64 = makeArchitecture("x64");
-  writeFileSync(join(arm64, "latest-mac.yml"), dump({
+  const dmgName = "Nodex-0.2.0-arm64.dmg";
+  const zipName = "Nodex-0.2.0-arm64.zip";
+  replaceUpdateManifest(arm64, {
     version: "0.2.0",
-    files: [{ url: "Nodex-0.2.0-arm64.zip", sha512: "wrong" }],
-  }));
-  const manifest = JSON.parse(readFileSync(join(arm64, "architecture-build.json"), "utf8")) as ArchitectureBuildManifest;
-  const artifacts = manifest.artifacts.map((artifact) => artifact.name === "latest-mac.yml"
-    ? { ...artifact, bytes: readFileSync(join(arm64, artifact.name)).byteLength, sha256: sha256File(join(arm64, artifact.name)) }
-    : artifact);
-  writeFileSync(join(arm64, "architecture-build.json"), `${JSON.stringify({ ...manifest, artifacts }, null, 2)}\n`);
+    files: [
+      { url: zipName, sha512: "wrong" },
+      { url: dmgName, sha512: sha512(join(arm64, dmgName)) },
+    ],
+    path: zipName,
+    sha512: "wrong",
+  });
   expect(() => assembleReleaseBundle({
     arm64Directory: arm64,
     outputDirectory: join(fixture, "output"),
@@ -158,19 +185,18 @@ test("assembleReleaseBundle rejects updater hashes that do not match the ZIP", (
 test("assembleReleaseBundle rejects updater entries outside the published ZIP closure", () => {
   const arm64 = makeArchitecture("arm64");
   const x64 = makeArchitecture("x64");
+  const dmgName = "Nodex-0.2.0-arm64.dmg";
   const zipName = "Nodex-0.2.0-arm64.zip";
-  writeFileSync(join(arm64, "latest-mac.yml"), dump({
+  replaceUpdateManifest(arm64, {
     version: "0.2.0",
     files: [
       { url: zipName, sha512: sha512(join(arm64, zipName)) },
+      { url: dmgName, sha512: sha512(join(arm64, dmgName)) },
       { url: "unpublished.zip", sha512: "unused" },
     ],
-  }));
-  const manifest = JSON.parse(readFileSync(join(arm64, "architecture-build.json"), "utf8")) as ArchitectureBuildManifest;
-  const artifacts = manifest.artifacts.map((artifact) => artifact.name === "latest-mac.yml"
-    ? { ...artifact, bytes: readFileSync(join(arm64, artifact.name)).byteLength, sha256: sha256File(join(arm64, artifact.name)) }
-    : artifact);
-  writeFileSync(join(arm64, "architecture-build.json"), `${JSON.stringify({ ...manifest, artifacts }, null, 2)}\n`);
+    path: zipName,
+    sha512: sha512(join(arm64, zipName)),
+  });
 
   expect(() => assembleReleaseBundle({
     arm64Directory: arm64,

--- a/scripts/release/bundle.ts
+++ b/scripts/release/bundle.ts
@@ -86,6 +86,11 @@ interface MacUpdateManifest {
   readonly [key: string]: unknown;
 }
 
+interface VerifiedMacUpdateManifest {
+  readonly manifest: MacUpdateManifest;
+  readonly updaterFile: UpdateFileInfo;
+}
+
 const SHA_PATTERN = /^[a-f0-9]{64}$/;
 const ARTIFACT_ROLES = new Set<ReleaseArtifactIdentity["role"]>([
   "blockmap",
@@ -436,7 +441,7 @@ const readAndVerifyUpdateManifest = (
   directory: string,
   architecture: MacArchitecture,
   version: string,
-): MacUpdateManifest => {
+): VerifiedMacUpdateManifest => {
   const manifestPath = join(directory, "latest-mac.yml");
   const value = load(readFileSync(manifestPath, "utf8"));
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -444,20 +449,38 @@ const readAndVerifyUpdateManifest = (
   }
   const manifest = value as MacUpdateManifest;
   if (manifest.version !== version) throw new Error(`${architecture} update manifest version mismatch.`);
-  const expectedName = `Nodex-${version}-${architecture}.zip`;
-  const expectedPath = join(directory, expectedName);
   const files = normalizeUpdateFiles(manifest);
-  if (files.length !== 1 || files[0].url !== expectedName) {
-    throw new Error(`${architecture} update manifest must contain exactly ${expectedName}.`);
+  const expectedNames = [
+    `Nodex-${version}-${architecture}.zip`,
+    `Nodex-${version}-${architecture}.dmg`,
+  ];
+  const filesByUrl = new Map(files.map((file) => [file.url, file]));
+  if (
+    files.length !== expectedNames.length
+    || filesByUrl.size !== expectedNames.length
+    || expectedNames.some((name) => !filesByUrl.has(name))
+  ) {
+    throw new Error(
+      `${architecture} update manifest must contain exactly ${expectedNames.join(" and ")}.`,
+    );
   }
-  const expected = files[0];
-  if (expected.sha512 !== sha512Base64(expectedPath)) {
-    throw new Error(`${architecture} update manifest SHA512 does not match ${expectedName}.`);
+  for (const expectedName of expectedNames) {
+    const expected = filesByUrl.get(expectedName);
+    if (!expected) throw new Error(`${architecture} update manifest is incomplete.`);
+    const expectedPath = join(directory, expectedName);
+    if (expected.sha512 !== sha512Base64(expectedPath)) {
+      throw new Error(`${architecture} update manifest SHA512 does not match ${expectedName}.`);
+    }
+    if (expected.size !== undefined && expected.size !== lstatSync(expectedPath).size) {
+      throw new Error(`${architecture} update manifest size does not match ${expectedName}.`);
+    }
   }
-  if (expected.size !== undefined && expected.size !== lstatSync(expectedPath).size) {
-    throw new Error(`${architecture} update manifest size does not match ${expectedName}.`);
+  const updaterFile = filesByUrl.get(expectedNames[0]);
+  if (!updaterFile) throw new Error(`${architecture} update manifest has no updater ZIP.`);
+  if (manifest.path !== updaterFile.url || manifest.sha512 !== updaterFile.sha512) {
+    throw new Error(`${architecture} update manifest legacy identity does not match its updater ZIP.`);
   }
-  return manifest;
+  return { manifest, updaterFile };
 };
 
 export function assembleReleaseBundle(options: {
@@ -509,15 +532,15 @@ export function assembleReleaseBundle(options: {
     { architecture: "x64", path: copy(x64Root, `Nodex-${version}-x64.zip.blockmap`), role: "blockmap" },
   ];
   const mergedFiles = [
-    ...normalizeUpdateFiles(armUpdate),
-    ...normalizeUpdateFiles(x64Update),
+    armUpdate.updaterFile,
+    x64Update.updaterFile,
   ];
   if (new Set(mergedFiles.map((entry) => entry.url)).size !== mergedFiles.length) {
     throw new Error("Merged macOS update manifest contains duplicate URLs.");
   }
-  const legacy = mergedFiles.find((entry) => entry.url.endsWith(".zip")) ?? mergedFiles[0];
+  const legacy = armUpdate.updaterFile;
   const mergedUpdate: MacUpdateManifest = {
-    ...armUpdate,
+    ...armUpdate.manifest,
     version,
     files: mergedFiles,
     path: legacy.url,


### PR DESCRIPTION
## Summary

- model electron-builder's actual per-architecture `latest-mac.yml` as one ZIP plus one DMG entry
- verify both upstream entries against their sealed architecture artifacts
- emit the final cross-architecture updater manifest with only the two versioned ZIPs that GitHub Release publishes
- keep canonical DMG downloads under `Nodex-latest-arm64.dmg` and `Nodex-latest-x64.dmg` without dangling versioned DMG URLs

## Why

[Distribution Rehearsal #30697140250](https://github.com/junyudev/nodex/actions/runs/30697140250) proved both arm64 and x64 signing, notarization, packaged runtime smoke, architecture identity, and artifact upload. The final Linux assembler then rejected the arm64 update manifest because it assumed electron-builder would emit exactly one ZIP entry.

With both `dmg` and `zip` targets enabled, electron-builder merges both artifact entries into the per-architecture `latest-mac.yml` and keeps the ZIP as the legacy `path`/`sha512` identity. The release intentionally renames DMGs to stable canonical asset names, so simply accepting and forwarding every upstream entry would leave dangling versioned DMG URLs. This change validates the full upstream closure and deliberately narrows the published updater closure to the versioned ZIPs used by the macOS updater.

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/release/bundle.test.ts` (6 passed)
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

After merge and protected-main CI, rerun the no-promotion dual-architecture rehearsal against the new exact main SHA before preparing v0.2.0 metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS update bundle validation for versioned ZIP and DMG files.
  * Added verification of file checksums, sizes, and update metadata.
  * Ensured release bundles include only the appropriate updater ZIP entries for each architecture.

* **Documentation**
  * Clarified that `latest-mac.yml` contains only the two published versioned ZIPs.

* **Tests**
  * Expanded coverage for valid and invalid updater manifests, including DMG entries and unpublished files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->