### PR TITLE
release: handle empty Sparkle history on macOS Bash

### DIFF
--- a/.github/actions/finalize-sparkle/action.yml
+++ b/.github/actions/finalize-sparkle/action.yml
@@ -66,19 +66,19 @@ runs:
           --version "${RELEASE_VERSION}" \
           --output "${RUNNER_TEMP}/release-notes.md"
         published_at="$(git show -s --format=%cI "${RELEASE_SOURCE_SHA}")"
-        history_args=()
-        if [[ -n "${HISTORY_DIRS}" ]]; then
-          history_args=(--history-dirs "${HISTORY_DIRS}")
-        fi
-        pnpm release:finalize:sparkle -- \
-          --arch "${RELEASE_ARCH}" \
-          --architecture-dir "${RUNNER_TEMP}/architecture" \
-          "${history_args[@]}" \
-          --notes "${RUNNER_TEMP}/release-notes.md" \
-          --published-at "${published_at}" \
-          --source-sha "${RELEASE_SOURCE_SHA}" \
-          --version "${RELEASE_VERSION}" \
+        sparkle_args=(
+          --arch "${RELEASE_ARCH}"
+          --architecture-dir "${RUNNER_TEMP}/architecture"
+          --notes "${RUNNER_TEMP}/release-notes.md"
+          --published-at "${published_at}"
+          --source-sha "${RELEASE_SOURCE_SHA}"
+          --version "${RELEASE_VERSION}"
           --output "${SPARKLE_OUTPUT}"
+        )
+        if [[ -n "${HISTORY_DIRS}" ]]; then
+          sparkle_args+=(--history-dirs "${HISTORY_DIRS}")
+        fi
+        pnpm release:finalize:sparkle -- "${sparkle_args[@]}"
 
     - name: Summarize signed update set
       env:


### PR DESCRIPTION
## Summary

- build the Sparkle finalizer command from one always-populated Bash array
- append compatible history arguments only when release history exists
- keep the v0.2.0 baseline valid under hosted macOS Bash 3.2 with nounset enabled

## Evidence

Distribution Rehearsal 30757776306 proved the protected environment key now resolves (masked in the runner environment) and both native architectures pass. Both finalizers then failed only at expansion of an empty history_args array under Bash nounset.

## Validation

- /bin/bash -u empty-history argument smoke check
- actionlint
- pnpm run ci:workflow-contracts
- zizmor on the changed composite action: no findings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sparkle finalization so available history information is passed reliably during processing.
  * Simplified command-line option handling to make finalization more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->