### PR TITLE
release: declare protected Sparkle secret contract

### DIFF
--- a/.github/workflows/_macos-distribution.yml
+++ b/.github/workflows/_macos-distribution.yml
@@ -26,6 +26,9 @@ on:
         required: false
         type: boolean
     secrets:
+      SPARKLE_ED25519_PRIVATE_KEY:
+        description: Resolved only from the protected Sparkle finalization environment
+        required: false
       apple_api_issuer:
         required: true
       apple_api_key_b64:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,8 +31,11 @@ Nodex is local-first. Main risks are malformed local inputs, accidental data los
   identities into package provenance. The Ed25519 public key is reviewed source;
   the private key is available only to protected
   `sparkle-feed-finalization` jobs and is streamed to official tools over
-  standard input. It is never written to an Action artifact, cache, manifest,
-  Pages repository, or log. Before signing release assets, the finalizer signs
+  standard input. The reusable workflow declares that environment-secret name
+  for expression resolution, while repository guards reject caller transport
+  or references outside the protected finalizer. The key is never written to
+  an Action artifact, cache, manifest, Pages repository, or log. Before signing
+  release assets, the finalizer signs
   a local sentinel and independently verifies it with the reviewed public key;
   the extracted App's `SUPublicEDKey` and sealed runtime manifest must carry
   that same key.

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -108,14 +108,18 @@ Configure these repository Action secrets:
 
 Configure `SPARKLE_ED25519_PRIVATE_KEY` as an environment secret on
 `sparkle-feed-finalization`, not as a repository-wide secret and not as a
-`workflow_call` input. The finalizer is the only job that receives it.
+caller-supplied `workflow_call` secret. The reusable distribution workflow
+declares the name as optional so GitHub resolves the expression, but repository
+guards reject any caller mapping; the finalizer's protected environment is the
+only source and the only job that receives it.
 
 Each caller maps the repository secrets above to lowercase
 `workflow_call.secrets` aliases. Do
 not replace the mappings with broad `secrets: inherit`, and do not reference a
-repository secret from PR CI. The Sparkle key is the deliberate exception: it
-is resolved directly from its protected job environment and has no caller
-transport. The alias boundary otherwise avoids relying on
+repository secret from PR CI. The Sparkle key is the deliberate exception: its
+name is declared by the reusable workflow but its value is resolved directly
+from the protected job environment and has no caller transport. The alias
+boundary otherwise avoids relying on
 implicit environment-secret resolution or same-name precedence inside nested
 reusable workflows. Record PAT expiry dates in release operations and rotate
 them before expiry. Remove duplicate credentials from the legacy `release`

--- a/scripts/ci/verify-reusable-workflow-secrets.test.ts
+++ b/scripts/ci/verify-reusable-workflow-secrets.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { expect, test } from "vitest";
 
-import { verifyDeclaredReferences } from "./verify-reusable-workflow-secrets";
+import { verifyCall, verifyDeclaredReferences } from "./verify-reusable-workflow-secrets";
 
 const workflow = (jobs: Record<string, unknown>): Record<string, unknown> => ({
   jobs,
@@ -10,6 +10,7 @@ const workflow = (jobs: Record<string, unknown>): Record<string, unknown> => ({
     workflow_call: {
       secrets: {
         DECLARED_SECRET: { required: true },
+        SPARKLE_ED25519_PRIVATE_KEY: { required: false },
       },
     },
   },
@@ -35,5 +36,23 @@ test("allows the Sparkle signing key only in its protected environment job", () 
     assemble: {
       steps: [{ env: { KEY: "${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}" } }],
     },
-  }))).toThrow("assemble references undeclared");
+  }))).toThrow("assemble references protected environment secrets outside their environment");
+});
+
+test("rejects transporting a protected environment secret from a caller", () => {
+  const callerPath = path.resolve(".github/workflows/caller.yml");
+  const calledPath = path.resolve(".github/workflows/called.yml");
+  const calledWorkflow = workflow({
+    finalize: {
+      environment: "sparkle-feed-finalization",
+      steps: [{ env: { KEY: "${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}" } }],
+    },
+  });
+
+  expect(() => verifyCall(callerPath, "distribution", {
+    uses: "./.github/workflows/called.yml",
+    secrets: {
+      SPARKLE_ED25519_PRIVATE_KEY: "${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}",
+    },
+  }, new Map([[calledPath, calledWorkflow]]))).toThrow("must resolve protected environment secrets in the called job");
 });

--- a/scripts/ci/verify-reusable-workflow-secrets.ts
+++ b/scripts/ci/verify-reusable-workflow-secrets.ts
@@ -11,6 +11,9 @@ const secretReferencePattern = /secrets\.([A-Za-z_][A-Za-z0-9_]*)/gu;
 const environmentSecretContracts = new Map<string, ReadonlySet<string>>([
   ["sparkle-feed-finalization", new Set(["SPARKLE_ED25519_PRIVATE_KEY"])],
 ]);
+const environmentSecretNames = new Set(
+  [...environmentSecretContracts.values()].flatMap((names) => [...names]),
+);
 
 const isRecord = (value: unknown): value is UnknownRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -74,7 +77,16 @@ export const verifyDeclaredReferences = (filePath: string, workflow: UnknownReco
   const jobs = requireRecord(workflow.jobs, `${path.relative(repositoryRoot, filePath)}.jobs`);
   const workflowWithoutJobs = { ...workflow };
   delete workflowWithoutJobs.jobs;
-  const topLevelUndeclared = [...referencedSecrets(workflowWithoutJobs)]
+  const topLevelReferences = [...referencedSecrets(workflowWithoutJobs)];
+  const topLevelEnvironmentSecrets = topLevelReferences
+    .filter((name) => environmentSecretNames.has(name))
+    .sort();
+  if (topLevelEnvironmentSecrets.length > 0) {
+    throw new Error(
+      `${path.relative(repositoryRoot, filePath)} references protected environment secrets outside a job: ${topLevelEnvironmentSecrets.join(", ")}`,
+    );
+  }
+  const topLevelUndeclared = topLevelReferences
     .filter((name) => !Object.hasOwn(declared, name))
     .sort();
   if (topLevelUndeclared.length > 0) {
@@ -87,7 +99,16 @@ export const verifyDeclaredReferences = (filePath: string, workflow: UnknownReco
     const allowed = typeof job.environment === "string"
       ? environmentSecretContracts.get(job.environment) ?? new Set<string>()
       : new Set<string>();
-    const undeclared = [...referencedSecrets(job)]
+    const references = [...referencedSecrets(job)];
+    const misplacedEnvironmentSecrets = references
+      .filter((name) => environmentSecretNames.has(name) && !allowed.has(name))
+      .sort();
+    if (misplacedEnvironmentSecrets.length > 0) {
+      throw new Error(
+        `${path.relative(repositoryRoot, filePath)}:${jobName} references protected environment secrets outside their environment: ${misplacedEnvironmentSecrets.join(", ")}`,
+      );
+    }
+    const undeclared = references
       .filter((name) => !Object.hasOwn(declared, name) && !allowed.has(name))
       .sort();
     if (undeclared.length > 0) {
@@ -98,7 +119,7 @@ export const verifyDeclaredReferences = (filePath: string, workflow: UnknownReco
   }
 };
 
-const verifyCall = (
+export const verifyCall = (
   callerPath: string,
   jobName: string,
   job: UnknownRecord,
@@ -116,6 +137,14 @@ const verifyCall = (
   const provided = job.secrets === undefined
     ? {}
     : requireRecord(job.secrets, `${path.relative(repositoryRoot, callerPath)}:${jobName}.secrets`);
+  const transportedEnvironmentSecrets = Object.keys(provided)
+    .filter((name) => environmentSecretNames.has(name))
+    .sort();
+  if (transportedEnvironmentSecrets.length > 0) {
+    throw new Error(
+      `${path.relative(repositoryRoot, callerPath)}:${jobName} must resolve protected environment secrets in the called job: ${transportedEnvironmentSecrets.join(", ")}`,
+    );
+  }
   const declared = workflowCallSecrets(target);
   const unknown = Object.keys(provided).filter((name) => !Object.hasOwn(declared, name)).sort();
   if (unknown.length > 0) {

--- a/src/main/core-client/core-launcher.node.test.ts
+++ b/src/main/core-client/core-launcher.node.test.ts
@@ -13,12 +13,12 @@ import {
 const CORE_BINARY = path.resolve("target/debug/nodex-core");
 
 const waitUntil = async (
-  predicate: () => boolean,
+  predicate: () => boolean | Promise<boolean>,
   message: string,
 ): Promise<void> => {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    if (await predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(message);
@@ -142,9 +142,10 @@ describe("native Core launcher", () => {
       expect(reusedEvents).toEqual(["candidate_checked"]);
       expect(reused.timings.disposition).toBe("reused");
       expect(reused.client.handshake.generation.pid).toBe(first.client.handshake.generation.pid);
-      await expect(reused.client.health()).resolves.toMatchObject({
-        metrics: { active_clients: 1 },
-      });
+      await waitUntil(
+        async () => (await reused.client.health()).metrics.active_clients === 1,
+        "Core retained the short-lived selector probe after runtime reuse",
+      );
 
       await first.client.shutdown();
       const socketPath = path.join(nodexHome, "run/core/core.sock");


### PR DESCRIPTION
## Summary

- declare the protected Sparkle environment secret name in the reusable workflow contract without transporting it from callers
- keep the private key confined to `sparkle-feed-finalization`
- strengthen CI guards against caller transport or references outside the protected finalizer
- document the reusable-workflow/environment resolution seam

## Validation

- `pnpm exec vitest run --config vitest.node.config.ts scripts/ci/verify-reusable-workflow-secrets.test.ts`
- `pnpm run ci:workflow-contracts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run verify:source` reached the main-process suite after all static, Rust, Canvas performance, and Node tests passed; one unrelated Git worker timing test exceeded its 20s budget under the full gate
- `pnpm test:main src/main/git-worker/git-worker-module.test.ts` (isolated rerun: 4/4 passed in 7.65s)

## Rehearsal evidence

Fresh Distribution Rehearsal run 30749584488 proved both signed architectures, but both finalizers resolved the environment secret as empty before this declaration was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened protection for macOS release-signing credentials.
  - Prevented protected signing secrets from being passed through unsupported workflow configurations or exposed outside approved release environments.
  - Confirmed signing keys remain excluded from build artifacts, caches, manifests, logs, and hosted repositories.

- **Documentation**
  - Clarified macOS release-signing requirements, secret handling, and permitted credential mappings.

- **Tests**
  - Added validation coverage for protected-environment secrets and rejected secret transport scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->