### PR TITLE
fix(release): make promotion recovery reliable

### DIFF
--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -128,14 +128,18 @@ jobs:
 
       - name: Publish the verified NodexApp/skills release
         env:
-          NODEX_SKILLS_GITHUB_TOKEN: ${{ secrets.skills_github_token }}
+          GH_TOKEN: ${{ secrets.skills_github_token }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${NODEX_SKILLS_GITHUB_TOKEN}" ]]; then
+          if [[ -z "${GH_TOKEN}" ]]; then
             echo "Missing NODEX_SKILLS_GITHUB_TOKEN." >&2
             exit 1
           fi
+          # Recovery checks out the immutable release source, whose publisher may
+          # predate the current authentication implementation. Keep the GitHub
+          # credential helper as the stable workflow-owned compatibility seam.
+          gh auth setup-git
           bundle="${RUNNER_TEMP}/release-bundle/release-bundle.json"
           manifest_sha="$(node -p "require('${bundle}').agentSkills.manifestSha256")"
           tree_sha="$(node -p "require('${bundle}').agentSkills.treeSha256")"
@@ -172,6 +176,7 @@ jobs:
       - name: Generate and publish cask
         env:
           GH_TOKEN: ${{ secrets.homebrew_github_token }}
+          HOMEBREW_TAP: junyudev/tap
           HOMEBREW_TAP_REPO: junyudev/homebrew-tap
         shell: bash
         run: |
@@ -181,12 +186,12 @@ jobs:
             exit 1
           fi
           generated="${RUNNER_TEMP}/nodex.rb"
-          tap="${RUNNER_TEMP}/homebrew-tap"
           pnpm release:cask -- \
             --bundle "${RUNNER_TEMP}/release-bundle/release-bundle.json" \
             --output "${generated}"
           gh auth setup-git
-          git clone "https://github.com/${HOMEBREW_TAP_REPO}.git" "${tap}"
+          brew tap "${HOMEBREW_TAP}" "https://github.com/${HOMEBREW_TAP_REPO}.git"
+          tap="$(brew --repository "${HOMEBREW_TAP}")"
           current="${tap}/Casks/nodex.rb"
           if [[ -f "${current}" ]] && cmp -s "${generated}" "${current}"; then
             echo "Homebrew tap already contains Nodex ${{ inputs.version }}."
@@ -212,7 +217,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          brew install --cask --force "${RUNNER_TEMP}/homebrew-tap/Casks/nodex.rb"
+          brew install --cask --force junyudev/tap/nodex
           actual="$(/Applications/Nodex.app/Contents/Resources/bin/nodex --version)"
           if [[ "${actual}" != "nodex ${{ inputs.version }}" ]]; then
             echo "Installed CLI reported ${actual}." >&2

--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${GH_TOKEN}" ]]; then
-            echo "Missing NODEX_SKILLS_GITHUB_TOKEN." >&2
+            echo "Missing GH_TOKEN." >&2
             exit 1
           fi
           # Recovery checks out the immutable release source, whose publisher may

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -42,6 +42,8 @@ smoke once against the extracted notarized ZIP App, including launch and the
 symlinked CLI/Core/ripgrep workflow. The mounted DMG receives structural,
 signature, notarization, and provenance verification only; matching sealed
 provenance proves it contains the same App without repeating stateful smoke.
+Runtime-probe teardown uses bounded filesystem retries because a stopped macOS
+Browser helper can briefly race recursive removal of its temporary Profile.
 
 ## Release Identity
 
@@ -100,12 +102,22 @@ reusable workflows. Record PAT expiry dates in release operations and rotate
 them before expiry. Remove duplicate credentials from the legacy `release`
 environment after rehearsal succeeds.
 
+The official Skills publisher authenticates Git through a GitHub-scoped Basic
+extra header and keeps credentials out of remote URLs. Promotion additionally
+configures `gh auth setup-git` as a workflow-owned recovery seam, so an
+immutable older release source can still be republished without changing its
+tag or checkout. Homebrew promotion registers `junyudev/tap` with `brew tap`
+before style, audit, commit, and smoke-install; a plain clone outside Homebrew's
+tap root is not a valid audit target.
+
 Distribution imports the Developer ID certificate into a per-job local
 keychain using a random keychain password, grants non-interactive Apple tool
 access with that keychain password, masks the generated password before any
 security command can log it, and removes both the keychain and decoded
-credentials in an `always()` cleanup step. Command failures report only the
-failed Security.framework operation, never its arguments. Electron Builder
+credentials in an `always()` cleanup step. Partial credential-file or job
+environment setup failures use the same immediate cleanup boundary as
+keychain failures. Command failures report only the failed Security.framework
+operation, never its arguments. Electron Builder
 discovers the installed identity but does not own credential import or
 temporary-keychain creation.
 
@@ -254,7 +266,8 @@ idempotent:
 - matching tag: reuse only when it resolves to the exact source SHA;
 - matching draft: verify every existing asset digest, upload only missing
   assets, then publish;
-- matching published release: verify it, then retry Homebrew;
+- matching published release: verify it, then retry the independently
+  idempotent Agent Skills, Homebrew, and landing promotion jobs;
 - matching Agent Skills tag and tree: reuse it; a conflicting tree or version
   rollback stops without moving the tag;
 - conflicting tag or asset digest: stop without mutation.

--- a/scripts/ci/macos-signing-keychain.ts
+++ b/scripts/ci/macos-signing-keychain.ts
@@ -152,20 +152,20 @@ const prepare = (): void => {
   const keychainPassword = randomBytes(32).toString("hex");
 
   cleanupPaths(paths);
-  writeFileSync(
-    paths.apiKey,
-    decodeBase64Secret(requiredEnvironmentValue("APPLE_API_KEY_B64"), "APPLE_API_KEY_B64"),
-    { mode: 0o600 },
-  );
-  writeFileSync(
-    paths.certificate,
-    decodeBase64Secret(requiredEnvironmentValue("CSC_LINK"), "CSC_LINK"),
-    { mode: 0o600 },
-  );
-  chmodSync(paths.apiKey, 0o600);
-  chmodSync(paths.certificate, 0o600);
-
   try {
+    writeFileSync(
+      paths.apiKey,
+      decodeBase64Secret(requiredEnvironmentValue("APPLE_API_KEY_B64"), "APPLE_API_KEY_B64"),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      paths.certificate,
+      decodeBase64Secret(requiredEnvironmentValue("CSC_LINK"), "CSC_LINK"),
+      { mode: 0o600 },
+    );
+    chmodSync(paths.apiKey, 0o600);
+    chmodSync(paths.certificate, 0o600);
+
     configureMacosSigningKeychain(
       { certificatePassword, keychainPassword, paths },
       {
@@ -174,17 +174,17 @@ const prepare = (): void => {
           execFileSync("/usr/bin/security", [...command], { stdio: "inherit" }),
       },
     );
+
+    appendJobEnvironment(environmentFile, {
+      APPLE_API_KEY: paths.apiKey,
+      CSC_IDENTITY_AUTO_DISCOVERY: "true",
+      NODEX_SIGNING_CERTIFICATE: paths.certificate,
+      NODEX_SIGNING_KEYCHAIN: paths.keychain,
+    });
   } catch (error) {
     cleanupPaths(paths);
     throw error;
   }
-
-  appendJobEnvironment(environmentFile, {
-    APPLE_API_KEY: paths.apiKey,
-    CSC_IDENTITY_AUTO_DISCOVERY: "true",
-    NODEX_SIGNING_CERTIFICATE: paths.certificate,
-    NODEX_SIGNING_KEYCHAIN: paths.keychain,
-  });
 };
 
 const main = (): void => {

--- a/scripts/probe-browser-runtime.test.ts
+++ b/scripts/probe-browser-runtime.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { cleanupBrowserRuntime } from "./probe-browser-runtime";
+
+describe("Browser runtime probe cleanup", () => {
+  test("attempts every teardown operation and preserves the first failure", async () => {
+    const events: string[] = [];
+
+    await expect(cleanupBrowserRuntime({
+      closeNativePipeServer: async () => {
+        events.push("close-pipe");
+        throw new Error("pipe close failed");
+      },
+      removeStateHome: () => {
+        events.push("remove-profile");
+      },
+      stopClient: async () => {
+        events.push("stop-client");
+        throw new Error("client stop failed");
+      },
+    })).rejects.toThrow("client stop failed");
+
+    expect(events).toEqual(["stop-client", "close-pipe", "remove-profile"]);
+  });
+});

--- a/scripts/probe-browser-runtime.ts
+++ b/scripts/probe-browser-runtime.ts
@@ -30,6 +30,36 @@ type BrowserRuntimeProbeReport = {
   targetPlatform: string;
 };
 
+interface BrowserRuntimeCleanupDependencies {
+  readonly closeNativePipeServer: () => Promise<void>;
+  readonly removeStateHome: () => void;
+  readonly stopClient: () => Promise<void>;
+}
+
+export async function cleanupBrowserRuntime(
+  dependencies: BrowserRuntimeCleanupDependencies,
+): Promise<void> {
+  let firstError: unknown;
+  let hasError = false;
+  const operations = [
+    dependencies.stopClient,
+    dependencies.closeNativePipeServer,
+    dependencies.removeStateHome,
+  ];
+
+  for (const operation of operations) {
+    try {
+      await operation();
+    } catch (error) {
+      if (hasError) continue;
+      firstError = error;
+      hasError = true;
+    }
+  }
+
+  if (hasError) throw firstError;
+}
+
 function textFromToolResponse(response: McpServerToolCallResponse): string {
   return response.content.flatMap((entry) => {
     if (
@@ -261,13 +291,15 @@ export async function probeBrowserRuntime(projectRoot: string): Promise<BrowserR
       targetPlatform: bundle.manifest.targetPlatform,
     };
   } finally {
-    await client.stop();
-    await nativePipeServer.close();
-    fs.rmSync(stateHome, {
-      force: true,
-      maxRetries: 10,
-      recursive: true,
-      retryDelay: 100,
+    await cleanupBrowserRuntime({
+      closeNativePipeServer: () => nativePipeServer.close(),
+      removeStateHome: () => fs.rmSync(stateHome, {
+        force: true,
+        maxRetries: 10,
+        recursive: true,
+        retryDelay: 100,
+      }),
+      stopClient: () => client.stop(),
     });
   }
 }

--- a/scripts/probe-browser-runtime.ts
+++ b/scripts/probe-browser-runtime.ts
@@ -263,7 +263,12 @@ export async function probeBrowserRuntime(projectRoot: string): Promise<BrowserR
   } finally {
     await client.stop();
     await nativePipeServer.close();
-    fs.rmSync(stateHome, { force: true, recursive: true });
+    fs.rmSync(stateHome, {
+      force: true,
+      maxRetries: 10,
+      recursive: true,
+      retryDelay: 100,
+    });
   }
 }
 

--- a/scripts/publish-official-agent-skills.test.ts
+++ b/scripts/publish-official-agent-skills.test.ts
@@ -7,7 +7,10 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 import { inspectOfficialAgentSkillsArtifact } from "./official-agent-skills-artifact.mjs";
-import { publishOfficialAgentSkills } from "./publish-official-agent-skills";
+import {
+  githubGitAuthorizationConfiguration,
+  publishOfficialAgentSkills,
+} from "./publish-official-agent-skills";
 
 const temporaryRoots: string[] = [];
 const sourceRepository = "NodexApp/nodex";
@@ -145,6 +148,18 @@ afterEach(() => {
 });
 
 describe("official Agent Skills publisher", () => {
+  test("uses GitHub-scoped password authentication without embedding the token", () => {
+    const secret = "github_pat_secret-sentinel";
+    const authorization = githubGitAuthorizationConfiguration(secret);
+    const encodedCredentials = authorization.value.slice("AUTHORIZATION: basic ".length);
+
+    expect(authorization.key).toBe("http.https://github.com/.extraheader");
+    expect(authorization.value).not.toContain(secret);
+    expect(Buffer.from(encodedCredentials, "base64").toString("utf8")).toBe(
+      `x-access-token:${secret}`,
+    );
+  });
+
   test("publishes managed paths atomically and preserves mirror automation", () => {
     const root = makeRoot();
     const remote = makeRemote(root);

--- a/scripts/publish-official-agent-skills.test.ts
+++ b/scripts/publish-official-agent-skills.test.ts
@@ -10,6 +10,7 @@ import { inspectOfficialAgentSkillsArtifact } from "./official-agent-skills-arti
 import {
   githubGitAuthorizationConfiguration,
   publishOfficialAgentSkills,
+  resolveGithubToken,
 } from "./publish-official-agent-skills";
 
 const temporaryRoots: string[] = [];
@@ -157,6 +158,13 @@ describe("official Agent Skills publisher", () => {
     expect(authorization.value).not.toContain(secret);
     expect(Buffer.from(encodedCredentials, "base64").toString("utf8")).toBe(
       `x-access-token:${secret}`,
+    );
+  });
+
+  test("falls back to the GitHub CLI token when the legacy token is blank", () => {
+    expect(resolveGithubToken(" \n", " github-cli-token ")).toBe("github-cli-token");
+    expect(resolveGithubToken(" legacy-token ", "github-cli-token")).toBe(
+      "legacy-token",
     );
   });
 

--- a/scripts/publish-official-agent-skills.ts
+++ b/scripts/publish-official-agent-skills.ts
@@ -70,6 +70,11 @@ export const githubGitAuthorizationConfiguration = (token: string): {
   value: `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`,
 });
 
+export const resolveGithubToken = (
+  legacyToken: string | undefined,
+  githubCliToken: string | undefined,
+): string | undefined => legacyToken?.trim() || githubCliToken?.trim() || undefined;
+
 const gitEnvironment = (token: string | undefined): NodeJS.ProcessEnv => {
   const authorization = token
     ? githubGitAuthorizationConfiguration(token)
@@ -443,7 +448,10 @@ const main = (): void => {
     expectedTreeSha256: requiredOption(arguments_, "--tree-sha256"),
     expectedVersion: requiredOption(arguments_, "--version"),
     remoteUrl: readOption(arguments_, "--remote") ?? undefined,
-    token: process.env.NODEX_SKILLS_GITHUB_TOKEN ?? process.env.GH_TOKEN,
+    token: resolveGithubToken(
+      process.env.NODEX_SKILLS_GITHUB_TOKEN,
+      process.env.GH_TOKEN,
+    ),
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 };

--- a/scripts/publish-official-agent-skills.ts
+++ b/scripts/publish-official-agent-skills.ts
@@ -54,24 +54,42 @@ interface GitResult {
   readonly stdout: string;
 }
 
-const redact = (value: string, secret: string | undefined): string =>
-  secret ? value.replaceAll(secret, "[REDACTED]") : value;
+const redact = (value: string, secret: string | undefined): string => {
+  if (!secret) return value;
+  const encodedCredentials = Buffer.from(`x-access-token:${secret}`).toString("base64");
+  return value
+    .replaceAll(secret, "[REDACTED]")
+    .replaceAll(encodedCredentials, "[REDACTED]");
+};
 
-const gitEnvironment = (token: string | undefined): NodeJS.ProcessEnv => ({
-  ...process.env,
-  GIT_AUTHOR_EMAIL: "release@nodex.app",
-  GIT_AUTHOR_NAME: "Nodex Release Bot",
-  GIT_COMMITTER_EMAIL: "release@nodex.app",
-  GIT_COMMITTER_NAME: "Nodex Release Bot",
-  GIT_CONFIG_COUNT: token ? "1" : "0",
-  ...(token
-    ? {
-        GIT_CONFIG_KEY_0: "http.extraHeader",
-        GIT_CONFIG_VALUE_0: `Authorization: Bearer ${token}`,
-      }
-    : {}),
-  GIT_TERMINAL_PROMPT: "0",
+export const githubGitAuthorizationConfiguration = (token: string): {
+  readonly key: string;
+  readonly value: string;
+} => ({
+  key: "http.https://github.com/.extraheader",
+  value: `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`,
 });
+
+const gitEnvironment = (token: string | undefined): NodeJS.ProcessEnv => {
+  const authorization = token
+    ? githubGitAuthorizationConfiguration(token)
+    : null;
+  return {
+    ...process.env,
+    GIT_AUTHOR_EMAIL: "release@nodex.app",
+    GIT_AUTHOR_NAME: "Nodex Release Bot",
+    GIT_COMMITTER_EMAIL: "release@nodex.app",
+    GIT_COMMITTER_NAME: "Nodex Release Bot",
+    GIT_CONFIG_COUNT: authorization ? "1" : "0",
+    ...(authorization
+      ? {
+          GIT_CONFIG_KEY_0: authorization.key,
+          GIT_CONFIG_VALUE_0: authorization.value,
+        }
+      : {}),
+    GIT_TERMINAL_PROMPT: "0",
+  };
+};
 
 const git = (
   cwd: string,
@@ -425,7 +443,7 @@ const main = (): void => {
     expectedTreeSha256: requiredOption(arguments_, "--tree-sha256"),
     expectedVersion: requiredOption(arguments_, "--version"),
     remoteUrl: readOption(arguments_, "--remote") ?? undefined,
-    token: process.env.NODEX_SKILLS_GITHUB_TOKEN,
+    token: process.env.NODEX_SKILLS_GITHUB_TOKEN ?? process.env.GH_TOKEN,
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 };


### PR DESCRIPTION
## Summary

- make official Skills publishing authenticate GitHub clones without putting credentials in remote URLs, while preserving recovery from immutable older release source
- register the Homebrew tap with Homebrew before style, audit, publish, and smoke installation
- retry the transient macOS Browser-profile teardown race with a strict one-second bound
- clean partial macOS signing credential preparation through the same failure boundary as keychain setup
- document the promotion and recovery contracts

## Why

The immutable v0.2.0 GitHub Release was published successfully from `b5bdc339efb9fff5062ba4e9349de177eea7a207`, but two independent downstream jobs failed:

- the official Skills publisher passed a bearer extra-header form that Git smart HTTP did not accept for clone authentication;
- Homebrew rejected a cask audited from a plain temporary clone because it was not registered as a tap.

Release recovery deliberately checks out the original immutable source SHA. The reusable promotion workflow now configures the GitHub CLI credential helper before invoking that older publisher, so recovery can use the corrected workflow without moving the v0.2.0 tag or rewriting release assets. Future publisher invocations also use a GitHub-scoped Basic extra header and accept `GH_TOKEN`.

The release run also exposed an `ENOTEMPTY` race while deleting a stopped Browser helper profile. Cleanup now uses Node's bounded retry support. Separately, this closes the remaining valid cleanup review from #29: any failure after decoded signing credential preparation starts now removes partial files and the temporary keychain.

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/ci/macos-signing-keychain.test.ts scripts/publish-official-agent-skills.test.ts scripts/release/homebrew.test.ts` (14 passed)
- `pnpm exec eslint scripts/ci/macos-signing-keychain.ts scripts/ci/macos-signing-keychain.test.ts scripts/publish-official-agent-skills.ts scripts/publish-official-agent-skills.test.ts scripts/probe-browser-runtime.ts`
- `pnpm run ci:workflow-contracts`
- `pnpm run typecheck`
- `pnpm run lint`
- workflow YAML parse and `git diff --check`

Performance-sensitive local E2E was intentionally not repeated on the busy development machine. The existing hosted release run already exercised the relevant signed artifacts; recovery will rerun only the idempotent promotion paths after this PR and protected-main CI pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release cleanup by retrying temporary browser-state removal when files are briefly locked.
  * Enhanced signing setup cleanup so partial failures remove generated credentials and configuration files.
  * Improved release publishing authentication and redaction, including support for standard GitHub tokens.

* **Release Process**
  * Homebrew publication and smoke testing now use the configured tap consistently.
  * Recovery guidance now covers retrying all publication steps for partially completed releases.

* **Documentation**
  * Updated the macOS release runbook with authentication, tap setup, cleanup, and retry requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->