### PR TITLE
fix(release): validate Apple build version separately

### DIFF
--- a/scripts/install-local-macos.ts
+++ b/scripts/install-local-macos.ts
@@ -223,6 +223,7 @@ const verify = (
   });
   verifyPackagedNativeRuntimeStructure({
     appPath,
+    expectedBuildVersion: provenance.product.version,
     expectedVersion: provenance.product.version,
     expectedUpdateChannel: "disabled",
     requireDeveloperId: false,

--- a/scripts/release/distribution.ts
+++ b/scripts/release/distribution.ts
@@ -173,6 +173,7 @@ const verifyApp = async (options: {
   });
   const runtimeOptions = {
     appPath: options.appPath,
+    expectedBuildVersion: options.buildVersion,
     expectedVersion: options.version,
     expectedUpdateChannel: options.channel,
     requireDeveloperId: true,

--- a/scripts/verify-native-runtime.ts
+++ b/scripts/verify-native-runtime.ts
@@ -31,7 +31,10 @@ import { createCoreProjectWorkspaceAdapter } from "../src/main/core-client/proje
 
 export interface PackagedNativeRuntimeStructureOptions {
   readonly appPath: string;
+  /** The human-facing CFBundleShortVersionString encoded in the app. */
   readonly expectedVersion: string;
+  /** The monotonic Apple CFBundleVersion used for update ordering. */
+  readonly expectedBuildVersion: string;
   readonly requireDeveloperId: boolean;
   readonly targetArch: NativeRuntimeArchitecture;
   readonly expectedUpdateChannel?: "disabled" | "stable" | "nightly";
@@ -729,8 +732,10 @@ export function verifyPackagedNativeRuntimeStructure(
     ["-extract", "CFBundleVersion", "raw", "-o", "-", infoPlist],
     "Read packaged app bundle version",
   ).stdout.trim();
-  if (bundleVersion !== expectedVersion) {
-    throw new Error(`Packaged app bundle version is ${bundleVersion}, expected ${expectedVersion}`);
+  if (bundleVersion !== options.expectedBuildVersion) {
+    throw new Error(
+      `Packaged app bundle version is ${bundleVersion}, expected build version ${options.expectedBuildVersion}`,
+    );
   }
   if (manifest.targetArch !== options.targetArch) {
     throw new Error(`Native runtime manifest is ${manifest.targetArch}, expected ${options.targetArch}`);
@@ -826,6 +831,7 @@ const main = async (): Promise<void> => {
   const requireDeveloperId = arguments_.includes("--require-developer-id");
   const verifyNotarization = arguments_.includes("--verify-notarization");
   const expectedUpdateChannel = readOption(arguments_, "--expected-update-channel");
+  const expectedBuildVersion = readOption(arguments_, "--expected-build-version") ?? expectedVersion;
   if (
     expectedUpdateChannel !== null
     && expectedUpdateChannel !== "disabled"
@@ -836,6 +842,7 @@ const main = async (): Promise<void> => {
   }
   await verifyPackagedNativeRuntimeSmoke({
     appPath,
+    expectedBuildVersion,
     expectedVersion,
     launchApp: arguments_.includes("--launch-app"),
     legacyProfileFixturePath:

--- a/scripts/verify-native-runtime.ts
+++ b/scripts/verify-native-runtime.ts
@@ -823,7 +823,8 @@ const main = async (): Promise<void> => {
   if (!appPath || !expectedVersion || (targetArch !== "arm64" && targetArch !== "x64")) {
     throw new Error(
       "usage: verify-native-runtime --app-path <Nodex.app> --target-arch arm64|x64 "
-      + "--expected-version <semver> [--legacy-profile-fixture <legacy.db>] [--verify-signatures] "
+      + "--expected-version <semver> [--expected-build-version <build>] "
+      + "[--legacy-profile-fixture <legacy.db>] [--verify-signatures] "
       + "[--require-developer-id] [--verify-notarization] [--launch-app] "
       + "[--expected-update-channel disabled|stable|nightly]",
     );


### PR DESCRIPTION
The first immediate Nightly release reached signed and notarized DMGs on both macOS architectures, then the packaged runtime smoke gate rejected both because it compared the monotonic Apple `CFBundleVersion` (`1.11.42`) to the display version (`0.2.2-nightly.20260818.1142`).

This keeps those two Release Identity fields explicit at the verification boundary: packaged `CFBundleShortVersionString` must match the display version, while `CFBundleVersion` must match the monotonic Apple build version. Local packaged verification preserves its same-version default.

Validation:
- `pnpm exec vitest run --config vitest.node.config.ts scripts/verify-native-runtime.test.ts`
- `pnpm run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged app verification by checking that the native runtime’s build version matches the expected release build.
  * Added support for separately validating product and build versions during runtime smoke tests.
  * Enhanced verification defaults to preserve compatibility when a separate build version is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->