### PR TITLE
fix(release): emit canonical Homebrew cask

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -239,7 +239,9 @@ A valid version transition runs this sequence:
    manifest/tree hashes to match the Release Bundle, and atomically publish the
    same version to `NodexApp/skills` with an annotated tag.
 9. Generate the Homebrew cask from the same bundle, audit it, push it, and
-   smoke-install the published app.
+   smoke-install the published app. The generated DSL follows Homebrew's
+   canonical stanza grouping and order and expresses the Monterey minimum as
+   `depends_on macos: :monterey`.
 10. Deploy the landing site from the same source SHA after release verification,
    so its version and Changelog never lead the published downloads.
 

--- a/scripts/release/homebrew.test.ts
+++ b/scripts/release/homebrew.test.ts
@@ -10,7 +10,10 @@ test("generateHomebrewCask binds immutable version tags to canonical DMGs", () =
   expect(cask).toContain('version "0.2.0"');
   expect(cask).toContain("/releases/download/v#{version}/Nodex-latest-arm64.dmg");
   expect(cask).toContain("strategy :github_latest");
+  expect(cask).toContain("  end\n  on_intel do");
+  expect(cask).toContain("  auto_updates true\n  depends_on macos: :monterey");
   expect(cask).not.toContain("Nodex-#{version}-arm64.dmg");
+  expect(cask).not.toContain('depends_on macos: ">= :monterey"');
 });
 
 test("generateHomebrewCask rejects malformed checksums", () => {

--- a/scripts/release/homebrew.ts
+++ b/scripts/release/homebrew.ts
@@ -36,7 +36,6 @@ cask "nodex" do
     url "${releaseBase}/Nodex-latest-arm64.dmg",
         verified: "github.com/${owner}/${repo}/"
   end
-
   on_intel do
     sha256 "${x64}"
 
@@ -53,8 +52,8 @@ cask "nodex" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :monterey"
   auto_updates true
+  depends_on macos: :monterey
 
   app "Nodex.app"
   binary "#{appdir}/Nodex.app/Contents/Resources/bin/nodex", target: "nodex"


### PR DESCRIPTION
## Summary

- emit architecture blocks without a grouping break
- place `auto_updates` before `depends_on` per canonical cask stanza order
- express the Monterey minimum with the current symbolic DSL
- cover the generated Homebrew contract in the focused test and runbook

## Failure reproduced

The v0.2.0 recovery successfully restored and verified the Release Bundle, reused the immutable GitHub Release, published official Agent Skills, and deployed the landing site. Homebrew then rejected the generated cask during `brew style --cask`:

```text
Cask/StanzaGrouping: stanzas within the same group should have no lines between them
Cask/StanzaOrder: depends_on stanza out of order
Homebrew/OSDependsOn: Use depends_on macos: :monterey
Cask/StanzaOrder: auto_updates stanza out of order
```

This patch applies Homebrew's current canonical cask stanza sequence. It does not change release URLs, checksums, bundle identity, app artifacts, or the tap publication transaction.

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/release/homebrew.test.ts` (2 passed)
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

The next idempotent recovery will reuse the already-published GitHub Release and exact Skills tag/tree; only the previously failing Homebrew path still needs to mutate downstream state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS release documentation to reflect Homebrew cask formatting and macOS Monterey as the minimum supported version.

* **Bug Fixes**
  * Improved generated Homebrew casks with consistent stanza ordering, automatic update support, and correct Monterey compatibility declarations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->