### PR TITLE
ci(main): keep hardware-sensitive gates in performance tier

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -168,7 +168,9 @@ jobs:
       - uses: ./.github/actions/fetch-legacy-migrator
       - uses: ./.github/actions/setup-rust-ci
       - uses: ./.github/actions/setup-playwright
-      - name: Run complete Electron E2E suite
+      - name: Run functional Electron E2E suite
+        env:
+          NODEX_SKIP_PERFORMANCE_GATES: "1"
         run: pnpm exec tsx scripts/ci/run-timed.ts --name electron-e2e -- xvfb-run --auto-servernum pnpm run test:e2e
       - name: Upload Electron failure diagnostics
         if: failure()


### PR DESCRIPTION
Main CI is documented as the functional, non-performance gate, but its Electron job currently runs hardware-sensitive performance assertions. That makes the exact main commit ineligible for nightly release when the shared runner varies, even though the dedicated Performance CI owns those thresholds.

Set NODEX_SKIP_PERFORMANCE_GATES=1 for the main functional Electron suite and keep the explicit performance workflow as the owner of those gates.

Validation:
- pnpm run ci:workflow-contracts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Electron end-to-end test workflow to run the functional test suite.
  * Performance gate checks are skipped during this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->