### PR TITLE
ci: narrow stable release PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,63 @@ jobs:
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Change classification\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`);
           ' "${RUNNER_TEMP}/classification.json"
 
+  release-transition:
+    name: release transition
+    if: needs.classify.outputs.release_metadata == 'true'
+    needs: classify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Verify exact stable release transition
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          transition="${RUNNER_TEMP}/release-transition.json"
+          identity="${RUNNER_TEMP}/release-identity.json"
+          pnpm release:detect -- \
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}" \
+            --output "${transition}"
+          test "$(node -p "require('${transition}').shouldRelease")" = true
+          pnpm release:resolve:stable -- \
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}" \
+            --output "${identity}"
+          version="$(node -p "require('${identity}').version")"
+          pnpm release:check:remote -- \
+            --repo "${GITHUB_REPOSITORY}" \
+            --source-sha "${HEAD_SHA}" \
+            --version "${version}"
+          {
+            echo "## Release transition"
+            echo
+            echo '```json'
+            cat "${transition}"
+            echo '```'
+            echo
+            echo '```json'
+            cat "${identity}"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   static-contracts:
     name: static contracts
-    if: needs.classify.outputs.docs_only != 'true'
+    if: needs.classify.outputs.docs_only != 'true' && needs.classify.outputs.release_metadata != 'true'
     needs: classify
     runs-on: ubuntu-latest
     env:
@@ -337,6 +391,7 @@ jobs:
     if: always()
     needs:
       - classify
+      - release-transition
       - static-contracts
       - rust-pr
       - rust-migration
@@ -365,6 +420,8 @@ jobs:
           RUNTIME_RESULT: ${{ needs.runtime-contracts.result }}
           RUST: ${{ needs.classify.outputs.rust }}
           RUST_RESULT: ${{ needs.rust-pr.result }}
+          RELEASE_METADATA: ${{ needs.classify.outputs.release_metadata }}
+          RELEASE_TRANSITION_RESULT: ${{ needs.release-transition.result }}
           STATIC_RESULT: ${{ needs.static-contracts.result }}
           STRESS_RELEVANT: ${{ needs.classify.outputs.stress_relevant }}
           STRESS_RESULT: ${{ needs.stress-tests.result }}
@@ -380,6 +437,10 @@ jobs:
             fi
           }
           require_success classify "${CLASSIFY_RESULT}"
+          if [[ "${RELEASE_METADATA}" == "true" ]]; then
+            require_success release-transition "${RELEASE_TRANSITION_RESULT}"
+            exit 0
+          fi
           if [[ "${DOCS_ONLY}" != "true" ]]; then
             require_success static-contracts "${STATIC_RESULT}"
           fi

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -10,6 +10,12 @@ continuously exercised.
 - `.github/workflows/ci.yml` runs on pull requests and owns the stable
   `required` check. It selects Rust, migration, application, browser, Electron,
   stress, and runtime gates from `scripts/ci/classify-change.ts`.
+- An exact four-file stable release transition (`CHANGELOG.md`, `Cargo.lock`,
+  `Cargo.toml`, and `package.json`) is a narrow CI mode: classification skips
+  the application gates and `release transition` validates the semantic version
+  transition, release identity, and remote tag availability. The protected-main
+  `Main CI` workflow remains exhaustive after merge, before the production
+  Release workflow builds the signed application.
 - `.github/workflows/ci-main.yml` runs the complete static, runtime, Rust, app,
   browser, stress, and Electron non-performance suite after changes land on
   `main`.

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -190,7 +190,10 @@ builds, and does not ask the bot branch to commit generated output.
 CI also classifies dependency-only changes as GitHub Actions, Rust, ordinary
 JavaScript, or editor dependencies for later matrix tuning; the first rollout
 keeps the existing full application/runtime coverage so classification cannot
-hide a dependency regression.
+hide a dependency regression. The exact four-file stable release transition is
+the deliberate exception: its PR runs only the classifier and semantic release
+transition guard; the protected-main Main CI and production Release workflow
+still provide the post-merge source and signed-distribution gates.
 
 ## Sparkle update signing and feeds
 

--- a/scripts/ci/classify-change.test.ts
+++ b/scripts/ci/classify-change.test.ts
@@ -39,28 +39,49 @@ describe("CI change classification", () => {
     });
   });
 
-  test("forces release metadata through both application and runtime gates", () => {
+  test("routes an exact release metadata set to the narrow release guard", () => {
     expect(classifyChangedPaths([
       "Cargo.lock",
       "Cargo.toml",
       "CHANGELOG.md",
       "package.json",
     ])).toEqual({
-      app: true,
+      app: false,
       dependencyKind: "none",
       browser: false,
       docsOnly: false,
       electronMain: false,
-      fullRequired: true,
+      fullRequired: false,
       landingOnly: false,
       migration: false,
       protocol: false,
       releaseMetadata: true,
       renderer: false,
-      runtime: true,
-      rust: true,
+      runtime: false,
+      rust: false,
       storage: false,
-      stressRelevant: true,
+      stressRelevant: false,
+    });
+  });
+
+  test("keeps an incomplete release metadata set on the ordinary gates", () => {
+    expect(classifyChangedPaths(["package.json"])).toMatchObject({
+      app: true,
+      fullRequired: true,
+      releaseMetadata: false,
+      runtime: true,
+    });
+    expect(classifyChangedPaths([
+      "Cargo.lock",
+      "Cargo.toml",
+      "CHANGELOG.md",
+      "package.json",
+      "README.md",
+    ])).toMatchObject({
+      app: true,
+      fullRequired: true,
+      releaseMetadata: false,
+      runtime: true,
     });
   });
 

--- a/scripts/ci/classify-change.ts
+++ b/scripts/ci/classify-change.ts
@@ -28,12 +28,6 @@ const RELEASE_PATHS = new Set([
   "package.json",
 ]);
 
-const RELEASE_IDENTITY_PATHS = new Set([
-  "Cargo.lock",
-  "Cargo.toml",
-  "package.json",
-]);
-
 const isDocumentationPath = (path: string): boolean =>
   path === "AGENTS.md"
   || path === "docs/ARCHITECTURE.md"
@@ -235,8 +229,8 @@ export function classifyChangedPaths(
     };
   }
 
-  const releaseMetadata = paths.every((path) => RELEASE_PATHS.has(path))
-    && paths.some((path) => RELEASE_IDENTITY_PATHS.has(path));
+  const releaseMetadata = paths.length === RELEASE_PATHS.size
+    && [...RELEASE_PATHS].every((path) => paths.includes(path));
   const docsOnly = !releaseMetadata && paths.every(isDocumentationPath);
   const landingOnly = !releaseMetadata && paths.every(isLandingPath);
   const hasUnknownPath = paths.some((path) => (
@@ -245,11 +239,12 @@ export function classifyChangedPaths(
     && !isKnownAppPath(path)
     && !RELEASE_PATHS.has(path)
   ));
-  const fullRequired = paths.some(isFullRequiredPath) || hasUnknownPath || releaseMetadata;
+  const fullRequired = !releaseMetadata
+    && (paths.some(isFullRequiredPath) || hasUnknownPath);
   const dependencyKind = dependencyKindFor(paths);
 
   return {
-    app: releaseMetadata || (!docsOnly && !landingOnly),
+    app: !releaseMetadata && !docsOnly && !landingOnly,
     dependencyKind,
     browser: paths.some(isBrowserPath),
     docsOnly,
@@ -260,10 +255,10 @@ export function classifyChangedPaths(
     protocol: paths.some(isProtocolPath),
     releaseMetadata,
     renderer: paths.some(isRendererPath),
-    rust: paths.some(isRustPath),
-    runtime: releaseMetadata || hasUnknownPath || paths.some(isRuntimePath),
+    rust: !releaseMetadata && paths.some(isRustPath),
+    runtime: !releaseMetadata && (hasUnknownPath || paths.some(isRuntimePath)),
     storage: paths.some(isStoragePath),
-    stressRelevant: paths.some(isStressRelevantPath),
+    stressRelevant: !releaseMetadata && paths.some(isStressRelevantPath),
   };
 }
 


### PR DESCRIPTION
## Problem
A stable release PR that changes only the four release metadata files currently looks like a broad application change, so the PR spends time running Rust, app, browser, Electron, stress, and runtime gates even though the release source has already been validated by the nightly path.

## Change
- classify only the exact `CHANGELOG.md`, `Cargo.lock`, `Cargo.toml`, and `package.json` set as a stable release transition;
- route that transition through one `release transition` guard that reuses the existing semantic transition, stable identity, and remote-tag checks;
- keep incomplete or mixed metadata changes on the ordinary gates;
- leave protected-main `Main CI` exhaustive before production distribution.

## Validation
- `pnpm exec vitest run --config vitest.node.config.ts scripts/ci/classify-change.test.ts scripts/release/source.test.ts`
- `pnpm exec eslint scripts/ci/classify-change.ts scripts/ci/classify-change.test.ts`
- `pnpm run typecheck`
- YAML parse of `.github/workflows/ci.yml`
- local release guard simulation against stable release PR source `b9fe0a5bf5ea97ac882cab81d4f99c98e8060b25` (`0.2.2`, remote tag plan `create`)
