### PR TITLE
fix(release): normalize recovered Homebrew casks

### DIFF
--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -193,18 +193,26 @@ jobs:
           brew tap "${HOMEBREW_TAP}" "https://github.com/${HOMEBREW_TAP_REPO}.git"
           tap="$(brew --repository "${HOMEBREW_TAP}")"
           current="${tap}/Casks/nodex.rb"
-          if [[ -f "${current}" ]] && cmp -s "${generated}" "${current}"; then
+          previous="${RUNNER_TEMP}/previous-nodex.rb"
+          if [[ -f "${current}" ]]; then
+            cp "${current}" "${previous}"
+          fi
+          # Recovery may execute an immutable release source whose generator
+          # predates Homebrew's current canonical DSL. Normalize inside the
+          # registered tap before comparing or validating the derived cask.
+          cp "${generated}" "${current}"
+          brew style --fix --cask "${current}"
+          brew style --cask "${current}"
+          if [[ -f "${previous}" ]] && cmp -s "${current}" "${previous}"; then
             echo "Homebrew tap already contains Nodex ${{ inputs.version }}."
           else
-            if [[ -f "${current}" ]]; then
-              current_version="$(sed -n 's/^  version "\([^"]*\)"/\1/p' "${current}")"
+            if [[ -f "${previous}" ]]; then
+              current_version="$(sed -n 's/^  version "\([^"]*\)"/\1/p' "${previous}")"
               if [[ "${current_version}" == "${{ inputs.version }}" ]]; then
                 echo "Homebrew already has version ${current_version} with different checksums." >&2
                 exit 1
               fi
             fi
-            cp "${generated}" "${current}"
-            brew style --cask "${current}"
             brew audit --cask --online "${current}"
             git -C "${tap}" config user.name "github-actions[bot]"
             git -C "${tap}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -108,7 +108,10 @@ configures `gh auth setup-git` as a workflow-owned recovery seam, so an
 immutable older release source can still be republished without changing its
 tag or checkout. Homebrew promotion registers `junyudev/tap` with `brew tap`
 before style, audit, commit, and smoke-install; a plain clone outside Homebrew's
-tap root is not a valid audit target.
+tap root is not a valid audit target. Promotion runs Homebrew's own cask
+autocorrect inside that registered tap before its exact idempotency comparison,
+so recovery can safely normalize derived output from an immutable older release
+source without weakening version or checksum conflict rejection.
 
 Distribution imports the Developer ID certificate into a per-job local
 keychain using a random keychain password, grants non-interactive Apple tool


### PR DESCRIPTION
## Summary

- normalize generated Homebrew casks with Homebrew's own autocorrect inside the registered tap
- perform the exact idempotency comparison only after normalization
- retain hard failure when the tap already contains the requested version with different checksums
- document the workflow-owned compatibility seam for immutable release recovery

## Why

The v0.2.0 recovery run executes the immutable release source commit. That source predates Homebrew's current canonical cask DSL, so its generated cask fails current `brew style` even though the current generator has already been corrected on `main`. The promotion workflow is the stable compatibility boundary and can normalize this derived artifact without changing the signed release source or tag.

## Validation

- `pnpm run ci:workflow-contracts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_promote-release.yml")'`
- `git diff --check`

## Release evidence

- failed recovery run: https://github.com/junyudev/nodex/actions/runs/30710029050
- immutable release source: `b5bdc339efb9fff5062ba4e9349de177eea7a207`
