### PR TITLE
fix(release): restore bundles through gh run

### DIFF
--- a/.github/workflows/release-recovery.yml
+++ b/.github/workflows/release-recovery.yml
@@ -131,8 +131,8 @@ jobs:
         run: |
           set -euo pipefail
           bundle="${RUNNER_TEMP}/release-bundle"
-          artifact_id=""
-          while IFS=$'\t' read -r candidate_id run_id; do
+          artifact_run_id=""
+          while IFS= read -r run_id; do
             IFS=$'\t' read -r run_name run_event run_branch run_sha < <(
               gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
                 --jq '[.name, .event, .head_branch, .head_sha] | @tsv'
@@ -141,19 +141,19 @@ jobs:
               ( "${run_name}" == "Release" && "${run_event}" == "workflow_run" && "${run_sha}" == "${EXPECTED_SHA}" )
               || ( "${run_name}" == "Release Recovery" && "${run_event}" == "workflow_dispatch" && "${run_branch}" == "main" )
             ]]; then
-              artifact_id="${candidate_id}"
+              artifact_run_id="${run_id}"
               break
             fi
           done < <(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/artifacts" \
             -f name="${ARTIFACT_NAME}" -F per_page=100 \
-            --jq '.artifacts | sort_by(.created_at) | reverse | .[] | select(.expired == false) | [.id, .workflow_run.id] | @tsv')
+            --jq '.artifacts | sort_by(.created_at) | reverse | .[] | select(.expired == false) | .workflow_run.id')
 
-          if [[ -n "${artifact_id}" ]]; then
+          if [[ -n "${artifact_run_id}" ]]; then
             mkdir -p "${bundle}"
-            gh api -H "Accept: application/octet-stream" \
-              "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" \
-              > "${RUNNER_TEMP}/release-bundle.zip"
-            unzip -q "${RUNNER_TEMP}/release-bundle.zip" -d "${bundle}"
+            gh run download "${artifact_run_id}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --name "${ARTIFACT_NAME}" \
+              --dir "${bundle}"
           else
             release_state="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --slurp \
               | jq -r --arg tag "${EXPECTED_TAG}" '[.[][] | select(.tag_name == $tag)][0] | if . == null then "none" elif .draft then "draft" else "published" end')"

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -268,6 +268,8 @@ idempotent:
   assets, then publish;
 - matching published release: verify it, then retry the independently
   idempotent Agent Skills, Homebrew, and landing promotion jobs;
+- retained cross-run artifacts are restored with `gh run download`, which owns
+  GitHub's archive redirect and extraction behavior before bundle verification;
 - matching Agent Skills tag and tree: reuse it; a conflicting tree or version
   rollback stops without moving the tag;
 - conflicting tag or asset digest: stop without mutation.


### PR DESCRIPTION
## Summary

- restore retained production Release Bundles through `gh run download`
- keep trusted workflow-run selection and all existing bundle identity and digest verification
- document the redirect/extraction ownership boundary

## Failure reproduced

The first v0.2.0 recovery run validated the exact release transition, then stopped before promotion while restoring the retained artifact:

```text
gh: Unsupported 'Accept' header: 'application/octet-stream'. Must accept 'application/json'. (HTTP 415)
```

The Actions artifact archive endpoint no longer accepts the forced binary media type used by the workflow. GitHub CLI already provides a run-aware artifact downloader that handles the API redirect and extracts the selected named artifact.

The workflow still selects only an unexpired artifact whose owning run is either the exact production Release run for the requested source SHA or a main-branch Release Recovery run. After download, it still verifies source SHA, tag, version, every bundle artifact digest, and regenerated release notes before re-upload or promotion.

## Validation

- `pnpm run ci:workflow-contracts`
- workflow YAML parse
- `git diff --check`
- read-only artifact lookup selected artifact `8819787387` from original Release run `30701777185`
- current `gh run download` help confirms `<run-id>`, `--name`, `--dir`, and extraction semantics

No distribution, tag, release asset, or downstream repository mutation occurred in the failed recovery run.
