### PR TITLE
release: prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.2.1] - 2026-08-02
+
+### Added
 - Added Window Session-owned Project and Session Scenes with one fixed owner-root primary and shared right/bottom panel surfaces. Projects can open with zero chats, while Database, Page, Canvas, Files, Browser, Review, and Terminal surfaces no longer need a chat as their panel host.
 - Added native macOS Picture-in-Picture for background Browser work and Apple Silicon Computer Use, including live desktop-app presentation, native per-task visibility, and turn-scoped cleanup.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-browser-profile-helper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes",
  "cbc",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-contracts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "getrandom",
  "hex",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Block-based Agent Orchestrator",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
## Summary

- synchronize the Electron app and Rust workspace at v0.2.1
- roll the curated Unreleased product notes into the v0.2.1 release entry
- keep the release transition scoped to the four canonical metadata files

## Validation

- pnpm release:check -- --base origin/main --worktree
- Distribution Rehearsal 30759954817 passed for source cded11dba5e33572fa97794345160f61cf20ecac
- pnpm release:verify:bundle passed for the downloaded rehearsal bundle
- confirmed zero Sparkle delta assets and zero deltaFrom entries for the v0.2.0 baseline
- pnpm run typecheck
- pnpm run lint
- Rust workspace, Canvas performance, Node, main, renderer, integration, and browser suites passed
- pnpm run verify:runtime:mac
- two of three Electron E2E scenarios passed under the timing gate; the unchanged license scenario exceeded the local 250 ms long-task threshold at 353 ms, then passed functionally with NODEX_SKIP_PERFORMANCE_GATES=1. The same source SHA passed protected-main Electron E2E in GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.2.1 is now available.

* **Documentation**
  * Added an Unreleased changelog section for upcoming additions, changes, and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->