### PR TITLE
fix(board): open pages from the card surface

### DIFF
--- a/docs/product-specs/database-pages-and-views-behavior.md
+++ b/docs/product-specs/database-pages-and-views-behavior.md
@@ -165,7 +165,10 @@ button, switch, popover, and checkbox primitives. Selectors backed by Source
 Properties, options, or other growing data catalogs are searchable; closed
 presentation enums remain compact selection menus without a redundant search
 field. Board and List share bounded group windows, selection, Page-open behavior,
-Property editors, and mutation receipts.
+Property editors, and mutation receipts. On Board, a normal pointer click on the
+title or any non-interactive part of a Page card opens that Page; card Property
+controls, menus, and drag gestures keep their own interaction instead of
+opening the Page.
 
 Database row authority always carries canonical Property values. In particular,
 select and multi-select values remain stable option IDs through View windows,

--- a/src/renderer/components/workbench/database-board/database-board-card.tsx
+++ b/src/renderer/components/workbench/database-board/database-board-card.tsx
@@ -1,4 +1,4 @@
-import type { DragEvent as ReactDragEvent } from "react";
+import type { DragEvent as ReactDragEvent, MouseEvent as ReactMouseEvent } from "react";
 import { createPortal } from "react-dom";
 
 import { BoardPageKey } from "@/components/board/board-page-key";
@@ -29,6 +29,23 @@ import { DatabaseListRowContextMenu } from "../database-list/database-list-row-c
 import type { BoardCardDragData } from "@/components/board/pragmatic-drag-data";
 import { useDatabaseViewPageDragSource } from "../database-view-page-drag";
 import { projectDatabaseBoardCardProperties } from "./database-board-model";
+
+const DATABASE_BOARD_CARD_INTERACTIVE_SELECTOR = [
+  "button",
+  "a",
+  "input",
+  "textarea",
+  "select",
+  "[role=button]",
+  "[role=checkbox]",
+  "[role=combobox]",
+  "[role=listbox]",
+  "[role=menu]",
+  "[role=menuitem]",
+  "[role=option]",
+  "[contenteditable=true]",
+  "[data-database-view-property-id]",
+].join(",");
 
 export interface DatabaseBoardCardProps {
   readonly model: DatabaseViewRenderModel;
@@ -258,6 +275,25 @@ export function DatabaseBoardCard({
   const previewShadow = document.documentElement.classList.contains("dark")
     ? "0 4px 12px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.1), 0 0 0 1px color-mix(in srgb, var(--column-accent, rgba(255,255,255,0.07)) 20%, transparent)"
     : "0 4px 12px rgba(25,25,25,0.027), 0 1px 2px rgba(25,25,25,0.02), 0 0 0 1px color-mix(in srgb, var(--column-accent, rgba(42,28,0,0.07)) 15%, transparent)";
+  const handleCardClick = (event: ReactMouseEvent<HTMLElement>): void => {
+    if (event.defaultPrevented) return;
+    if (
+      typeof Node === "undefined"
+      || !(event.target instanceof Node)
+      || !event.currentTarget.contains(event.target)
+    ) return;
+    if (
+      typeof Element !== "undefined"
+      && event.target instanceof Element
+      && event.target.closest(DATABASE_BOARD_CARD_INTERACTIVE_SELECTOR)
+    ) return;
+    if (event.shiftKey) {
+      event.preventDefault();
+      onToggleSelection(row.pageId);
+      return;
+    }
+    onOpenPage(row.pageId, title);
+  };
   const renderCard = (previewRect: DOMRect | null) => (
     <article
       ref={previewRect ? undefined : cardRef}
@@ -274,6 +310,7 @@ export function DatabaseBoardCard({
       aria-label={!previewRect && draggable ? `Drag ${title}` : undefined}
       onPointerDown={previewRect ? undefined : () => onHighlight(row.pageId)}
       onFocus={previewRect ? undefined : () => onHighlight(row.pageId)}
+      onClick={previewRect ? undefined : handleCardClick}
       onDragStart={!previewRect && draggable ? (event) => onDragStartPage(row, event) : undefined}
       onDragEnd={!previewRect && draggable ? onDragEndPage : undefined}
       className={cn(

--- a/src/renderer/components/workbench/database-view-surface.test.tsx
+++ b/src/renderer/components/workbench/database-view-surface.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, waitFor, within } from "@testing-library/react";
 import { act, useRef, useState } from "react";
 import type { DatabaseViewRenderModel } from "@/lib/database-view-render-model";
 import {
@@ -656,6 +656,43 @@ describe("DatabaseViewSurface", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Open Page Focused Page" }));
     expect(opened[0]).toEqual(["page-focused", "Focused Page"]);
+  });
+
+  test("opens a Board Page from its description without hijacking Property controls", async () => {
+    const onOpenPage = vi.fn();
+    const screen = render(
+      <DatabaseViewSurface
+        model={describedBoardModel()}
+        presentationLayout="board"
+        searchQuery=""
+        onOpenPage={onOpenPage}
+      />,
+    );
+    const card = screen.container.querySelector<HTMLElement>(
+      '[data-database-view-page-id="page-focused"]',
+    );
+    if (!card) throw new Error("Expected the focused Board card");
+    const description = card.querySelector<HTMLElement>(
+      '[data-board-page-description="true"]',
+    );
+    if (!description) throw new Error("Expected the Board description");
+
+    await act(async () => {
+      fireEvent.click(description);
+      await Promise.resolve();
+    });
+    expect(onOpenPage).toHaveBeenCalledWith("page-focused", "Focused Page");
+
+    await act(async () => {
+      fireEvent.click(within(card).getByRole("button", { name: "Edit Tags" }));
+      await Promise.resolve();
+    });
+    const nextOption = await screen.findByRole("option", { name: "Next" });
+    await act(async () => {
+      fireEvent.click(nextOption);
+      await Promise.resolve();
+    });
+    expect(onOpenPage).toHaveBeenCalledTimes(1);
   });
 
   test("renders an enabled Board Page key above the title and applies the shared key lookup", () => {


### PR DESCRIPTION
## Summary

- make a normal click on any non-interactive part of a Board Page card open that Page
- preserve Property controls, menus, drag gestures, and Shift-click selection behavior
- add a regression test covering description clicks and Property option controls

## Root cause

The view refactor left Board card root interactions responsible for focus/highlight only, while Page opening remained attached to the title button. As a result, clicking the description focused the card but did not open the Page.

## Validation

- `pnpm exec vitest run --config vitest.renderer.config.ts src/renderer/components/workbench/database-view-surface.test.tsx src/renderer/components/workbench/database-list/database-list-dnd.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Board cards now open their pages when users click the title or other non-interactive areas.
  * Shift-clicking a card toggles its selection.

* **Bug Fixes**
  * Property controls, menus, and drag interactions continue working without unexpectedly opening the page.
  * Clicking a page description now correctly opens the page.

* **Tests**
  * Added coverage for card navigation and property-control interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->