### PR TITLE
fix(release): point Browser runtime at vendored plugin modules

### DIFF
--- a/scripts/vendor-browser-runtime.test.ts
+++ b/scripts/vendor-browser-runtime.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "vitest";
-import { readCuaRuntimeVersion } from "./vendor-browser-runtime";
+import {
+  browserPluginNodeModuleDirs,
+  readCuaRuntimeVersion,
+} from "./vendor-browser-runtime";
+
+test("declares the vendored Browser plugin dependency directory", () => {
+  expect(browserPluginNodeModuleDirs()).toEqual([
+    "runtime/lib/node_modules",
+    "marketplace/plugins/browser/node_modules",
+  ]);
+});
 
 describe("readCuaRuntimeVersion", () => {
   test("reads the unified CUA runtime version used by current desktop builds", () => {

--- a/scripts/vendor-browser-runtime.ts
+++ b/scripts/vendor-browser-runtime.ts
@@ -17,6 +17,13 @@ const DIRECTORY_MODE = 0o755;
 const REGULAR_MODE = 0o644;
 const PLUGIN_NAME = "browser";
 
+export function browserPluginNodeModuleDirs(): string[] {
+  return [
+    "runtime/lib/node_modules",
+    "marketplace/plugins/browser/node_modules",
+  ];
+}
+
 type VendorBrowserRuntimeOptions = {
   appPath: string;
   codexCompatibilityVersion: string;
@@ -487,10 +494,7 @@ export function vendorBrowserRuntime(
         manifest: "marketplace/plugins/browser/.codex-plugin/plugin.json",
         marketplaceManifest: "marketplace/.agents/plugins/marketplace.json",
         marketplaceRoot: "marketplace",
-        nodeModuleDirs: [
-          "runtime/lib/node_modules",
-          "marketplace/plugins/browser/scripts/node_modules",
-        ],
+        nodeModuleDirs: browserPluginNodeModuleDirs(),
         root: "marketplace/plugins/browser",
         version: pluginVersion,
       },


### PR DESCRIPTION
The release verifier currently rejects packaged macOS builds because the generated Browser runtime manifest points at `marketplace/plugins/browser/scripts/node_modules`, while the vendored plugin dependencies are copied under `marketplace/plugins/browser/node_modules`.

Use the actual vendored directory for the manifest and cover the path contract with a focused test. This lets the packaged runtime verifier find the dependencies after Electron Builder prunes empty directories.

Checks:
- `pnpm exec vitest run --config vitest.node.config.ts scripts/vendor-browser-runtime.test.ts scripts/stage-browser-runtime.test.ts src/main/codex/codex-runtime.test.ts`
- `pnpm exec eslint scripts/vendor-browser-runtime.ts scripts/vendor-browser-runtime.test.ts`
- `pnpm run typecheck`

The previous release run reached notarization successfully and failed only at this path verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser plugin dependency resolution for both runtime and marketplace installations.
  * Updated generated browser plugin manifests to reference the correct dependency directories.

* **Tests**
  * Added coverage to verify browser plugin dependency paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->