### PR TITLE
fix(release): normalize legacy Browser runtime module paths

### DIFF
--- a/scripts/stage-browser-runtime.test.ts
+++ b/scripts/stage-browser-runtime.test.ts
@@ -102,12 +102,24 @@ describe("stageBrowserRuntime", () => {
     expect(stagedManifest.browserPlugin.nodeModuleDirs).not.toContain(
       "marketplace/plugins/browser/scripts/node_modules",
     );
+    const activeRoot = path.join(runtimeRoot, BROWSER_RUNTIME_BUNDLE_DIRECTORY);
+    const activeRootInode = fs.statSync(activeRoot).ino;
+
+    stageBrowserRuntime({
+      expectedCodexCompatibilityVersion: "0.144.6",
+      runtimeRoot,
+      sourceRoot,
+      targetArch: "arm64",
+      targetPlatform: "darwin",
+    });
+
     expect(resolveBrowserRuntimeBundle({
       expectedCodexCompatibilityVersion: "0.144.6",
       runtimeRoot,
       targetArch: "arm64",
       targetPlatform: "darwin",
     }).status).toBe("available");
+    expect(fs.statSync(activeRoot).ino).toBe(activeRootInode);
   });
 
   test("preserves the previously active bundle when source verification fails", () => {

--- a/scripts/stage-browser-runtime.test.ts
+++ b/scripts/stage-browser-runtime.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { BROWSER_RUNTIME_BUNDLE_DIRECTORY } from "../src/shared/browser-runtime-metadata";
+import {
+  BROWSER_PLUGIN_NODE_MODULE_DIR,
+  BROWSER_RUNTIME_BUNDLE_DIRECTORY,
+  BROWSER_RUNTIME_MANIFEST_FILENAME,
+} from "../src/shared/browser-runtime-metadata";
 import { writeBrowserRuntimeFixture } from "../src/main/codex/browser-runtime-test-fixture";
 import { resolveBrowserRuntimeBundle } from "../src/main/codex/browser-runtime-bundle";
 import { stageBrowserRuntime } from "./stage-browser-runtime";
@@ -63,6 +67,41 @@ describe("stageBrowserRuntime", () => {
       targetPlatform: "darwin",
     });
 
+    expect(resolveBrowserRuntimeBundle({
+      expectedCodexCompatibilityVersion: "0.144.6",
+      runtimeRoot,
+      targetArch: "arm64",
+      targetPlatform: "darwin",
+    }).status).toBe("available");
+  });
+
+  test("normalizes legacy Browser plugin module paths during staging", () => {
+    const sourceRoot = makeRoot("nodex-browser-source-");
+    const runtimeRoot = makeRoot("nodex-browser-destination-");
+    writeBrowserRuntimeFixture(sourceRoot);
+    const manifestPath = path.join(sourceRoot, BROWSER_RUNTIME_MANIFEST_FILENAME);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      browserPlugin: { nodeModuleDirs: string[] };
+    };
+    manifest.browserPlugin.nodeModuleDirs = manifest.browserPlugin.nodeModuleDirs.map((directory) => (
+      directory === BROWSER_PLUGIN_NODE_MODULE_DIR
+        ? "marketplace/plugins/browser/scripts/node_modules"
+        : directory
+    ));
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const stagedManifest = stageBrowserRuntime({
+      expectedCodexCompatibilityVersion: "0.144.6",
+      runtimeRoot,
+      sourceRoot,
+      targetArch: "arm64",
+      targetPlatform: "darwin",
+    });
+
+    expect(stagedManifest.browserPlugin.nodeModuleDirs).toContain(BROWSER_PLUGIN_NODE_MODULE_DIR);
+    expect(stagedManifest.browserPlugin.nodeModuleDirs).not.toContain(
+      "marketplace/plugins/browser/scripts/node_modules",
+    );
     expect(resolveBrowserRuntimeBundle({
       expectedCodexCompatibilityVersion: "0.144.6",
       runtimeRoot,

--- a/scripts/stage-browser-runtime.ts
+++ b/scripts/stage-browser-runtime.ts
@@ -178,13 +178,11 @@ export function stageBrowserRuntime(
   }
   const activeRoot = path.join(runtimeRoot, BROWSER_RUNTIME_BUNDLE_DIRECTORY);
   try {
-    const sourceManifest = fs.readFileSync(
-      path.join(sourceRoot, BROWSER_RUNTIME_MANIFEST_FILENAME),
-    );
+    const normalizedManifest = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8");
     const activeManifest = fs.readFileSync(
       path.join(activeRoot, BROWSER_RUNTIME_MANIFEST_FILENAME),
     );
-    if (sourceManifest.equals(activeManifest)) {
+    if (normalizedManifest.equals(activeManifest)) {
       assertBrowserRuntimeSourceClosure(activeRoot, manifest);
       const verification = resolveBrowserRuntimeBundle({
         expectedCodexCompatibilityVersion: options.expectedCodexCompatibilityVersion,

--- a/scripts/stage-browser-runtime.ts
+++ b/scripts/stage-browser-runtime.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  BROWSER_PLUGIN_NODE_MODULE_DIR,
   BROWSER_RUNTIME_BUNDLE_DIRECTORY,
   BROWSER_RUNTIME_MANIFEST_FILENAME,
   parseBrowserRuntimeManifest,
@@ -15,6 +16,7 @@ import { replaceOwnedDirectory } from "./replace-owned-directory";
 
 const EXECUTABLE_RUNTIME_MODE = 0o755;
 const REGULAR_RUNTIME_MODE = 0o644;
+const LEGACY_BROWSER_PLUGIN_NODE_MODULE_DIR = "marketplace/plugins/browser/scripts/node_modules";
 
 type StageBrowserRuntimeOptions = {
   expectedCodexCompatibilityVersion: string;
@@ -106,6 +108,45 @@ export function assertBrowserRuntimeSourceClosure(
   }
 }
 
+function normalizeBrowserRuntimeManifest(
+  sourceRoot: string,
+  manifest: BrowserRuntimeManifest,
+): BrowserRuntimeManifest {
+  if (!manifest.browserPlugin.nodeModuleDirs.includes(LEGACY_BROWSER_PLUGIN_NODE_MODULE_DIR)) {
+    return manifest;
+  }
+
+  const canonicalDirectory = path.join(sourceRoot, ...BROWSER_PLUGIN_NODE_MODULE_DIR.split("/"));
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(canonicalDirectory);
+  } catch {
+    throw new Error(
+      `Legacy Browser runtime manifest requires ${BROWSER_PLUGIN_NODE_MODULE_DIR}`,
+    );
+  }
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(
+      `Legacy Browser runtime module directory is unavailable: ${BROWSER_PLUGIN_NODE_MODULE_DIR}`,
+    );
+  }
+
+  const nodeModuleDirs = [...new Set(
+    manifest.browserPlugin.nodeModuleDirs.map((directory) => (
+      directory === LEGACY_BROWSER_PLUGIN_NODE_MODULE_DIR
+        ? BROWSER_PLUGIN_NODE_MODULE_DIR
+        : directory
+    )),
+  )];
+  return {
+    ...manifest,
+    browserPlugin: {
+      ...manifest.browserPlugin,
+      nodeModuleDirs,
+    },
+  };
+}
+
 export function stageBrowserRuntime(
   options: StageBrowserRuntimeOptions,
 ): BrowserRuntimeManifest {
@@ -116,18 +157,19 @@ export function stageBrowserRuntime(
     throw new Error(`Browser runtime source must be a real directory: ${sourceRoot}`);
   }
 
-  const manifest = readBrowserRuntimeSourceManifest(sourceRoot);
+  const sourceManifest = readBrowserRuntimeSourceManifest(sourceRoot);
   if (
     !isBrowserRuntimeCompatibleWithCodex(
-      manifest,
+      sourceManifest,
       options.expectedCodexCompatibilityVersion,
     )
-    || manifest.targetArch !== options.targetArch
-    || manifest.targetPlatform !== options.targetPlatform
+    || sourceManifest.targetArch !== options.targetArch
+    || sourceManifest.targetPlatform !== options.targetPlatform
   ) {
     throw new Error("Browser runtime source manifest does not match the active Agent runtime");
   }
-  assertBrowserRuntimeSourceClosure(sourceRoot, manifest);
+  assertBrowserRuntimeSourceClosure(sourceRoot, sourceManifest);
+  const manifest = normalizeBrowserRuntimeManifest(sourceRoot, sourceManifest);
 
   fs.mkdirSync(runtimeRoot, { recursive: true });
   const runtimeRootStats = fs.lstatSync(runtimeRoot);

--- a/scripts/vendor-browser-runtime.ts
+++ b/scripts/vendor-browser-runtime.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  BROWSER_PLUGIN_NODE_MODULE_DIR,
   BROWSER_RUNTIME_MANIFEST_FILENAME,
   BROWSER_RUNTIME_SCHEMA_VERSION,
   parseBrowserRuntimeManifest,
@@ -20,7 +21,7 @@ const PLUGIN_NAME = "browser";
 export function browserPluginNodeModuleDirs(): string[] {
   return [
     "runtime/lib/node_modules",
-    "marketplace/plugins/browser/node_modules",
+    BROWSER_PLUGIN_NODE_MODULE_DIR,
   ];
 }
 

--- a/src/main/codex/browser-runtime-test-fixture.ts
+++ b/src/main/codex/browser-runtime-test-fixture.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
+  BROWSER_PLUGIN_NODE_MODULE_DIR,
   BROWSER_RUNTIME_MANIFEST_FILENAME,
   type BrowserRuntimeArtifact,
   type BrowserRuntimeManifest,
@@ -150,7 +151,7 @@ export function writeBrowserRuntimeFixture(
       size: Buffer.byteLength(content),
     };
   });
-  fs.mkdirSync(path.join(bundleRoot, "marketplace", "plugins", "browser", "node_modules"), {
+  fs.mkdirSync(path.join(bundleRoot, ...BROWSER_PLUGIN_NODE_MODULE_DIR.split("/")), {
     recursive: true,
   });
   if (targetArch === "arm64") {
@@ -168,7 +169,7 @@ export function writeBrowserRuntimeFixture(
       manifest: "marketplace/plugins/browser/manifest.json",
       marketplaceManifest: "marketplace/.agents/plugins/marketplace.json",
       marketplaceRoot: "marketplace",
-      nodeModuleDirs: ["marketplace/plugins/browser/node_modules"],
+      nodeModuleDirs: [BROWSER_PLUGIN_NODE_MODULE_DIR],
       root: "marketplace/plugins/browser",
       version: "1.0.0-test",
     },

--- a/src/shared/browser-runtime-metadata.ts
+++ b/src/shared/browser-runtime-metadata.ts
@@ -1,6 +1,7 @@
 export const BROWSER_RUNTIME_BUNDLE_DIRECTORY = "browser-runtime";
 export const BROWSER_RUNTIME_MANIFEST_FILENAME = "browser-runtime-manifest.json";
 export const BROWSER_RUNTIME_SCHEMA_VERSION = 4;
+export const BROWSER_PLUGIN_NODE_MODULE_DIR = "marketplace/plugins/browser/node_modules";
 
 export type BrowserRuntimeArtifactArchitecture = "any" | "arm64" | "universal" | "x64";
 export type BrowserRuntimeArtifactKind = "data" | "executable" | "native-addon";


### PR DESCRIPTION
Nightly distribution now reaches notarization and DMG validation, but the locked Browser runtime archive still carries a legacy manifest path (marketplace/plugins/browser/scripts/node_modules) while its vendored dependencies live under the plugin root.\n\nNormalize that legacy metadata at the staging boundary, verify the canonical directory exists, and keep newly generated manifests on the canonical shared path. This lets existing locked runtime archives and future archives converge without weakening artifact integrity checks.\n\nChecks:\n- pnpm exec vitest run --config vitest.node.config.ts scripts/stage-browser-runtime.test.ts scripts/vendor-browser-runtime.test.ts src/main/codex/browser-runtime.test.ts\n- pnpm exec eslint scripts/stage-browser-runtime.ts scripts/stage-browser-runtime.test.ts scripts/vendor-browser-runtime.ts src/main/codex/browser-runtime-test-fixture.ts src/shared/browser-runtime-metadata.ts\n- pnpm run typecheck\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser runtime staging by normalizing legacy browser plugin paths to the canonical location.
  * Added validation to ensure staged runtime bundles remain complete and verifiable.
  * Prevented duplicate module directory entries during staging.

* **Tests**
  * Added coverage confirming legacy paths are normalized and staged bundles remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->