### PR TITLE
release: promote verified Nightly source to v0.2.2 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.2.2] - 2026-08-18
+
+### Added
 - Added an opt-in Nightly update channel with signed, notarized mainline builds, isolated Sparkle feeds, and an in-app Stable/Nightly selector.
 - Added coherent Page connections: inline `@Page` mentions, live `/Embed page` references, internal Page links and contextual deeplink paste, typed `/Subpage` creation, and authorized `Referenced by` navigation in Page Stage.
 - Added shared image preview and restorable right-panel editing for uploaded and generated images, including direct Composer entry, New Chat and queued edit submission, zoom and pan, positional comments, removal masks, aspect-ratio edits, and Focused/Canvas generated-image workflows.
@@ -19,18 +26,15 @@ All notable changes to this project will be documented in this file.
 - Added a searchable keyboard shortcut reference plus Board-first navigation, Peek, selection, property editing, reordering, expanded Page creation, and sequence shortcuts for opening and navigating Pages, chats, and Settings.
 
 ### Changed
-
 - Database Views now keep one durable identity and Filter while switching between Board and List; personal display changes persist per View and can be reset or published as the View default.
 - Board and List now share effective View authority and layout-independent manual order, and every Board grouping uses the same compact Column/Card UI, whole-card drag, column controls, Page menus, and keyboard behavior.
 - Replaced the Library workspace and ownership tree with a compact Pages section for standalone top-level resources; every Page, Database, and Canvas in a window now shares one restorable tablist with searchable open/new actions, breadcrumbs, and app-wide Back/Forward navigation without switching Projects.
 
 ### Removed
-
 - Removed the former Table, top-level expandable List, and Database Calendar presentations; scheduling, recurrence, reminders, and occurrence data remain available as independent domain capabilities.
 - Removed the `P4 - Later` priority tier; existing P4 assignments, saved View filters, and local UI filters migrate to `P3 - Low`.
 
 ### Fixed
-
 - Fixed NFM Block promotion so task shorthand such as `1XL(ui, unclear)` atomically becomes Page Priority, Estimate, and Tags; unsafe interpretations preserve the complete title, and the whole promotion can be safely undone.
 - Fixed Project New Chat Terminals failing before the first message; they now open in the Project workspace and remain the same Terminal when the Chat gains its Thread.
 - Fixed the NFM `Move to` picker so Page and Database-status destinations commit real atomic Block moves, stay inside the source Project's write authority, and show specific retryable errors instead of a generic failure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-browser-profile-helper"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes",
  "cbc",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "chrono",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-contracts"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "getrandom",
  "hex",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-core-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-page-search-kernel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "nodex-store-format"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.97.1"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodex",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Block-based Agent Orchestrator",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
The verified Nightly source line is ready to become the 0.2.2 stable release.

This PR applies the repository-owned four-file release transition, moving the curated Unreleased notes into the 0.2.2 changelog section and synchronizing package/Cargo versions. The immutable v0.2.2-nightly.20260818.1143 remains unchanged; after merge, the protected-main Release workflow will build and publish the stable channel from this exact reviewed transition.

Validation:
- `pnpm release:check -- --base origin/main --worktree`
- `git diff --check`
- Nightly workflow 32161917357 completed successfully across both architectures, Sparkle finalization, bundle assembly, GitHub Release publication, and feed promotion.

The stable release must be generated by the production Release workflow so its channel metadata, signed appcasts, Homebrew cask, official skills, and landing feed all agree on v0.2.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Database View, Board/List, Pages, Library, and navigation updates.
  - Removed legacy presentations and the “P4 - Later” priority tier.

- **Bug Fixes**
  - Improved NFM promotion, terminal handling, atomic moves, synchronization, editing, caching, and access revocation.

- **Changelog**
  - Added release notes for version 0.2.2, including categorized changes and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->