### PR TITLE
release: verify remote assets from bundle allowlist

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -458,6 +458,11 @@ curl --fail --silent https://nodex.jyu.app/updates/stable/x64/appcast.xml \
   --output .generated/v0.2.1-remote/appcast-x64.xml
 ```
 
+The remote verifier needs only `release-bundle.json` and `SHA256SUMS` locally.
+It reconstructs the exact asset allowlist from those files, then downloads every
+published asset once into a temporary directory and verifies its byte length and
+SHA-256 digest before removing the temporary copy.
+
 The 0.2.1 baseline must contain zero deltas because 0.2.0 and earlier are not
 compatible history. Also verify both stable DMG URLs, a clean Apple Silicon
 install/first launch,

--- a/scripts/release/bundle.test.ts
+++ b/scripts/release/bundle.test.ts
@@ -8,7 +8,7 @@ import {
   type ArchitectureBuildManifest,
   type MacArchitecture,
 } from "./bundle";
-import { releaseAssetPaths } from "./github-release";
+import { releaseAssetPaths, remoteReleaseAssetIdentities } from "./github-release";
 import { sha256File } from "./model";
 import { projectReleaseAppcasts } from "./pages";
 import {
@@ -205,6 +205,36 @@ test("assembles the exact dual-architecture Sparkle asset closure", () => {
   })).toThrow("cannot move");
   appendFileSync(join(output, "Nodex-latest-arm64.dmg"), "tampered");
   expect(() => releaseAssetPaths(join(output, "release-bundle.json"))).toThrow("does not match");
+});
+
+test("derives remote release identities without local copies of the full assets", () => {
+  const arm64 = makeArchitecture("arm64");
+  const x64 = makeArchitecture("x64");
+  const output = join(fixture, "output");
+  const bundle = assembleReleaseBundle({
+    arm64Directory: arm64,
+    arm64UpdateDirectory: makeUpdate("arm64", arm64),
+    outputDirectory: output,
+    sourceSha: SOURCE_SHA,
+    version: VERSION,
+    x64Directory: x64,
+    x64UpdateDirectory: makeUpdate("x64", x64),
+  });
+  for (const asset of bundle.assets) rmSync(join(output, asset.name));
+
+  const identities = remoteReleaseAssetIdentities(join(output, "release-bundle.json"));
+  expect([...identities.keys()].sort()).toEqual([
+    ...bundle.assets.map(({ name }) => name),
+    "release-bundle.json",
+    "SHA256SUMS",
+  ].sort());
+  for (const asset of bundle.assets) {
+    expect(identities.get(asset.name)).toEqual({ bytes: asset.bytes, sha256: asset.sha256 });
+  }
+
+  appendFileSync(join(output, "SHA256SUMS"), "tampered\n");
+  expect(() => remoteReleaseAssetIdentities(join(output, "release-bundle.json")))
+    .toThrow("SHA256SUMS does not match");
 });
 
 test("rejects a Sparkle full update that does not match the architecture ZIP", () => {

--- a/scripts/release/github-release.ts
+++ b/scripts/release/github-release.ts
@@ -26,10 +26,50 @@ interface GitHubRelease {
   readonly tag_name: string;
 }
 
+interface ReleaseAssetIdentity {
+  readonly bytes: number;
+  readonly sha256: string;
+}
+
 export type PublicationPlan =
   | { readonly kind: "create" }
   | { readonly kind: "resume-draft"; readonly missingAssetNames: readonly string[] }
   | { readonly kind: "verify-published" };
+
+const assertRegularFile = (filePath: string): void => {
+  if (!existsSync(filePath)) throw new Error(`Release asset is missing: ${filePath}`);
+  const metadata = lstatSync(filePath);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`Release asset must be a regular file: ${filePath}`);
+  }
+};
+
+const readBundle = (bundlePath: string) => {
+  const resolvedBundle = resolve(bundlePath);
+  assertRegularFile(resolvedBundle);
+  return {
+    bundle: parseReleaseBundleManifest(JSON.parse(readFileSync(resolvedBundle, "utf8"))),
+    resolvedBundle,
+    root: dirname(resolvedBundle),
+  };
+};
+
+const verifyChecksumAllowlist = (
+  resolvedBundle: string,
+  bundle: ReturnType<typeof parseReleaseBundleManifest>,
+): string => {
+  const checksumPath = join(dirname(resolvedBundle), "SHA256SUMS");
+  assertRegularFile(checksumPath);
+  const checksumEntries = [
+    ...bundle.assets.map(({ name, sha256 }) => ({ name, sha256 })),
+    { name: basename(resolvedBundle), sha256: sha256File(resolvedBundle) },
+  ].sort((left, right) => left.name.localeCompare(right.name));
+  const expectedChecksums = `${checksumEntries.map(({ name, sha256 }) => `${sha256}  ${name}`).join("\n")}\n`;
+  if (readFileSync(checksumPath, "utf8") !== expectedChecksums) {
+    throw new Error("SHA256SUMS does not match the Release Bundle allowlist.");
+  }
+  return checksumPath;
+};
 
 const gh = (args: readonly string[], options?: { readonly allowFailure?: boolean }): string => {
   try {
@@ -44,47 +84,54 @@ const gh = (args: readonly string[], options?: { readonly allowFailure?: boolean
 };
 
 export const releaseAssetPaths = (bundlePath: string): readonly string[] => {
-  const resolvedBundle = resolve(bundlePath);
-  const root = dirname(resolvedBundle);
-  const bundle = parseReleaseBundleManifest(JSON.parse(readFileSync(resolvedBundle, "utf8")));
+  const { bundle, resolvedBundle, root } = readBundle(bundlePath);
+  const checksumPath = join(root, "SHA256SUMS");
   const paths = [
     ...bundle.assets.map((asset) => join(root, asset.name)),
     resolvedBundle,
-    join(root, "SHA256SUMS"),
+    checksumPath,
   ];
-  for (const filePath of paths) {
-    if (!existsSync(filePath)) throw new Error(`Release asset is missing: ${filePath}`);
-    const metadata = lstatSync(filePath);
-    if (!metadata.isFile() || metadata.isSymbolicLink()) {
-      throw new Error(`Release asset must be a regular file: ${filePath}`);
-    }
-  }
+  for (const filePath of paths) assertRegularFile(filePath);
   for (const artifact of bundle.assets) {
     const filePath = join(root, artifact.name);
     if (lstatSync(filePath).size !== artifact.bytes || sha256File(filePath) !== artifact.sha256) {
       throw new Error(`Release asset ${artifact.name} does not match release-bundle.json.`);
     }
   }
-  const checksumEntries = [
-    ...bundle.assets.map(({ name, sha256 }) => ({ name, sha256 })),
-    { name: basename(resolvedBundle), sha256: sha256File(resolvedBundle) },
-  ].sort((left, right) => left.name.localeCompare(right.name));
-  const expectedChecksums = `${checksumEntries.map(({ name, sha256 }) => `${sha256}  ${name}`).join("\n")}\n`;
-  if (readFileSync(join(root, "SHA256SUMS"), "utf8") !== expectedChecksums) {
-    throw new Error("SHA256SUMS does not match the Release Bundle allowlist.");
-  }
+  verifyChecksumAllowlist(resolvedBundle, bundle);
   return paths;
 };
 
-const expectedAssets = (bundlePath: string): ReadonlyMap<string, { readonly bytes: number; readonly sha256: string }> =>
+const expectedLocalAssets = (bundlePath: string): ReadonlyMap<string, ReleaseAssetIdentity> =>
   new Map(releaseAssetPaths(bundlePath).map((filePath) => [
     basename(filePath),
     { bytes: lstatSync(filePath).size, sha256: sha256File(filePath) },
   ]));
 
+export const remoteReleaseAssetIdentities = (
+  bundlePath: string,
+): ReadonlyMap<string, ReleaseAssetIdentity> => {
+  const { bundle, resolvedBundle } = readBundle(bundlePath);
+  const checksumPath = verifyChecksumAllowlist(resolvedBundle, bundle);
+  return new Map([
+    ...bundle.assets.map((asset) => [
+      asset.name,
+      { bytes: asset.bytes, sha256: asset.sha256 },
+    ] as const),
+    [
+      basename(resolvedBundle),
+      { bytes: lstatSync(resolvedBundle).size, sha256: sha256File(resolvedBundle) },
+    ],
+    [
+      basename(checksumPath),
+      { bytes: lstatSync(checksumPath).size, sha256: sha256File(checksumPath) },
+    ],
+  ]);
+};
+
 export function planPublication(
   release: GitHubRelease | null,
-  expected: ReadonlyMap<string, { readonly bytes: number; readonly sha256: string }>,
+  expected: ReadonlyMap<string, ReleaseAssetIdentity>,
 ): PublicationPlan {
   if (!release) return { kind: "create" };
   if (release.prerelease) throw new Error("Stable app release cannot be a prerelease.");
@@ -221,7 +268,7 @@ export function publishGitHubRelease(options: {
 }): PublicationPlan {
   const bundlePath = resolve(options.bundlePath);
   const bundle = parseReleaseBundleManifest(JSON.parse(readFileSync(bundlePath, "utf8")));
-  const expected = expectedAssets(bundlePath);
+  const expected = expectedLocalAssets(bundlePath);
   const release = readRelease(options.repo, bundle.tag);
   const plan = planPublication(release, expected);
   const filesByName = new Map(releaseAssetPaths(bundlePath).map((filePath) => [basename(filePath), filePath]));
@@ -268,7 +315,8 @@ export function verifyRemoteRelease(options: {
   const bundle = parseReleaseBundleManifest(JSON.parse(readFileSync(bundlePath, "utf8")));
   if (!stableVersionFromAppTag(bundle.tag)) throw new Error("Release Bundle tag is not a stable app tag.");
   const release = readRelease(options.repo, bundle.tag);
-  const plan = planPublication(release, expectedAssets(bundlePath));
+  const expected = remoteReleaseAssetIdentities(bundlePath);
+  const plan = planPublication(release, expected);
   if (plan.kind !== "verify-published" || !release) throw new Error("GitHub release is not fully published.");
   if (options.requireImmutable !== false && release.immutable !== true) {
     throw new Error("GitHub release is not immutable.");
@@ -284,7 +332,6 @@ export function verifyRemoteRelease(options: {
   const downloadRoot = mkdtempSync(join(tmpdir(), "nodex-release-redownload-"));
   try {
     gh(["release", "download", bundle.tag, "--repo", options.repo, "--dir", downloadRoot]);
-    const expected = expectedAssets(bundlePath);
     for (const [name, identity] of expected) {
       const downloaded = join(downloadRoot, name);
       if (


### PR DESCRIPTION
## Summary

- derive remote release asset identities from release-bundle.json and SHA256SUMS
- keep publication recovery on the stricter local full-asset validation path
- make the documented post-release command download each remote asset only once
- document the corrected verifier contract

## Validation

- pnpm exec vitest run --config vitest.node.config.ts scripts/release/bundle.test.ts scripts/release/github-release.test.ts
- pnpm run typecheck
- pnpm run lint
- pnpm release:verify:bundle -- --bundle .generated/v0.2.1-remote/release-bundle.json
- the v0.2.1 post-release remote verifier completed successfully against the immutable Release before this follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification to reliably validate published assets, including file sizes and SHA-256 checksums.
  * Releases can now be verified even when local copies of assets are unavailable.
  * Added detection for tampered or inconsistent checksum data.

* **Documentation**
  * Added guidance for remote release verification, including required files and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->