### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.2.0] - 2026-08-01
+
+### Added
 - Added automatic fresh-Profile setup with one source-backed `My Project`, an editable source-aware `Welcome to Nodex` Page opened in the normal Workbench, atomic single-winner creation, and exact-payload crash recovery.
 - Added recoverable Project removal with active-work protection, a lazy `Removed projects` restore manager, preserved chats/files/Library content, and an explicit projectless Workbench state after the final Project is removed.
 - Projectless chats with an attached thread can now open temporary Side chats and cwd-bound Terminals alongside Browser; exact Output files remain pinnable without enabling the generic Project Files tree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-browser-profile-helper"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cbc",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-cli"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-contracts"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-protocol"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "getrandom",
  "hex",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-server"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodex",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Block-based Agent Orchestrator",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

- prepare the exact `0.1.10` → `0.2.0` release metadata transition
- synchronize the Electron app and Rust workspace package versions
- roll the curated Unreleased changelog into the dated `0.2.0` section

This PR intentionally changes only `CHANGELOG.md`, `Cargo.lock`, `Cargo.toml`, and `package.json`. Please squash merge it so `main` receives one single-parent release commit and the automatic Release workflow can verify the transition before creating `v0.2.0`.

## Validation

- `pnpm release:check -- --base origin/main --worktree`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run --config vitest.node.config.ts scripts/release/source.test.ts scripts/release/homebrew.test.ts scripts/release/model.test.ts scripts/release/changelog.test.ts scripts/release/bundle.test.ts scripts/release/github-release.test.ts scripts/release/browser-runtime.test.ts scripts/ci/macos-signing-keychain.test.ts scripts/ci/classify-change.test.ts` (9 files, 31 tests)
- `pnpm run ci:workflow-contracts`
- [final no-promotion Distribution Rehearsal](https://github.com/junyudev/nodex/actions/runs/30699692869) passed for signed/notarized arm64 and x64 artifacts, runtime smoke, and release-bundle assembly

Local performance-sensitive Electron E2E was intentionally not repeated on a busy workstation; the PR's hosted CI and the successful dual-architecture rehearsal remain the release gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 0.2.0.

- **Documentation**
  - Added an Unreleased section to the changelog for upcoming additions, changes, and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->