### PR TITLE
fix(release): reseal Sparkle schema v3 manifests

### DIFF
--- a/scripts/sign-macos-runtime.mjs
+++ b/scripts/sign-macos-runtime.mjs
@@ -135,7 +135,7 @@ export const refreshSignedSparkleRuntimeManifest = (appPath) => {
     frameworkInfoPlist: "Frameworks/Sparkle.framework/Versions/B/Resources/Info.plist",
     updater: "Frameworks/Sparkle.framework/Versions/B/Updater.app/Contents/MacOS/Updater",
   };
-  if (manifest.schemaVersion !== 2 || !manifest.artifacts) {
+  if (manifest.schemaVersion !== 3 || !manifest.artifacts) {
     throw new Error(`Unsupported Sparkle runtime manifest: ${manifestPath}`);
   }
   const artifacts = Object.fromEntries(Object.entries(expectedArtifacts).map(([

--- a/scripts/sign-macos-runtime.test.ts
+++ b/scripts/sign-macos-runtime.test.ts
@@ -136,7 +136,20 @@ describe("Sparkle code signing", () => {
       appPath,
       "Contents/Resources/native/sparkle-runtime.json",
     );
-    fs.writeFileSync(manifestPath, JSON.stringify({ artifacts, schemaVersion: 2 }));
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      architecture: "arm64",
+      artifacts,
+      buildChannel: "nightly",
+      feedUrls: {
+        stable: "https://nodex.jyu.app/updates/stable/arm64/appcast.xml",
+        nightly: "https://nodex.jyu.app/updates/nightly/arm64/appcast.xml",
+      },
+      minimumMacOS: "12.0",
+      publicKey: "A".repeat(43) + "=",
+      schemaVersion: 3,
+      sparkleArchiveSha256: "1".repeat(64),
+      sparkleVersion: "2.9.4",
+    }));
 
     refreshSignedSparkleRuntimeManifest(appPath);
 
@@ -147,6 +160,11 @@ describe("Sparkle code signing", () => {
       path: artifactPaths.bridge,
       sha256: createHash("sha256").update("signed-bridge\n").digest("hex"),
       size: Buffer.byteLength("signed-bridge\n"),
+    });
+    expect(manifest).toMatchObject({
+      architecture: "arm64",
+      buildChannel: "nightly",
+      schemaVersion: 3,
     });
   });
 });


### PR DESCRIPTION
Nightly macOS signing rejected the current Sparkle runtime manifest because the signing hook still accepted schema v2 while the channel-aware bridge emits schema v3.

Update the reseal boundary to accept schema v3 and exercise the channel/feed metadata in the regression fixture. This keeps the manifest identity intact while refreshing post-signing artifact hashes.



**Checks**

- pnpm exec vitest run --config vitest.node.config.ts scripts/sign-macos-runtime.test.ts

- pnpm exec eslint scripts/sign-macos-runtime.mjs scripts/sign-macos-runtime.test.ts

- pnpm run typecheck



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS runtime manifest validation to support Sparkle schema version 3.
  * Added validation for required schema version 3 metadata, including architecture, update channel, feed URL, minimum macOS version, signing key, archive hash, and Sparkle version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->