### PR TITLE
fix(release): audit Homebrew cask by name

### DIFF
--- a/.github/workflows/_promote-release.yml
+++ b/.github/workflows/_promote-release.yml
@@ -213,7 +213,7 @@ jobs:
                 exit 1
               fi
             fi
-            brew audit --cask --online "${current}"
+            brew audit --cask --online "${HOMEBREW_TAP}/nodex"
             git -C "${tap}" config user.name "github-actions[bot]"
             git -C "${tap}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git -C "${tap}" add Casks/nodex.rb

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -111,7 +111,9 @@ before style, audit, commit, and smoke-install; a plain clone outside Homebrew's
 tap root is not a valid audit target. Promotion runs Homebrew's own cask
 autocorrect inside that registered tap before its exact idempotency comparison,
 so recovery can safely normalize derived output from an immutable older release
-source without weakening version or checksum conflict rejection.
+source without weakening version or checksum conflict rejection. It audits the
+registered cask by its fully qualified tap name because current Homebrew rejects
+file-path arguments to `brew audit`.
 
 Distribution imports the Developer ID certificate into a per-job local
 keychain using a random keychain password, grants non-interactive Apple tool


### PR DESCRIPTION
## Summary

- audit the generated cask by its fully qualified registered-tap name
- document why Homebrew style and audit use different target forms

## Why

Recovery run `30711570439` proved that Homebrew autocorrect successfully normalizes the immutable v0.2.0 generator output and strict style then passes. Current Homebrew rejects the following online audit only because it receives a file path: `Calling brew audit [path ...] is disabled! Use brew audit [name ...] instead.` The tap is already registered, so `junyudev/tap/nodex` is the canonical audit target.

## Validation

- `pnpm run ci:workflow-contracts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_promote-release.yml")'`
- `git diff --check`

## Release evidence

- failed recovery run: https://github.com/junyudev/nodex/actions/runs/30711570439
- failed Homebrew job: https://github.com/junyudev/nodex/actions/runs/30711570439/job/91400365353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Homebrew release validation to use the registered tap-qualified cask name, ensuring audits work with current Homebrew requirements.

* **Documentation**
  * Updated macOS release instructions to reflect the correct Homebrew audit command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->