### PR TITLE
fix(search): keep interactive requests responsive under load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed Core-backed views intermittently timing out during larger searches or maintenance; interactive work keeps reserved capacity, Full Page search avoids pathological SQLite query plans and preserves multi-term evidence, stale searches cancel silently end to end, and slow requests return typed Core outcomes instead of arbitrary transport failures.
+
 ## [0.2.2] - 2026-08-18
 
 ### Added

--- a/crates/nodex-core-contracts/src/lib.rs
+++ b/crates/nodex-core-contracts/src/lib.rs
@@ -67,6 +67,9 @@ pub enum CoreErrorCode {
     StoreCorrupt,
     ProtocolIncompatible,
     EventReplayUnavailable,
+    DeadlineExceeded,
+    Cancelled,
+    Overloaded,
     ResourceExhausted,
     CoreUnavailable,
 }

--- a/crates/nodex-core-protocol/src/lib.rs
+++ b/crates/nodex-core-protocol/src/lib.rs
@@ -36,8 +36,8 @@ pub use nodex_store_format::{
     STORE_LINEAGE,
 };
 
-pub const TRANSPORT_PROTOCOL_MIN: u32 = 10;
-pub const TRANSPORT_PROTOCOL_MAX: u32 = 10;
+pub const TRANSPORT_PROTOCOL_MIN: u32 = 11;
+pub const TRANSPORT_PROTOCOL_MAX: u32 = 11;
 pub const COMPATIBILITY_MANIFEST_VERSION: u32 = 1;
 pub const MAX_ORDINARY_JSON_REQUEST_BYTES: usize = 2 * 1024 * 1024;
 pub const MAX_ORDINARY_JSON_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
@@ -51,6 +51,11 @@ pub const MAX_DOCUMENT_JSON_STRING_BYTES: usize = 8 * 1024 * 1024;
 pub const MAX_DOCUMENT_JSON_REQUEST_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_DOCUMENT_RESPONSE_BYTES: usize =
     MAX_ORDINARY_JSON_RESPONSE_BYTES + MAX_DOCUMENT_JSON_STRING_BYTES + 8;
+pub const MIN_REQUEST_DEADLINE_MS: u64 = 250;
+pub const MAX_REQUEST_DEADLINE_MS: u64 = 5 * 60_000;
+pub const INTERACTIVE_REQUEST_DEADLINE_MS: u64 = 20_000;
+pub const BACKGROUND_REQUEST_DEADLINE_MS: u64 = 60_000;
+pub const MAINTENANCE_REQUEST_DEADLINE_MS: u64 = 120_000;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 pub struct CoreTransportBudgets {
@@ -59,6 +64,11 @@ pub struct CoreTransportBudgets {
     pub event_frame_bytes: u64,
     pub document_json_request_bytes: u64,
     pub document_response_bytes: u64,
+    pub request_deadline_min_ms: u64,
+    pub request_deadline_max_ms: u64,
+    pub interactive_request_deadline_ms: u64,
+    pub background_request_deadline_ms: u64,
+    pub maintenance_request_deadline_ms: u64,
 }
 
 pub const CORE_TRANSPORT_BUDGETS: CoreTransportBudgets = CoreTransportBudgets {
@@ -67,6 +77,11 @@ pub const CORE_TRANSPORT_BUDGETS: CoreTransportBudgets = CoreTransportBudgets {
     event_frame_bytes: MAX_EVENT_FRAME_BYTES as u64,
     document_json_request_bytes: MAX_DOCUMENT_JSON_REQUEST_BYTES as u64,
     document_response_bytes: MAX_DOCUMENT_RESPONSE_BYTES as u64,
+    request_deadline_min_ms: MIN_REQUEST_DEADLINE_MS,
+    request_deadline_max_ms: MAX_REQUEST_DEADLINE_MS,
+    interactive_request_deadline_ms: INTERACTIVE_REQUEST_DEADLINE_MS,
+    background_request_deadline_ms: BACKGROUND_REQUEST_DEADLINE_MS,
+    maintenance_request_deadline_ms: MAINTENANCE_REQUEST_DEADLINE_MS,
 };
 
 pub fn store_format(version: u32) -> Option<StoreFormatIdentity> {
@@ -542,8 +557,40 @@ pub struct HealthDurationMetric {
     pub max_micros: u64,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CoreRequestClass {
+    Interactive,
+    Background,
+    Maintenance,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+pub struct CoreRequestCancelRequest {
+    pub request_id: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+pub struct CoreRequestCancelResponse {
+    pub cancelled: bool,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 pub struct CoreHealthMetrics {
+    #[serde(default)]
+    pub active_requests: u64,
+    #[serde(default)]
+    pub queued_requests: u64,
+    #[serde(default)]
+    pub request_admission_wait: HealthDurationMetric,
+    #[serde(default)]
+    pub request_execution_duration: HealthDurationMetric,
+    #[serde(default)]
+    pub request_deadline_exceeded: u64,
+    #[serde(default)]
+    pub request_cancelled: u64,
+    #[serde(default)]
+    pub request_overloaded: u64,
     pub writer_queue_depth: u64,
     pub active_writer_commands: u64,
     pub active_read_commands: u64,
@@ -903,10 +950,23 @@ mod api {
     #[utoipa::path(
         post,
         path = "/core/v1/local-mutations/resolve",
+        params(
+            ("x-nodex-request-id" = String, Header),
+            ("x-nodex-request-class" = CoreRequestClass, Header),
+            ("x-nodex-request-deadline-ms" = u64, Header)
+        ),
         request_body = LocalMutationResolveRequest,
         responses((status = 200, body = LocalMutationResolveResponse))
     )]
     pub(super) fn resolve_local_mutation() {}
+
+    #[utoipa::path(
+        post,
+        path = "/core/v1/requests/cancel",
+        request_body = CoreRequestCancelRequest,
+        responses((status = 200, body = CoreRequestCancelResponse))
+    )]
+    pub(super) fn cancel_request() {}
 
     #[utoipa::path(
         post,
@@ -921,6 +981,11 @@ mod api {
             #[utoipa::path(
                                         post,
                                         path = concat!($path, "/read"),
+                                        params(
+                                            ("x-nodex-request-id" = String, Header),
+                                            ("x-nodex-request-class" = CoreRequestClass, Header),
+                                            ("x-nodex-request-deadline-ms" = u64, Header)
+                                        ),
                                         request_body = $read,
                                         responses((status = 200, body = $read_response))
                                     )]
@@ -929,6 +994,11 @@ mod api {
             #[utoipa::path(
                                         post,
                                         path = concat!($path, "/apply"),
+                                        params(
+                                            ("x-nodex-request-id" = String, Header),
+                                            ("x-nodex-request-class" = CoreRequestClass, Header),
+                                            ("x-nodex-request-deadline-ms" = u64, Header)
+                                        ),
                                         request_body = $apply,
                                         responses((status = 200, body = $apply_response))
                                     )]
@@ -1000,6 +1070,7 @@ mod api {
         api::handshake,
         api::events,
         api::resolve_local_mutation,
+        api::cancel_request,
         api::shutdown,
         api::library_read,
         api::library_apply,
@@ -1034,6 +1105,9 @@ mod api {
         HealthResponse,
         CoreHealthMetrics,
         HealthDurationMetric,
+        CoreRequestClass,
+        CoreRequestCancelRequest,
+        CoreRequestCancelResponse,
         ShutdownRequest,
         ShutdownResponse,
         RuntimeGenerationIdentity,

--- a/crates/nodex-core-protocol/src/lib.rs
+++ b/crates/nodex-core-protocol/src/lib.rs
@@ -951,9 +951,9 @@ mod api {
         post,
         path = "/core/v1/local-mutations/resolve",
         params(
-            ("x-nodex-request-id" = String, Header),
-            ("x-nodex-request-class" = CoreRequestClass, Header),
-            ("x-nodex-request-deadline-ms" = u64, Header)
+            ("x-nodex-request-id" = Option<String>, Header),
+            ("x-nodex-request-class" = Option<CoreRequestClass>, Header),
+            ("x-nodex-request-deadline-ms" = Option<u64>, Header)
         ),
         request_body = LocalMutationResolveRequest,
         responses((status = 200, body = LocalMutationResolveResponse))

--- a/crates/nodex-core-protocol/src/lib.rs
+++ b/crates/nodex-core-protocol/src/lib.rs
@@ -982,9 +982,9 @@ mod api {
                                         post,
                                         path = concat!($path, "/read"),
                                         params(
-                                            ("x-nodex-request-id" = String, Header),
-                                            ("x-nodex-request-class" = CoreRequestClass, Header),
-                                            ("x-nodex-request-deadline-ms" = u64, Header)
+                                            ("x-nodex-request-id" = Option<String>, Header),
+                                            ("x-nodex-request-class" = Option<CoreRequestClass>, Header),
+                                            ("x-nodex-request-deadline-ms" = Option<u64>, Header)
                                         ),
                                         request_body = $read,
                                         responses((status = 200, body = $read_response))
@@ -995,9 +995,9 @@ mod api {
                                         post,
                                         path = concat!($path, "/apply"),
                                         params(
-                                            ("x-nodex-request-id" = String, Header),
-                                            ("x-nodex-request-class" = CoreRequestClass, Header),
-                                            ("x-nodex-request-deadline-ms" = u64, Header)
+                                            ("x-nodex-request-id" = Option<String>, Header),
+                                            ("x-nodex-request-class" = Option<CoreRequestClass>, Header),
+                                            ("x-nodex-request-deadline-ms" = Option<u64>, Header)
                                         ),
                                         request_body = $apply,
                                         responses((status = 200, body = $apply_response))
@@ -1200,6 +1200,25 @@ mod tests {
     fn openapi_is_version_3_1() {
         let json = serde_json::to_value(openapi()).expect("OpenAPI serializes");
         assert_eq!(json["openapi"], "3.1.0");
+    }
+
+    #[test]
+    fn module_execution_headers_are_optional_in_openapi() {
+        let json = serde_json::to_value(openapi()).expect("OpenAPI serializes");
+        for path in json["paths"]
+            .as_object()
+            .expect("OpenAPI paths")
+            .keys()
+            .filter(|path| path.starts_with("/core/v1/modules/"))
+        {
+            let parameters = json["paths"][path]["post"]["parameters"]
+                .as_array()
+                .expect("module execution headers");
+            assert_eq!(parameters.len(), 3);
+            assert!(parameters.iter().all(|parameter| {
+                parameter["in"] == "header" && parameter["required"] == false
+            }));
+        }
     }
 
     #[test]

--- a/crates/nodex-core-protocol/src/lib.rs
+++ b/crates/nodex-core-protocol/src/lib.rs
@@ -1175,6 +1175,7 @@ mod tests {
             "/core/v1/handshake",
             "/core/v1/health",
             "/core/v1/local-mutations/resolve",
+            "/core/v1/requests/cancel",
             "/core/v1/modules/administration/apply",
             "/core/v1/modules/administration/read",
             "/core/v1/modules/automation/apply",

--- a/crates/nodex-core-server/src/document_wire.rs
+++ b/crates/nodex-core-server/src/document_wire.rs
@@ -1,5 +1,6 @@
 use base64::prelude::{BASE64_STANDARD, Engine as _};
 use nodex_core::document::CanvasSceneSyncSnapshot;
+use nodex_core::infrastructure::request_execution::request_is_cancelled;
 use nodex_core_contracts::document::{
     OwnedDocumentAccessContext, OwnedDocumentCommitValue, OwnedDocumentDescriptor,
     OwnedDocumentReadValue, OwnedDocumentReceipt, OwnedDocumentSyncDescriptor,
@@ -257,6 +258,9 @@ pub(crate) fn parse_yjs_sync(
 }
 
 pub(crate) fn encode_sync(value: &YjsSyncValue) -> Result<Vec<u8>, CoreError> {
+    ensure_request_active()?;
+    let state_vector = BASE64_STANDARD.encode(&value.state_vector);
+    ensure_request_active()?;
     encode_envelope(
         &SyncResponseMetadata {
             version: 3,
@@ -265,7 +269,7 @@ pub(crate) fn encode_sync(value: &YjsSyncValue) -> Result<Vec<u8>, CoreError> {
             store_epoch: &value.store_epoch,
             generation: value.generation,
             head_seq: value.head_seq,
-            state_vector: BASE64_STANDARD.encode(&value.state_vector),
+            state_vector,
         },
         &value.update,
     )
@@ -367,6 +371,7 @@ pub(crate) fn encode_apply_ack(
 pub(crate) fn encode_realtime_event(
     event: &nodex_core::document::DocumentRealtimeEvent,
 ) -> Result<String, CoreError> {
+    ensure_request_active()?;
     let nodex_core::document::DocumentRealtimeEvent::Awareness {
         document_id,
         store_epoch,
@@ -374,7 +379,7 @@ pub(crate) fn encode_realtime_event(
         client_session_id,
         update,
     } = event;
-    serde_json::to_string(&serde_json::json!({
+    let encoded = serde_json::to_string(&serde_json::json!({
         "version": 1,
         "kind": "awareness",
         "documentId": document_id,
@@ -383,7 +388,9 @@ pub(crate) fn encode_realtime_event(
         "clientSessionId": client_session_id,
         "update": BASE64_STANDARD.encode(update),
     }))
-    .map_err(|_| invalid("Document realtime event cannot be encoded"))
+    .map_err(|_| invalid("Document realtime event cannot be encoded"))?;
+    ensure_request_active()?;
+    Ok(encoded)
 }
 
 fn decode_envelope<T: DeserializeOwned>(
@@ -426,8 +433,10 @@ fn decode_metadata_bytes(bytes: &[u8]) -> Result<&[u8], CoreError> {
 }
 
 fn encode_envelope<T: Serialize>(metadata: &T, payload: &[u8]) -> Result<Vec<u8>, CoreError> {
+    ensure_request_active()?;
     let metadata = serde_json::to_vec(metadata)
         .map_err(|_| invalid("Document binary metadata cannot be encoded"))?;
+    ensure_request_active()?;
     if metadata.len() > MAX_METADATA_BYTES {
         return Err(invalid("Document binary metadata exceeds its bound"));
     }
@@ -438,7 +447,24 @@ fn encode_envelope<T: Serialize>(metadata: &T, payload: &[u8]) -> Result<Vec<u8>
     frame.extend_from_slice(&length.to_be_bytes());
     frame.extend_from_slice(&metadata);
     frame.extend_from_slice(payload);
+    ensure_request_active()?;
     Ok(frame)
+}
+
+fn ensure_request_active() -> Result<(), CoreError> {
+    if request_is_cancelled() {
+        return Err(cancelled());
+    }
+    Ok(())
+}
+
+fn cancelled() -> CoreError {
+    CoreError {
+        code: nodex_core_contracts::CoreErrorCode::Cancelled,
+        message: "Core request was cancelled".to_owned(),
+        retryable: true,
+        recovery: nodex_core_contracts::CoreErrorRecovery::None,
+    }
 }
 
 fn invalid(message: &str) -> CoreError {
@@ -459,6 +485,13 @@ fn is_sha256(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
+    use nodex_core::infrastructure::request_execution::{
+        RequestExecutionContext, within_request_execution,
+    };
+    use nodex_core::infrastructure::sqlite::QueryCancellation;
+
     use super::*;
 
     #[test]
@@ -604,6 +637,26 @@ mod tests {
                 .expect_err("oversized Canvas snapshot")
                 .message,
             "Canvas scene snapshot exceeds its byte bound",
+        );
+    }
+
+    #[test]
+    fn response_encoding_preserves_request_cancellation() {
+        let cancellation = QueryCancellation::new();
+        let result = within_request_execution(
+            RequestExecutionContext::new(
+                cancellation.clone(),
+                Instant::now() + Duration::from_secs(2),
+            ),
+            || {
+                cancellation.cancel();
+                encode_envelope(&serde_json::json!({ "kind": "sync" }), &[])
+            },
+        );
+
+        assert_eq!(
+            result.expect_err("cancelled response was encoded").code,
+            nodex_core_contracts::CoreErrorCode::Cancelled,
         );
     }
 }

--- a/crates/nodex-core-server/src/lib.rs
+++ b/crates/nodex-core-server/src/lib.rs
@@ -7,6 +7,7 @@ mod lifecycle;
 mod lifecycle_summary;
 mod logging;
 mod metrics;
+mod request_execution;
 mod runtime_files;
 mod transport_bounds;
 
@@ -64,20 +65,22 @@ use nodex_core_contracts::{
 };
 use nodex_core_protocol::{
     AutomationApplyRequest, AutomationApplyResponse, AutomationReadRequest, AutomationReadResponse,
-    ClientKind, CoreHealthMetrics, CoreReadiness, CoreSelectionDisposition, CoreSelectionPolicy,
-    CoreSelectionReason, CoreSelectionResult, CoreStartupEvent, CoreStartupEventFrame,
-    DatabaseApplyRequest, DatabaseApplyResponse, DatabaseReadRequest, DatabaseReadResponse,
-    EventEnvelope, EventReplayRequired, HandshakeRequest, HandshakeResponse, HealthDurationMetric,
-    HealthResponse, LauncherKind, LibraryApplyRequest, LibraryApplyResponse, LibraryReadRequest,
-    LibraryReadResponse, LocalMutationResolveRequest, LocalMutationResolveResponse,
-    OwnedDocumentApplyRequest, OwnedDocumentApplyResponse, OwnedDocumentReadRequest,
-    OwnedDocumentReadResponse, ProjectWorkspaceApplyRequest, ProjectWorkspaceApplyResponse,
-    ProjectWorkspaceReadRequest, ProjectWorkspaceReadResponse, ResponseEnvelope, RuntimeDescriptor,
-    RuntimeGenerationIdentity, ShutdownRequest, ShutdownResponse, ShutdownStatus,
-    StoreAdministrationApplyRequest, StoreAdministrationApplyResponse,
-    StoreAdministrationReadRequest, StoreAdministrationReadResponse, TRANSPORT_PROTOCOL_MAX,
-    TRANSPORT_PROTOCOL_MIN, canonical_manifest_digest, core_client_requirements,
-    core_compatibility_manifest, evaluate_compatibility, replacement_is_forward_safe, store_format,
+    ClientKind, CoreHealthMetrics, CoreReadiness, CoreRequestCancelRequest,
+    CoreRequestCancelResponse, CoreRequestClass as RequestClass, CoreSelectionDisposition,
+    CoreSelectionPolicy, CoreSelectionReason, CoreSelectionResult, CoreStartupEvent,
+    CoreStartupEventFrame, DatabaseApplyRequest, DatabaseApplyResponse, DatabaseReadRequest,
+    DatabaseReadResponse, EventEnvelope, EventReplayRequired, HandshakeRequest, HandshakeResponse,
+    HealthDurationMetric, HealthResponse, LauncherKind, LibraryApplyRequest, LibraryApplyResponse,
+    LibraryReadRequest, LibraryReadResponse, LocalMutationResolveRequest,
+    LocalMutationResolveResponse, OwnedDocumentApplyRequest, OwnedDocumentApplyResponse,
+    OwnedDocumentReadRequest, OwnedDocumentReadResponse, ProjectWorkspaceApplyRequest,
+    ProjectWorkspaceApplyResponse, ProjectWorkspaceReadRequest, ProjectWorkspaceReadResponse,
+    ResponseEnvelope, RuntimeDescriptor, RuntimeGenerationIdentity, ShutdownRequest,
+    ShutdownResponse, ShutdownStatus, StoreAdministrationApplyRequest,
+    StoreAdministrationApplyResponse, StoreAdministrationReadRequest,
+    StoreAdministrationReadResponse, TRANSPORT_PROTOCOL_MAX, TRANSPORT_PROTOCOL_MIN,
+    canonical_manifest_digest, core_client_requirements, core_compatibility_manifest,
+    evaluate_compatibility, replacement_is_forward_safe, store_format,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -96,6 +99,7 @@ use document_wire::{ApplyFrame, CONTENT_TYPE as DOCUMENT_CONTENT_TYPE, CanvasSyn
 use lifecycle::{DrainReason, LifecycleCoordinator, configured_idle_timeout, monitor_idle};
 use lifecycle_summary::LifecycleSummaryWriter;
 use metrics::ServerMetrics;
+use request_execution::RequestExecutor;
 use runtime_files::{
     CandidateRuntime, ExistingCore, PRIVATE_FILE_MODE, RuntimePaths, current_artifact_identity,
     random_hex,
@@ -212,6 +216,7 @@ struct ServerState {
     document_live: DocumentLiveHub,
     document_live_publisher: DocumentLivePublisher,
     metrics: ServerMetrics,
+    request_executor: RequestExecutor,
     logging: logging::LoggingHandle,
 }
 
@@ -625,9 +630,17 @@ fn health_metrics(state: &ServerState) -> (CoreReadiness, CoreHealthMetrics) {
     ) = state.metrics.canvas_sync();
     let store_metrics = state.store.metrics();
     let block_transfer_metrics = state.library.block_transfer_metrics();
+    let request_metrics = state.request_executor.snapshot();
     (
         status,
         CoreHealthMetrics {
+            active_requests: request_metrics.active,
+            queued_requests: request_metrics.queued,
+            request_admission_wait: health_duration(request_metrics.admission_wait),
+            request_execution_duration: health_duration(request_metrics.execution_duration),
+            request_deadline_exceeded: request_metrics.deadline_exceeded,
+            request_cancelled: request_metrics.cancelled,
+            request_overloaded: request_metrics.overloaded,
             writer_queue_depth: usize_to_u64(store_activity.queued_writes),
             active_writer_commands: usize_to_u64(store_activity.active_writes),
             active_read_commands: usize_to_u64(store_activity.active_reads),
@@ -804,14 +817,32 @@ async fn library_read(
     headers: HeaderMap,
     Json(LibraryReadRequest(request)): Json<LibraryReadRequest>,
 ) -> Json<LibraryReadResponse> {
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.library.read(&context, request) {
-            Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(LibraryReadResponse(response_envelope(Err(error))));
+        }
     };
-    Json(LibraryReadResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            request_state.library.read(&context, request)
+        })
+        .await;
+    Json(LibraryReadResponse(response_envelope(response)))
+}
+
+async fn cancel_request(
+    State(state): State<Arc<ServerState>>,
+    Extension(bound): Extension<BoundConnection>,
+    Json(request): Json<CoreRequestCancelRequest>,
+) -> Json<CoreRequestCancelResponse> {
+    Json(CoreRequestCancelResponse {
+        cancelled: state
+            .request_executor
+            .cancel(&bound.id, &request.request_id),
+    })
 }
 
 fn module_storage_name(module: ModuleName) -> &'static str {
@@ -903,10 +934,19 @@ fn build_authorized_apply_response<T, R>(
 }
 
 fn apply_response_store_error(error: StoreError) -> CoreError {
+    let code = match error.code {
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::StoreCorrupt => CoreErrorCode::StoreCorrupt,
+        _ => CoreErrorCode::CoreUnavailable,
+    };
     CoreError {
-        code: CoreErrorCode::CoreUnavailable,
+        code,
         message: error.message,
-        retryable: true,
+        retryable: error.retryable,
         recovery: CoreErrorRecovery::None,
     }
 }
@@ -942,71 +982,69 @@ async fn resolve_local_mutation(
             "Local mutation resolve identity is invalid",
         ));
     }
-    let current_epoch = descriptor_snapshot(&state).store_epoch;
-    if request.store_epoch.0 != current_epoch {
-        return Ok(Json(LocalMutationResolveResponse::EpochMismatch {
-            requested_store_epoch: request.store_epoch,
-            current_store_epoch: StoreEpoch(current_epoch),
-        }));
-    }
-    let module_name = module_storage_name(request.module);
-    let stored = state
-        .store
-        .readers()
-        .read_default(|connection| {
-            read_module_receipt(connection, module_name, &request.operation_id)
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let current_epoch = descriptor_snapshot(&request_state).store_epoch;
+            if request.store_epoch.0 != current_epoch {
+                return Ok(LocalMutationResolveResponse::EpochMismatch {
+                    requested_store_epoch: request.store_epoch,
+                    current_store_epoch: StoreEpoch(current_epoch),
+                });
+            }
+            let module_name = module_storage_name(request.module);
+            let stored = request_state
+                .store
+                .readers()
+                .read_default(|connection| {
+                    read_module_receipt(connection, module_name, &request.operation_id)
+                })
+                .map_err(apply_response_store_error)?;
+            let Some(stored) = stored else {
+                return Ok(LocalMutationResolveResponse::NotCommitted {
+                    module: request.module,
+                    operation_id: request.operation_id,
+                });
+            };
+            if stored.profile_id != context.profile_id.0
+                || stored.project_id != context.project_id.as_ref().map(|id| id.0.clone())
+            {
+                return Ok(LocalMutationResolveResponse::NotCommitted {
+                    module: request.module,
+                    operation_id: request.operation_id,
+                });
+            }
+            if stored.store_epoch != request.store_epoch.0 {
+                return Ok(LocalMutationResolveResponse::EpochMismatch {
+                    requested_store_epoch: request.store_epoch,
+                    current_store_epoch: StoreEpoch(stored.store_epoch),
+                });
+            }
+            if stored.request_hash != request.intent_hash {
+                return Ok(LocalMutationResolveResponse::IntentConflict {
+                    module: request.module,
+                    operation_id: request.operation_id,
+                    expected_hash: request.intent_hash,
+                    observed_hash: stored.request_hash,
+                });
+            }
+            let delivery = stored
+                .local_commit_seq
+                .map(|commit_seq| authorized_apply_packet(&request_state, commit_seq, &context))
+                .transpose()
+                .map_err(apply_response_store_error)?;
+            Ok(LocalMutationResolveResponse::Committed {
+                module: request.module,
+                operation_id: request.operation_id,
+                request_hash: stored.request_hash,
+                result: stored.result,
+                delivery: delivery.flatten().map(Box::new),
+            })
         })
-        .map_err(|error| {
-            ApiError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("Local mutation receipt is unavailable: {}", error.message),
-            )
-        })?;
-    let Some(stored) = stored else {
-        return Ok(Json(LocalMutationResolveResponse::NotCommitted {
-            module: request.module,
-            operation_id: request.operation_id,
-        }));
-    };
-    if stored.profile_id != context.profile_id.0
-        || stored.project_id != context.project_id.as_ref().map(|id| id.0.clone())
-    {
-        return Ok(Json(LocalMutationResolveResponse::NotCommitted {
-            module: request.module,
-            operation_id: request.operation_id,
-        }));
-    }
-    if stored.store_epoch != request.store_epoch.0 {
-        return Ok(Json(LocalMutationResolveResponse::EpochMismatch {
-            requested_store_epoch: request.store_epoch,
-            current_store_epoch: StoreEpoch(stored.store_epoch),
-        }));
-    }
-    if stored.request_hash != request.intent_hash {
-        return Ok(Json(LocalMutationResolveResponse::IntentConflict {
-            module: request.module,
-            operation_id: request.operation_id,
-            expected_hash: request.intent_hash,
-            observed_hash: stored.request_hash,
-        }));
-    }
-    let delivery = stored
-        .local_commit_seq
-        .map(|commit_seq| authorized_apply_packet(&state, commit_seq, &context))
-        .transpose()
-        .map_err(|error| {
-            ApiError::new(
-                StatusCode::SERVICE_UNAVAILABLE,
-                format!("Local mutation commit is unavailable: {}", error.message),
-            )
-        })?;
-    Ok(Json(LocalMutationResolveResponse::Committed {
-        module: request.module,
-        operation_id: request.operation_id,
-        request_hash: stored.request_hash,
-        result: stored.result,
-        delivery: delivery.flatten().map(Box::new),
-    }))
+        .await
+        .map_err(api_core_error)?;
+    Ok(Json(response))
 }
 
 async fn library_apply(
@@ -1017,29 +1055,28 @@ async fn library_apply(
 ) -> Json<LibraryApplyResponse> {
     record_operation("library", &request.operation_id);
     let operation_id = request.operation_id.clone();
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.library.apply(&context, request) {
-            Ok(outcome) => {
-                let committed = outcome.committed;
-
-                let duplicate = committed.receipt.mutation.duplicate;
-                match build_authorized_apply_response(
-                    &state,
-                    ModuleName::Library,
-                    &operation_id,
-                    &context,
-                    duplicate,
-                    committed,
-                ) {
-                    Ok(response) => ResponseEnvelope::Ok(response),
-                    Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                }
-            }
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => return Json(LibraryApplyResponse(response_envelope(Err(error)))),
     };
-    Json(LibraryApplyResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let outcome = request_state.library.apply(&context, request)?;
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::Library,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
+    Json(LibraryApplyResponse(response_envelope(response)))
 }
 
 async fn database_read(
@@ -1048,14 +1085,20 @@ async fn database_read(
     headers: HeaderMap,
     Json(DatabaseReadRequest(request)): Json<DatabaseReadRequest>,
 ) -> Json<DatabaseReadResponse> {
-    let response = match database_context(&state, &headers, &bound) {
-        Ok(context) => match state.database.read(&context, request) {
-            Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match database_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(DatabaseReadResponse(response_envelope(Err(error))));
+        }
     };
-    Json(DatabaseReadResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            request_state.database.read(&context, request)
+        })
+        .await;
+    Json(DatabaseReadResponse(response_envelope(response)))
 }
 
 async fn database_apply(
@@ -1066,29 +1109,28 @@ async fn database_apply(
 ) -> Json<DatabaseApplyResponse> {
     record_operation("database", &request.operation_id);
     let operation_id = request.operation_id.clone();
-    let response = match database_context(&state, &headers, &bound) {
-        Ok(context) => match state.database.apply(&context, request) {
-            Ok(outcome) => {
-                let committed = outcome.committed;
-
-                let duplicate = committed.receipt.mutation.duplicate;
-                match build_authorized_apply_response(
-                    &state,
-                    ModuleName::Database,
-                    &operation_id,
-                    &context,
-                    duplicate,
-                    committed,
-                ) {
-                    Ok(response) => ResponseEnvelope::Ok(response),
-                    Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                }
-            }
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match database_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => return Json(DatabaseApplyResponse(response_envelope(Err(error)))),
     };
-    Json(DatabaseApplyResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let outcome = request_state.database.apply(&context, request)?;
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::Database,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
+    Json(DatabaseApplyResponse(response_envelope(response)))
 }
 
 async fn workspace_read(
@@ -1097,14 +1139,20 @@ async fn workspace_read(
     headers: HeaderMap,
     Json(ProjectWorkspaceReadRequest(request)): Json<ProjectWorkspaceReadRequest>,
 ) -> Json<ProjectWorkspaceReadResponse> {
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.workspace.read(&context, request) {
-            Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(ProjectWorkspaceReadResponse(response_envelope(Err(error))));
+        }
     };
-    Json(ProjectWorkspaceReadResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            request_state.workspace.read(&context, request)
+        })
+        .await;
+    Json(ProjectWorkspaceReadResponse(response_envelope(response)))
 }
 
 async fn workspace_apply(
@@ -1115,29 +1163,30 @@ async fn workspace_apply(
 ) -> Json<ProjectWorkspaceApplyResponse> {
     record_operation("project_workspace", &request.operation_id);
     let operation_id = request.operation_id.clone();
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.workspace.apply(&context, request) {
-            Ok(outcome) => {
-                let committed = outcome.committed;
-
-                let duplicate = committed.receipt.mutation.duplicate;
-                match build_authorized_apply_response(
-                    &state,
-                    ModuleName::ProjectWorkspace,
-                    &operation_id,
-                    &context,
-                    duplicate,
-                    committed,
-                ) {
-                    Ok(response) => ResponseEnvelope::Ok(response),
-                    Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                }
-            }
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(ProjectWorkspaceApplyResponse(response_envelope(Err(error))));
+        }
     };
-    Json(ProjectWorkspaceApplyResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let outcome = request_state.workspace.apply(&context, request)?;
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::ProjectWorkspace,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
+    Json(ProjectWorkspaceApplyResponse(response_envelope(response)))
 }
 
 async fn automation_read(
@@ -1146,14 +1195,20 @@ async fn automation_read(
     headers: HeaderMap,
     Json(AutomationReadRequest(request)): Json<AutomationReadRequest>,
 ) -> Json<AutomationReadResponse> {
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.automation.read(&context, request) {
-            Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(AutomationReadResponse(response_envelope(Err(error))));
+        }
     };
-    Json(AutomationReadResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            request_state.automation.read(&context, request)
+        })
+        .await;
+    Json(AutomationReadResponse(response_envelope(response)))
 }
 
 async fn automation_apply(
@@ -1164,29 +1219,28 @@ async fn automation_apply(
 ) -> Json<AutomationApplyResponse> {
     record_operation("automation", &request.operation_id);
     let operation_id = request.operation_id.clone();
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.automation.apply(&context, request) {
-            Ok(outcome) => {
-                let committed = outcome.committed;
-
-                let duplicate = committed.receipt.mutation.duplicate;
-                match build_authorized_apply_response(
-                    &state,
-                    ModuleName::Automation,
-                    &operation_id,
-                    &context,
-                    duplicate,
-                    committed,
-                ) {
-                    Ok(response) => ResponseEnvelope::Ok(response),
-                    Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                }
-            }
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => return Json(AutomationApplyResponse(response_envelope(Err(error)))),
     };
-    Json(AutomationApplyResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let outcome = request_state.automation.apply(&context, request)?;
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::Automation,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
+    Json(AutomationApplyResponse(response_envelope(response)))
 }
 
 async fn administration_read(
@@ -1195,14 +1249,22 @@ async fn administration_read(
     headers: HeaderMap,
     Json(StoreAdministrationReadRequest(request)): Json<StoreAdministrationReadRequest>,
 ) -> Json<StoreAdministrationReadResponse> {
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.administration.read(&context, request) {
-            Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(StoreAdministrationReadResponse(response_envelope(Err(
+                error,
+            ))));
+        }
     };
-    Json(StoreAdministrationReadResponse(response))
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Background, move || {
+            request_state.administration.read(&context, request)
+        })
+        .await;
+    Json(StoreAdministrationReadResponse(response_envelope(response)))
 }
 
 async fn administration_apply(
@@ -1218,32 +1280,37 @@ async fn administration_apply(
         StoreAdministrationIntent::CreateBackup { .. }
     )
     .then(std::time::Instant::now);
-    let response = match module_context(&state, &headers, &bound) {
-        Ok(context) => match state.administration.apply(&context, request) {
-            Ok(outcome) => {
-                let committed = outcome.committed;
-
-                let duplicate = committed.receipt.mutation.duplicate;
-                match build_authorized_apply_response(
-                    &state,
-                    ModuleName::StoreAdministration,
-                    &operation_id,
-                    &context,
-                    duplicate,
-                    committed,
-                ) {
-                    Ok(response) => ResponseEnvelope::Ok(response),
-                    Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                }
-            }
-            Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-        },
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match module_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(StoreAdministrationApplyResponse(response_envelope(Err(
+                error,
+            ))));
+        }
     };
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Maintenance, move || {
+            let outcome = request_state.administration.apply(&context, request)?;
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::StoreAdministration,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
     if let Some(started_at) = backup_started_at {
         state.metrics.record_backup_duration(started_at.elapsed());
     }
-    Json(StoreAdministrationApplyResponse(response))
+    Json(StoreAdministrationApplyResponse(response_envelope(
+        response,
+    )))
 }
 
 async fn document_read(State(state): State<Arc<ServerState>>, request: Request) -> Response {
@@ -1259,7 +1326,24 @@ async fn document_read(State(state): State<Arc<ServerState>>, request: Request) 
         Err(_) => return json_document_read_error(invalid("Document read body exceeds its bound")),
     };
     if is_document_binary(&headers) {
-        return binary_document_read(&state, &headers, &bound, &bytes);
+        let request_state = Arc::clone(&state);
+        let request_headers = headers.clone();
+        let request_bound = bound.clone();
+        return match state
+            .request_executor
+            .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+                Ok(binary_document_read(
+                    &request_state,
+                    &request_headers,
+                    &request_bound,
+                    &bytes,
+                ))
+            })
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => json_document_read_error(error),
+        };
     }
     let OwnedDocumentReadRequest(request) = match serde_json::from_slice(&bytes) {
         Ok(request) => request,
@@ -1268,37 +1352,51 @@ async fn document_read(State(state): State<Arc<ServerState>>, request: Request) 
     if let OwnedDocumentRead::PrepareAgentSemanticMutation { operation_id, .. } = &request.read {
         record_operation("owned_document", operation_id);
     }
-    let response = match document_context(&state, &headers, &bound) {
-        Ok(context) => {
-            let result = match &request.read {
-                OwnedDocumentRead::SyncYjs { .. } => {
-                    required_header(&headers, CLIENT_SESSION_HEADER, "Document client session")
-                        .and_then(|client_session_id| {
-                            let OwnedDocumentRead::SyncYjs {
-                                document_id,
-                                state_vector,
-                            } = request.read
-                            else {
-                                unreachable!();
-                            };
-                            state.document_realtime.sync_yjs(
-                                &context,
-                                &client_session_id,
-                                document_id,
-                                state_vector,
-                            )
-                        })
-                }
-                _ => state.document.read(&context, request),
-            };
-            match result {
-                Ok(snapshot) => ResponseEnvelope::Ok(snapshot),
-                Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match document_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(OwnedDocumentReadResponse(response_envelope(Err(error)))).into_response();
+        }
+    };
+    let client_session_id = if matches!(&request.read, OwnedDocumentRead::SyncYjs { .. }) {
+        match required_header(&headers, CLIENT_SESSION_HEADER, "Document client session") {
+            Ok(value) => Some(value),
+            Err(error) => {
+                return Json(OwnedDocumentReadResponse(response_envelope(Err(error))))
+                    .into_response();
             }
         }
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    } else {
+        None
     };
-    Json(OwnedDocumentReadResponse(response)).into_response()
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(
+            &bound.id,
+            &headers,
+            RequestClass::Interactive,
+            move || match request.read {
+                OwnedDocumentRead::SyncYjs {
+                    document_id,
+                    state_vector,
+                } => request_state.document_realtime.sync_yjs(
+                    &context,
+                    client_session_id.as_deref().expect("validated session"),
+                    document_id,
+                    state_vector,
+                ),
+                read => request_state.document.read(
+                    &context,
+                    nodex_core_contracts::ModuleReadRequest {
+                        contract_version: request.contract_version,
+                        read,
+                    },
+                ),
+            },
+        )
+        .await;
+    Json(OwnedDocumentReadResponse(response_envelope(response))).into_response()
 }
 
 async fn document_apply(State(state): State<Arc<ServerState>>, request: Request) -> Response {
@@ -1316,7 +1414,24 @@ async fn document_apply(State(state): State<Arc<ServerState>>, request: Request)
         }
     };
     if is_document_binary(&headers) {
-        return binary_document_apply(&state, &headers, &bound, &bytes);
+        let request_state = Arc::clone(&state);
+        let request_headers = headers.clone();
+        let request_bound = bound.clone();
+        return match state
+            .request_executor
+            .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+                Ok(binary_document_apply(
+                    &request_state,
+                    &request_headers,
+                    &request_bound,
+                    &bytes,
+                ))
+            })
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => json_document_apply_error(error),
+        };
     }
     let OwnedDocumentApplyRequest(request) = match serde_json::from_slice(&bytes) {
         Ok(request) => request,
@@ -1324,46 +1439,54 @@ async fn document_apply(State(state): State<Arc<ServerState>>, request: Request)
     };
     record_operation("owned_document", &request.operation_id);
     let operation_id = request.operation_id.clone();
-    let response = match document_context(&state, &headers, &bound) {
-        Ok(context) => {
-            let realtime_bound = matches!(
-                &request.intent,
-                OwnedDocumentIntent::ApplyYjsUpdate { .. }
-                    | OwnedDocumentIntent::ApplyCanvasMutation { .. }
-            );
-            let result = if realtime_bound {
-                required_header(&headers, CLIENT_SESSION_HEADER, "Document client session")
-                    .and_then(|client_session_id| {
-                        state
-                            .document_realtime
-                            .apply(&context, &client_session_id, request)
-                    })
-            } else {
-                state.document.apply(&context, request)
-            };
-            match result {
-                Ok(outcome) => {
-                    let committed = outcome.committed;
-
-                    let duplicate = committed.receipt.mutation.duplicate;
-                    match build_authorized_apply_response(
-                        &state,
-                        ModuleName::OwnedDocument,
-                        &operation_id,
-                        &context,
-                        duplicate,
-                        committed,
-                    ) {
-                        Ok(response) => ResponseEnvelope::Ok(response),
-                        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
-                    }
-                }
-                Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    let context = match document_context(&state, &headers, &bound) {
+        Ok(context) => context,
+        Err(error) => {
+            return Json(OwnedDocumentApplyResponse(response_envelope(Err(error)))).into_response();
+        }
+    };
+    let realtime_bound = matches!(
+        &request.intent,
+        OwnedDocumentIntent::ApplyYjsUpdate { .. }
+            | OwnedDocumentIntent::ApplyCanvasMutation { .. }
+    );
+    let client_session_id = if realtime_bound {
+        match required_header(&headers, CLIENT_SESSION_HEADER, "Document client session") {
+            Ok(value) => Some(value),
+            Err(error) => {
+                return Json(OwnedDocumentApplyResponse(response_envelope(Err(error))))
+                    .into_response();
             }
         }
-        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    } else {
+        None
     };
-    Json(OwnedDocumentApplyResponse(response)).into_response()
+    let request_state = Arc::clone(&state);
+    let response = state
+        .request_executor
+        .execute(&bound.id, &headers, RequestClass::Interactive, move || {
+            let outcome = if realtime_bound {
+                request_state.document_realtime.apply(
+                    &context,
+                    client_session_id.as_deref().expect("validated session"),
+                    request,
+                )?
+            } else {
+                request_state.document.apply(&context, request)?
+            };
+            let committed = outcome.committed;
+            let duplicate = committed.receipt.mutation.duplicate;
+            build_authorized_apply_response(
+                &request_state,
+                ModuleName::OwnedDocument,
+                &operation_id,
+                &context,
+                duplicate,
+                committed,
+            )
+        })
+        .await;
+    Json(OwnedDocumentApplyResponse(response_envelope(response))).into_response()
 }
 
 fn binary_document_read(
@@ -1592,7 +1715,10 @@ async fn events(
         .acquire_event_subscription(&bound.id, EventSubscriptionKey::Global)
         .map_err(connection_registry_error)?;
     let context = module_context(&state, &headers, &bound).map_err(api_core_error)?;
-    let generation = descriptor_snapshot(&state).start_nonce;
+    let stream_descriptor = descriptor_snapshot(&state);
+    let generation = stream_descriptor.start_nonce.clone();
+    let stream_store_epoch = stream_descriptor.store_epoch;
+    let stream_state = Arc::clone(&state);
     let scanner = state.commit_wake_scanner.clone();
     let recipient = CommitRecipientResolver::bound_scope(generation.clone(), context);
     let stream_generation = generation;
@@ -1604,6 +1730,20 @@ async fn events(
         let mut opening = true;
         let mut opening_packet_count = 0_u64;
         loop {
+            let current_descriptor = descriptor_snapshot(&stream_state);
+            if current_descriptor.store_epoch != stream_store_epoch {
+                // Store replacement can invalidate the old scanner before it
+                // can form another checkpoint. Emit the new identity first so
+                // clients fail closed instead of observing a clean EOF.
+                yield Ok(sse_stream_checkpoint(&StreamCheckpoint {
+                    store_epoch: StoreEpoch(current_descriptor.store_epoch),
+                    generation: current_descriptor.start_nonce,
+                    scanned_through_seq: scanned_through,
+                    oldest_available_seq: 0,
+                    resync_token: None,
+                }));
+                return;
+            }
             loop {
                 match scanner.scan(scanned_through, recipient.clone()).await {
                     Ok(CoreAuthorizedEventReplay::Scan { packets, checkpoint, commit_head }) => {
@@ -2330,6 +2470,7 @@ fn router(state: Arc<ServerState>) -> Router {
         .route("/core/v1/admin/shutdown", post(shutdown));
     let connected_routes = Router::new()
         .route("/core/v1/events", get(events))
+        .route("/core/v1/requests/cancel", post(cancel_request))
         .route("/core/v1/projections/live", get(projection_live_events))
         .route(
             "/core/v1/local-mutations/resolve",
@@ -2550,6 +2691,9 @@ fn record_core_error(error: CoreError) -> CoreError {
         CoreErrorCode::ProtocolIncompatible => "protocol_incompatible",
         CoreErrorCode::EventReplayUnavailable => "event_replay_unavailable",
         CoreErrorCode::ResourceExhausted => "resource_exhausted",
+        CoreErrorCode::DeadlineExceeded => "deadline_exceeded",
+        CoreErrorCode::Cancelled => "cancelled",
+        CoreErrorCode::Overloaded => "overloaded",
         CoreErrorCode::CoreUnavailable => "core_unavailable",
     };
     match &error.code {
@@ -2562,7 +2706,9 @@ fn record_core_error(error: CoreError) -> CoreError {
         }
         CoreErrorCode::MaintenanceInProgress
         | CoreErrorCode::EventReplayUnavailable
-        | CoreErrorCode::ResourceExhausted => {
+        | CoreErrorCode::ResourceExhausted
+        | CoreErrorCode::DeadlineExceeded
+        | CoreErrorCode::Overloaded => {
             tracing::warn!(
                 errorCode = code,
                 retryable = error.retryable,
@@ -2578,6 +2724,13 @@ fn record_core_error(error: CoreError) -> CoreError {
         }
     }
     error
+}
+
+fn response_envelope<T>(result: Result<T, CoreError>) -> ResponseEnvelope<T> {
+    match result {
+        Ok(value) => ResponseEnvelope::Ok(value),
+        Err(error) => ResponseEnvelope::Error(record_core_error(error)),
+    }
 }
 
 struct DocumentSubscriptionGuard {
@@ -2730,7 +2883,11 @@ fn api_core_error(error: CoreError) -> ApiError {
         CoreErrorCode::Unauthorized => StatusCode::UNAUTHORIZED,
         CoreErrorCode::NotFound => StatusCode::NOT_FOUND,
         CoreErrorCode::InvalidInput => StatusCode::BAD_REQUEST,
-        CoreErrorCode::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+        CoreErrorCode::ResourceExhausted | CoreErrorCode::Overloaded => {
+            StatusCode::TOO_MANY_REQUESTS
+        }
+        CoreErrorCode::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        CoreErrorCode::Cancelled => StatusCode::from_u16(499).expect("499 is a valid status"),
         _ => StatusCode::CONFLICT,
     };
     ApiError::new(status, error.message)
@@ -3233,6 +3390,7 @@ pub async fn run_with_selection(
         document_live,
         document_live_publisher,
         metrics: ServerMetrics::default(),
+        request_executor: RequestExecutor::new(),
         logging: logging_handle,
     });
     let idle_task = idle_timeout.map(|timeout| {

--- a/crates/nodex-core-server/src/request_execution.rs
+++ b/crates/nodex-core-server/src/request_execution.rs
@@ -296,7 +296,7 @@ impl RequestExecutor {
             .map_err(|_| worker_failed("registry"))?;
         registry.prune_tombstones(Instant::now());
         if registry.active.contains_key(key) {
-            return Err(invalid_request("Core request ID is already active"));
+            return Err(active_request_conflict());
         }
         let cancelled_before_registration = registry.cancellation_tombstones.remove(key).is_some();
         registry.active.insert(key.clone(), cancellation.clone());
@@ -428,6 +428,15 @@ fn invalid_request(message: &str) -> CoreError {
         code: CoreErrorCode::InvalidInput,
         message: message.to_owned(),
         retryable: false,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+fn active_request_conflict() -> CoreError {
+    CoreError {
+        code: CoreErrorCode::Conflict,
+        message: "Core request ID is already active".to_owned(),
+        retryable: true,
         recovery: CoreErrorRecovery::None,
     }
 }
@@ -578,5 +587,26 @@ mod tests {
 
         assert_eq!(result.unwrap_err().code, CoreErrorCode::Cancelled);
         assert!(!operation_ran.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn duplicate_active_request_is_a_retryable_conflict() {
+        let executor = RequestExecutor::with_capacities(1, 1, 1, 8);
+        let key = RequestKey {
+            connection_id: "connection".to_owned(),
+            request_id: "duplicate".to_owned(),
+        };
+        let first_cancellation = QueryCancellation::new();
+        let _first_guard = executor
+            .register(&key, &first_cancellation)
+            .expect("first request registration");
+
+        let error = match executor.register(&key, &QueryCancellation::new()) {
+            Ok(_) => panic!("duplicate request identity was accepted"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, CoreErrorCode::Conflict);
+        assert!(error.retryable);
     }
 }

--- a/crates/nodex-core-server/src/request_execution.rs
+++ b/crates/nodex-core-server/src/request_execution.rs
@@ -1,0 +1,515 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::http::HeaderMap;
+use nodex_core::infrastructure::metrics::{DurationMetric, DurationMetricSnapshot};
+use nodex_core::infrastructure::request_execution::{
+    RequestExecutionContext, within_request_execution,
+};
+use nodex_core::infrastructure::sqlite::QueryCancellation;
+use nodex_core_contracts::{CoreError, CoreErrorCode, CoreErrorRecovery};
+use nodex_core_protocol::{
+    BACKGROUND_REQUEST_DEADLINE_MS, CoreRequestClass as RequestClass,
+    INTERACTIVE_REQUEST_DEADLINE_MS, MAINTENANCE_REQUEST_DEADLINE_MS, MAX_REQUEST_DEADLINE_MS,
+    MIN_REQUEST_DEADLINE_MS,
+};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+pub(crate) const REQUEST_ID_HEADER: &str = "x-nodex-request-id";
+pub(crate) const REQUEST_CLASS_HEADER: &str = "x-nodex-request-class";
+pub(crate) const REQUEST_DEADLINE_HEADER: &str = "x-nodex-request-deadline-ms";
+
+const TOTAL_EXECUTION_CAPACITY: usize = 4;
+const BACKGROUND_EXECUTION_CAPACITY: usize = TOTAL_EXECUTION_CAPACITY - 1;
+const MAINTENANCE_EXECUTION_CAPACITY: usize = 1;
+const ADMISSION_CAPACITY: usize = 128;
+const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+fn parse_request_class(value: &str) -> Option<RequestClass> {
+    match value {
+        "interactive" => Some(RequestClass::Interactive),
+        "background" => Some(RequestClass::Background),
+        "maintenance" => Some(RequestClass::Maintenance),
+        _ => None,
+    }
+}
+
+fn default_deadline(class: RequestClass) -> Duration {
+    match class {
+        RequestClass::Interactive => Duration::from_millis(INTERACTIVE_REQUEST_DEADLINE_MS),
+        RequestClass::Background => Duration::from_millis(BACKGROUND_REQUEST_DEADLINE_MS),
+        RequestClass::Maintenance => Duration::from_millis(MAINTENANCE_REQUEST_DEADLINE_MS),
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RequestKey {
+    connection_id: String,
+    request_id: String,
+}
+
+struct ActiveRequestGuard {
+    active: Arc<Mutex<HashMap<RequestKey, QueryCancellation>>>,
+    key: RequestKey,
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        let Ok(mut active) = self.active.lock() else {
+            return;
+        };
+        active.remove(&self.key);
+    }
+}
+
+struct ExecutionPermits {
+    _admission: OwnedSemaphorePermit,
+    _class: Option<OwnedSemaphorePermit>,
+    _maintenance: Option<OwnedSemaphorePermit>,
+    _total: OwnedSemaphorePermit,
+}
+
+#[derive(Clone)]
+pub(crate) struct RequestExecutor {
+    total: Arc<Semaphore>,
+    background: Arc<Semaphore>,
+    maintenance: Arc<Semaphore>,
+    admission: Arc<Semaphore>,
+    active: Arc<Mutex<HashMap<RequestKey, QueryCancellation>>>,
+    metrics: Arc<RequestExecutorMetrics>,
+    total_capacity: usize,
+}
+
+#[derive(Default)]
+struct RequestExecutorMetrics {
+    admission_wait: DurationMetric,
+    execution_duration: DurationMetric,
+    deadline_exceeded: AtomicU64,
+    cancelled: AtomicU64,
+    overloaded: AtomicU64,
+}
+
+pub(crate) struct RequestExecutorSnapshot {
+    pub(crate) active: u64,
+    pub(crate) queued: u64,
+    pub(crate) admission_wait: DurationMetricSnapshot,
+    pub(crate) execution_duration: DurationMetricSnapshot,
+    pub(crate) deadline_exceeded: u64,
+    pub(crate) cancelled: u64,
+    pub(crate) overloaded: u64,
+}
+
+impl RequestExecutor {
+    pub(crate) fn new() -> Self {
+        Self::with_capacities(
+            TOTAL_EXECUTION_CAPACITY,
+            BACKGROUND_EXECUTION_CAPACITY,
+            MAINTENANCE_EXECUTION_CAPACITY,
+            ADMISSION_CAPACITY,
+        )
+    }
+
+    fn with_capacities(
+        total: usize,
+        background: usize,
+        maintenance: usize,
+        admission: usize,
+    ) -> Self {
+        Self {
+            total: Arc::new(Semaphore::new(total)),
+            background: Arc::new(Semaphore::new(background)),
+            maintenance: Arc::new(Semaphore::new(maintenance)),
+            admission: Arc::new(Semaphore::new(admission)),
+            active: Arc::new(Mutex::new(HashMap::new())),
+            metrics: Arc::new(RequestExecutorMetrics::default()),
+            total_capacity: total,
+        }
+    }
+
+    pub(crate) async fn execute<T>(
+        &self,
+        connection_id: &str,
+        headers: &HeaderMap,
+        default_class: RequestClass,
+        operation: impl FnOnce() -> Result<T, CoreError> + Send + 'static,
+    ) -> Result<T, CoreError>
+    where
+        T: Send + 'static,
+    {
+        let spec = RequestSpec::from_headers(connection_id, headers, default_class)?;
+        let cancellation = QueryCancellation::new();
+        let guard = self.register(&spec.key, &cancellation)?;
+        let admitted_at = Instant::now();
+        let admission = self.admission.clone().try_acquire_owned().map_err(|_| {
+            self.metrics.overloaded.fetch_add(1, Ordering::Relaxed);
+            overloaded()
+        })?;
+        let permits = match self
+            .acquire_permits(spec.class, spec.deadline, &cancellation, admission)
+            .await
+        {
+            Ok(permits) => permits,
+            Err(error) => {
+                self.record_error(&error);
+                return Err(error);
+            }
+        };
+        self.metrics.admission_wait.record(admitted_at.elapsed());
+        let context = RequestExecutionContext::new(cancellation.clone(), spec.deadline);
+        let metrics = Arc::clone(&self.metrics);
+        let request_span = tracing::Span::current();
+        let mut worker = tokio::task::spawn_blocking(move || {
+            let _guard = guard;
+            let _permits = permits;
+            let started_at = Instant::now();
+            // Tokio blocking workers do not inherit the async task's tracing
+            // span. Carry it explicitly so SQLite work remains correlated with
+            // the request, operation, and receipt that caused it.
+            let result = request_span.in_scope(|| within_request_execution(context, operation));
+            metrics.execution_duration.record(started_at.elapsed());
+            result
+        });
+
+        loop {
+            let remaining = spec.deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                cancellation.cancel();
+                let error = deadline_exceeded();
+                self.record_error(&error);
+                return Err(error);
+            }
+            tokio::select! {
+                result = &mut worker => {
+                    let result = result.map_err(|error| worker_failed(&error.to_string()))?;
+                    if let Err(error) = &result {
+                        self.record_error(error);
+                    }
+                    return result;
+                }
+                () = tokio::time::sleep(remaining) => {
+                    cancellation.cancel();
+                    let error = deadline_exceeded();
+                    self.record_error(&error);
+                    return Err(error);
+                }
+                () = tokio::time::sleep(CANCELLATION_POLL_INTERVAL) => {
+                    if cancellation.is_cancelled() {
+                        let error = cancelled();
+                        self.record_error(&error);
+                        return Err(error);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn cancel(&self, connection_id: &str, request_id: &str) -> bool {
+        let key = RequestKey {
+            connection_id: connection_id.to_owned(),
+            request_id: request_id.to_owned(),
+        };
+        let Ok(active) = self.active.lock() else {
+            return false;
+        };
+        let Some(cancellation) = active.get(&key) else {
+            return false;
+        };
+        cancellation.cancel();
+        true
+    }
+
+    pub(crate) fn snapshot(&self) -> RequestExecutorSnapshot {
+        let active = self
+            .total_capacity
+            .saturating_sub(self.total.available_permits());
+        let registered = self.active.lock().map_or(0, |active| active.len());
+        RequestExecutorSnapshot {
+            active: u64::try_from(active).unwrap_or(u64::MAX),
+            queued: u64::try_from(registered.saturating_sub(active)).unwrap_or(u64::MAX),
+            admission_wait: self.metrics.admission_wait.snapshot(),
+            execution_duration: self.metrics.execution_duration.snapshot(),
+            deadline_exceeded: self.metrics.deadline_exceeded.load(Ordering::Relaxed),
+            cancelled: self.metrics.cancelled.load(Ordering::Relaxed),
+            overloaded: self.metrics.overloaded.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record_error(&self, error: &CoreError) {
+        let counter = match error.code {
+            CoreErrorCode::DeadlineExceeded => Some(&self.metrics.deadline_exceeded),
+            CoreErrorCode::Cancelled => Some(&self.metrics.cancelled),
+            CoreErrorCode::Overloaded => Some(&self.metrics.overloaded),
+            _ => None,
+        };
+        if let Some(counter) = counter {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn register(
+        &self,
+        key: &RequestKey,
+        cancellation: &QueryCancellation,
+    ) -> Result<ActiveRequestGuard, CoreError> {
+        let mut active = self.active.lock().map_err(|_| worker_failed("registry"))?;
+        if active.contains_key(key) {
+            return Err(invalid_request("Core request ID is already active"));
+        }
+        active.insert(key.clone(), cancellation.clone());
+        Ok(ActiveRequestGuard {
+            active: Arc::clone(&self.active),
+            key: key.clone(),
+        })
+    }
+
+    async fn acquire_permits(
+        &self,
+        class: RequestClass,
+        deadline: Instant,
+        cancellation: &QueryCancellation,
+        admission: OwnedSemaphorePermit,
+    ) -> Result<ExecutionPermits, CoreError> {
+        let maintenance = match class {
+            RequestClass::Maintenance => {
+                Some(acquire(Arc::clone(&self.maintenance), deadline, cancellation).await?)
+            }
+            RequestClass::Interactive | RequestClass::Background => None,
+        };
+        let class_permit = match class {
+            RequestClass::Interactive => None,
+            RequestClass::Background | RequestClass::Maintenance => {
+                Some(acquire(Arc::clone(&self.background), deadline, cancellation).await?)
+            }
+        };
+        let total = acquire(Arc::clone(&self.total), deadline, cancellation).await?;
+        Ok(ExecutionPermits {
+            _admission: admission,
+            _class: class_permit,
+            _maintenance: maintenance,
+            _total: total,
+        })
+    }
+}
+
+struct RequestSpec {
+    key: RequestKey,
+    class: RequestClass,
+    deadline: Instant,
+}
+
+impl RequestSpec {
+    fn from_headers(
+        connection_id: &str,
+        headers: &HeaderMap,
+        default_class: RequestClass,
+    ) -> Result<Self, CoreError> {
+        let request_id = header(headers, REQUEST_ID_HEADER)?
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("core-{}", NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)));
+        if request_id.is_empty() || request_id.len() > 128 || request_id.trim() != request_id {
+            return Err(invalid_request("Core request ID is invalid"));
+        }
+        let class = header(headers, REQUEST_CLASS_HEADER)?
+            .map(|value| {
+                parse_request_class(value)
+                    .ok_or_else(|| invalid_request("Core request class is invalid"))
+            })
+            .transpose()?
+            .unwrap_or(default_class);
+        let deadline_duration = header(headers, REQUEST_DEADLINE_HEADER)?
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .ok()
+                    .map(Duration::from_millis)
+                    .filter(|value| {
+                        *value >= Duration::from_millis(MIN_REQUEST_DEADLINE_MS)
+                            && *value <= Duration::from_millis(MAX_REQUEST_DEADLINE_MS)
+                    })
+                    .ok_or_else(|| invalid_request("Core request deadline is invalid"))
+            })
+            .transpose()?
+            .unwrap_or_else(|| default_deadline(class));
+        Ok(Self {
+            key: RequestKey {
+                connection_id: connection_id.to_owned(),
+                request_id,
+            },
+            class,
+            deadline: Instant::now() + deadline_duration,
+        })
+    }
+}
+
+async fn acquire(
+    semaphore: Arc<Semaphore>,
+    deadline: Instant,
+    cancellation: &QueryCancellation,
+) -> Result<OwnedSemaphorePermit, CoreError> {
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(cancelled());
+        }
+        if Instant::now() >= deadline {
+            return Err(deadline_exceeded());
+        }
+        match semaphore.clone().try_acquire_owned() {
+            Ok(permit) => return Ok(permit),
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(worker_failed("execution semaphore closed"));
+            }
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                tokio::time::sleep(CANCELLATION_POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+fn header<'a>(headers: &'a HeaderMap, name: &str) -> Result<Option<&'a str>, CoreError> {
+    headers
+        .get(name)
+        .map(|value| {
+            value
+                .to_str()
+                .map_err(|_| invalid_request("Core request header is invalid"))
+        })
+        .transpose()
+}
+
+fn invalid_request(message: &str) -> CoreError {
+    CoreError {
+        code: CoreErrorCode::InvalidInput,
+        message: message.to_owned(),
+        retryable: false,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+fn overloaded() -> CoreError {
+    CoreError {
+        code: CoreErrorCode::Overloaded,
+        message: "Core request admission capacity is exhausted".to_owned(),
+        retryable: true,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+fn deadline_exceeded() -> CoreError {
+    CoreError {
+        code: CoreErrorCode::DeadlineExceeded,
+        message: "Core request deadline was exceeded".to_owned(),
+        retryable: true,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+fn cancelled() -> CoreError {
+    CoreError {
+        code: CoreErrorCode::Cancelled,
+        message: "Core request was cancelled".to_owned(),
+        retryable: true,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+fn worker_failed(detail: &str) -> CoreError {
+    CoreError {
+        code: CoreErrorCode::CoreUnavailable,
+        message: format!("Core request worker failed: {detail}"),
+        retryable: true,
+        recovery: CoreErrorRecovery::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+
+    fn headers(request_id: &str, class: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(REQUEST_ID_HEADER, request_id.parse().unwrap());
+        headers.insert(REQUEST_CLASS_HEADER, class.parse().unwrap());
+        headers.insert(REQUEST_DEADLINE_HEADER, "2000".parse().unwrap());
+        headers
+    }
+
+    #[tokio::test]
+    async fn reserves_execution_capacity_for_interactive_work() {
+        let executor = RequestExecutor::with_capacities(2, 1, 1, 8);
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let (started_tx, started_rx) = mpsc::channel::<()>();
+        let background_executor = executor.clone();
+        let background = tokio::spawn(async move {
+            background_executor
+                .execute(
+                    "connection",
+                    &headers("background", "background"),
+                    RequestClass::Interactive,
+                    move || {
+                        started_tx.send(()).unwrap();
+                        release_rx.recv().unwrap();
+                        Ok(())
+                    },
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if started_rx.try_recv().is_ok() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let result = executor
+            .execute(
+                "connection",
+                &headers("interactive", "interactive"),
+                RequestClass::Interactive,
+                || Ok("ready"),
+            )
+            .await;
+
+        assert_eq!(result.unwrap(), "ready");
+        release_tx.send(()).unwrap();
+        background.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn explicit_cancellation_reaches_running_sqlite_context() {
+        let executor = RequestExecutor::with_capacities(1, 1, 1, 8);
+        let worker_executor = executor.clone();
+        let worker = tokio::spawn(async move {
+            worker_executor
+                .execute(
+                    "connection",
+                    &headers("cancel-me", "interactive"),
+                    RequestClass::Interactive,
+                    || {
+                        while !nodex_core::infrastructure::request_execution::request_is_cancelled()
+                        {
+                            std::thread::yield_now();
+                        }
+                        Err::<(), _>(cancelled())
+                    },
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(executor.cancel("connection", "cancel-me"));
+        assert_eq!(
+            worker.await.unwrap().unwrap_err().code,
+            CoreErrorCode::Cancelled
+        );
+    }
+}

--- a/crates/nodex-core-server/src/request_execution.rs
+++ b/crates/nodex-core-server/src/request_execution.rs
@@ -26,6 +26,8 @@ const BACKGROUND_EXECUTION_CAPACITY: usize = TOTAL_EXECUTION_CAPACITY - 1;
 const MAINTENANCE_EXECUTION_CAPACITY: usize = 1;
 const ADMISSION_CAPACITY: usize = 128;
 const CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const CANCELLATION_TOMBSTONE_TTL: Duration = Duration::from_secs(60);
+const MAX_CANCELLATION_TOMBSTONES: usize = 4_096;
 
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -53,16 +55,29 @@ struct RequestKey {
 }
 
 struct ActiveRequestGuard {
-    active: Arc<Mutex<HashMap<RequestKey, QueryCancellation>>>,
+    registry: Arc<Mutex<RequestRegistry>>,
     key: RequestKey,
 }
 
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
-        let Ok(mut active) = self.active.lock() else {
+        let Ok(mut registry) = self.registry.lock() else {
             return;
         };
-        active.remove(&self.key);
+        registry.active.remove(&self.key);
+    }
+}
+
+#[derive(Default)]
+struct RequestRegistry {
+    active: HashMap<RequestKey, QueryCancellation>,
+    cancellation_tombstones: HashMap<RequestKey, Instant>,
+}
+
+impl RequestRegistry {
+    fn prune_tombstones(&mut self, now: Instant) {
+        self.cancellation_tombstones
+            .retain(|_, expires_at| *expires_at > now);
     }
 }
 
@@ -79,7 +94,7 @@ pub(crate) struct RequestExecutor {
     background: Arc<Semaphore>,
     maintenance: Arc<Semaphore>,
     admission: Arc<Semaphore>,
-    active: Arc<Mutex<HashMap<RequestKey, QueryCancellation>>>,
+    registry: Arc<Mutex<RequestRegistry>>,
     metrics: Arc<RequestExecutorMetrics>,
     total_capacity: usize,
 }
@@ -124,7 +139,7 @@ impl RequestExecutor {
             background: Arc::new(Semaphore::new(background)),
             maintenance: Arc::new(Semaphore::new(maintenance)),
             admission: Arc::new(Semaphore::new(admission)),
-            active: Arc::new(Mutex::new(HashMap::new())),
+            registry: Arc::new(Mutex::new(RequestRegistry::default())),
             metrics: Arc::new(RequestExecutorMetrics::default()),
             total_capacity: total,
         }
@@ -143,6 +158,11 @@ impl RequestExecutor {
         let spec = RequestSpec::from_headers(connection_id, headers, default_class)?;
         let cancellation = QueryCancellation::new();
         let guard = self.register(&spec.key, &cancellation)?;
+        if cancellation.is_cancelled() {
+            let error = cancelled();
+            self.record_error(&error);
+            return Err(error);
+        }
         let admitted_at = Instant::now();
         let admission = self.admission.clone().try_acquire_owned().map_err(|_| {
             self.metrics.overloaded.fetch_add(1, Ordering::Relaxed);
@@ -158,6 +178,11 @@ impl RequestExecutor {
                 return Err(error);
             }
         };
+        if cancellation.is_cancelled() {
+            let error = cancelled();
+            self.record_error(&error);
+            return Err(error);
+        }
         self.metrics.admission_wait.record(admitted_at.elapsed());
         let context = RequestExecutionContext::new(cancellation.clone(), spec.deadline);
         let metrics = Arc::clone(&self.metrics);
@@ -212,13 +237,20 @@ impl RequestExecutor {
             connection_id: connection_id.to_owned(),
             request_id: request_id.to_owned(),
         };
-        let Ok(active) = self.active.lock() else {
+        let Ok(mut registry) = self.registry.lock() else {
             return false;
         };
-        let Some(cancellation) = active.get(&key) else {
+        registry.prune_tombstones(Instant::now());
+        if let Some(cancellation) = registry.active.get(&key) {
+            cancellation.cancel();
+            return true;
+        }
+        if registry.cancellation_tombstones.len() >= MAX_CANCELLATION_TOMBSTONES {
             return false;
-        };
-        cancellation.cancel();
+        }
+        registry
+            .cancellation_tombstones
+            .insert(key, Instant::now() + CANCELLATION_TOMBSTONE_TTL);
         true
     }
 
@@ -226,7 +258,10 @@ impl RequestExecutor {
         let active = self
             .total_capacity
             .saturating_sub(self.total.available_permits());
-        let registered = self.active.lock().map_or(0, |active| active.len());
+        let registered = self
+            .registry
+            .lock()
+            .map_or(0, |registry| registry.active.len());
         RequestExecutorSnapshot {
             active: u64::try_from(active).unwrap_or(u64::MAX),
             queued: u64::try_from(registered.saturating_sub(active)).unwrap_or(u64::MAX),
@@ -255,13 +290,21 @@ impl RequestExecutor {
         key: &RequestKey,
         cancellation: &QueryCancellation,
     ) -> Result<ActiveRequestGuard, CoreError> {
-        let mut active = self.active.lock().map_err(|_| worker_failed("registry"))?;
-        if active.contains_key(key) {
+        let mut registry = self
+            .registry
+            .lock()
+            .map_err(|_| worker_failed("registry"))?;
+        registry.prune_tombstones(Instant::now());
+        if registry.active.contains_key(key) {
             return Err(invalid_request("Core request ID is already active"));
         }
-        active.insert(key.clone(), cancellation.clone());
+        let cancelled_before_registration = registry.cancellation_tombstones.remove(key).is_some();
+        registry.active.insert(key.clone(), cancellation.clone());
+        if cancelled_before_registration {
+            cancellation.cancel();
+        }
         Ok(ActiveRequestGuard {
-            active: Arc::clone(&self.active),
+            registry: Arc::clone(&self.registry),
             key: key.clone(),
         })
     }
@@ -427,6 +470,7 @@ fn worker_failed(detail: &str) -> CoreError {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
 
     use super::*;
@@ -511,5 +555,28 @@ mod tests {
             worker.await.unwrap().unwrap_err().code,
             CoreErrorCode::Cancelled
         );
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_request_registration_is_honored() {
+        let executor = RequestExecutor::with_capacities(1, 1, 1, 8);
+        let operation_ran = Arc::new(AtomicBool::new(false));
+        let operation_ran_in_worker = Arc::clone(&operation_ran);
+        assert!(executor.cancel("connection", "cancel-before-register"));
+
+        let result = executor
+            .execute(
+                "connection",
+                &headers("cancel-before-register", "interactive"),
+                RequestClass::Interactive,
+                move || {
+                    operation_ran_in_worker.store(true, Ordering::Relaxed);
+                    Ok::<_, CoreError>(())
+                },
+            )
+            .await;
+
+        assert_eq!(result.unwrap_err().code, CoreErrorCode::Cancelled);
+        assert!(!operation_ran.load(Ordering::Relaxed));
     }
 }

--- a/crates/nodex-core/src/administration/mod.rs
+++ b/crates/nodex-core/src/administration/mod.rs
@@ -1503,10 +1503,12 @@ fn core_error(error: StoreError) -> CoreError {
         StoreErrorCode::StoreCorrupt => CoreErrorCode::StoreCorrupt,
         StoreErrorCode::MaintenanceInProgress => CoreErrorCode::MaintenanceInProgress,
         StoreErrorCode::ResourceExhausted => CoreErrorCode::ResourceExhausted,
-        StoreErrorCode::WriterQueueFull
-        | StoreErrorCode::WriterClosed
-        | StoreErrorCode::ReaderPoolTimeout
-        | StoreErrorCode::QueryCancelled
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::WriterClosed
         | StoreErrorCode::SqliteBusy
         | StoreErrorCode::SqliteFailure
         | StoreErrorCode::Internal => CoreErrorCode::CoreUnavailable,

--- a/crates/nodex-core/src/automation/mod.rs
+++ b/crates/nodex-core/src/automation/mod.rs
@@ -239,10 +239,12 @@ fn core_error(error: StoreError) -> CoreError {
         | StoreErrorCode::AlreadyOwned
         | StoreErrorCode::InvalidProfile
         | StoreErrorCode::RuntimeIncompatible => CoreErrorCode::SchemaUnsupported,
-        StoreErrorCode::WriterQueueFull
-        | StoreErrorCode::WriterClosed
-        | StoreErrorCode::ReaderPoolTimeout
-        | StoreErrorCode::QueryCancelled
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::WriterClosed
         | StoreErrorCode::SqliteBusy
         | StoreErrorCode::SqliteFailure
         | StoreErrorCode::Internal => CoreErrorCode::CoreUnavailable,

--- a/crates/nodex-core/src/database/mod.rs
+++ b/crates/nodex-core/src/database/mod.rs
@@ -231,10 +231,12 @@ fn core_error(error: StoreError) -> CoreError {
         StoreErrorCode::GenerationConflict => CoreErrorCode::GenerationConflict,
         StoreErrorCode::MissingDependencies => CoreErrorCode::DocumentUpdateMissingDependencies,
         StoreErrorCode::MaterializationStale => CoreErrorCode::MaterializationStale,
-        StoreErrorCode::WriterQueueFull
-        | StoreErrorCode::WriterClosed
-        | StoreErrorCode::ReaderPoolTimeout
-        | StoreErrorCode::QueryCancelled
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::WriterClosed
         | StoreErrorCode::SqliteBusy
         | StoreErrorCode::SqliteFailure
         | StoreErrorCode::Internal => CoreErrorCode::CoreUnavailable,

--- a/crates/nodex-core/src/document/canvas.rs
+++ b/crates/nodex-core/src/document/canvas.rs
@@ -16,6 +16,7 @@ use crate::infrastructure::document_repository::{
 };
 use crate::infrastructure::event_log::{NewChangeLogEntry, append_change_log};
 use crate::infrastructure::local_commit::CommitContext;
+use crate::infrastructure::request_execution::check_request_interruption;
 use crate::infrastructure::sqlite::{StoreError, StoreErrorCode};
 
 use super::canvas_scene::{
@@ -933,6 +934,7 @@ pub(crate) fn load_canvas_scene(
     connection: &Connection,
     authority: &DocumentAuthorityRow,
 ) -> Result<LoadedCanvasAuthority, StoreError> {
+    check_request_interruption()?;
     #[cfg(test)]
     FULL_SCENE_LOAD_COUNT.with(|count| count.set(count.get().saturating_add(1)));
     validate_canvas_authority(authority)?;
@@ -998,8 +1000,10 @@ pub(crate) fn load_canvas_scene(
         })?
         .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(|_| corrupt("Canvas element row has invalid column types"))?;
+    check_request_interruption()?;
     let mut elements = Vec::with_capacity(element_rows.len());
     for row in element_rows {
+        check_request_interruption()?;
         let value = serde_json::from_str::<Value>(&row.5)
             .map_err(|_| corrupt("Canvas element JSON is invalid"))?;
         let element = parse_stored_element(&value, &row.0, row.3.clone())?;
@@ -1040,8 +1044,10 @@ pub(crate) fn load_canvas_scene(
         })?
         .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(|_| corrupt("Canvas file row has invalid column types"))?;
+    check_request_interruption()?;
     let mut files = BTreeMap::new();
     for row in file_rows {
+        check_request_interruption()?;
         let value = serde_json::from_str::<Value>(&row.4)
             .map_err(|_| corrupt("Canvas file JSON is invalid"))?;
         let file = parse_stored_file(&value, &row.0)?;
@@ -1058,6 +1064,7 @@ pub(crate) fn load_canvas_scene(
     let app_state = serde_json::from_str::<Value>(&scene_row.4)
         .map_err(|_| corrupt("Canvas appState JSON is invalid"))?;
     let scene = materialize_loaded_scene(elements, &app_state, files)?;
+    check_request_interruption()?;
     let metadata = compute_canvas_scene_incremental_metadata(&scene)
         .map_err(|_| corrupt("Canvas incremental scene metadata is invalid"))?;
     let mismatches = [
@@ -1168,6 +1175,7 @@ pub(crate) fn load_v94_canvas_scene(
     connection: &Connection,
     authority: &DocumentAuthorityRow,
 ) -> Result<LoadedCanvasAuthority, StoreError> {
+    check_request_interruption()?;
     validate_canvas_authority(authority)?;
     let scene_row = connection
         .query_row(
@@ -1213,9 +1221,11 @@ pub(crate) fn load_v94_canvas_scene(
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
+    check_request_interruption()?;
     let mut elements = Vec::with_capacity(element_rows.len());
     let mut raw_element_jsons = Vec::with_capacity(element_rows.len());
     for row in element_rows {
+        check_request_interruption()?;
         let value = serde_json::from_str::<Value>(&row.5)
             .map_err(|_| corrupt("v94 Canvas element JSON is invalid"))?;
         let element = parse_stored_element(&value, &row.0, row.3.clone())?;
@@ -1251,9 +1261,11 @@ pub(crate) fn load_v94_canvas_scene(
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
+    check_request_interruption()?;
     let mut files = BTreeMap::new();
     let mut raw_file_jsons = BTreeMap::new();
     for row in file_rows {
+        check_request_interruption()?;
         let value = serde_json::from_str::<Value>(&row.4)
             .map_err(|_| corrupt("v94 Canvas file JSON is invalid"))?;
         let file = parse_stored_file(&value, &row.0)?;
@@ -1270,6 +1282,7 @@ pub(crate) fn load_v94_canvas_scene(
     let app_state = serde_json::from_str::<Value>(&scene_row.3)
         .map_err(|_| corrupt("v94 Canvas appState JSON is invalid"))?;
     let scene = materialize_loaded_scene(elements, &app_state, files)?;
+    check_request_interruption()?;
     let scene_hash = sha256(scene.fingerprint()?.as_bytes());
     let legacy_fingerprint = legacy_canvas_scene_fingerprint(
         &raw_element_jsons,

--- a/crates/nodex-core/src/document/module.rs
+++ b/crates/nodex-core/src/document/module.rs
@@ -5599,6 +5599,11 @@ fn core_error(error: StoreError) -> CoreError {
         StoreErrorCode::StoreCorrupt => CoreErrorCode::StoreCorrupt,
         StoreErrorCode::MaintenanceInProgress => CoreErrorCode::MaintenanceInProgress,
         StoreErrorCode::ResourceExhausted => CoreErrorCode::ResourceExhausted,
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
         _ => CoreErrorCode::CoreUnavailable,
     };
     CoreError {

--- a/crates/nodex-core/src/document/runtime.rs
+++ b/crates/nodex-core/src/document/runtime.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 
 use crate::infrastructure::document_repository::{DocumentHeadRow, DocumentReadRepository};
 use crate::infrastructure::metrics::{DurationMetric, DurationMetricSnapshot};
+use crate::infrastructure::request_execution::check_request_interruption;
 use crate::infrastructure::sqlite::{StoreError, StoreErrorCode};
 
 use super::{
@@ -95,6 +96,7 @@ impl DocumentRuntimeCache {
         connection: &Connection,
         head: &DocumentHeadRow,
     ) -> Result<DocumentWorkingCopy, StoreError> {
+        check_request_interruption()?;
         if let Some(entry) = self.entries.get(&head.id)
             && entry_matches(entry, head)
         {
@@ -103,12 +105,14 @@ impl DocumentRuntimeCache {
             self.touch(&head.id);
             let engine = YrsDocumentEngine::from_full_state_v1(&head.id, &full_state)
                 .map_err(|error| corrupt(format!("Cached Document clone failed: {error}")))?;
+            check_request_interruption()?;
             return Ok(DocumentWorkingCopy { engine, full_state });
         }
         self.remove(&head.id);
         self.misses += 1;
         let engine = reconstruct_yjs_engine(connection, head)?;
         let full_state = engine.full_state_v1();
+        check_request_interruption()?;
         let working = YrsDocumentEngine::from_full_state_v1(&head.id, &full_state)
             .map_err(|error| corrupt(format!("Reconstructed Document clone failed: {error}")))?;
         self.install_with_state(head, engine, full_state.clone());
@@ -124,6 +128,7 @@ impl DocumentRuntimeCache {
         head: &DocumentHeadRow,
         remote_state_vector: &[u8],
     ) -> Result<Vec<u8>, StoreError> {
+        check_request_interruption()?;
         if let Some(entry) = self.entries.get(&head.id)
             && entry_matches(entry, head)
         {
@@ -131,6 +136,7 @@ impl DocumentRuntimeCache {
                 .engine
                 .diff_v1(remote_state_vector)
                 .map_err(|error| invalid_input(format!("Invalid client state vector: {error}")))?;
+            check_request_interruption()?;
             self.hits += 1;
             self.touch(&head.id);
             return Ok(update);
@@ -138,9 +144,11 @@ impl DocumentRuntimeCache {
         self.remove(&head.id);
         self.misses += 1;
         let engine = reconstruct_yjs_engine(connection, head)?;
+        check_request_interruption()?;
         let update = engine
             .diff_v1(remote_state_vector)
             .map_err(|error| invalid_input(format!("Invalid client state vector: {error}")))?;
+        check_request_interruption()?;
         self.install(head, engine);
         Ok(update)
     }
@@ -237,6 +245,7 @@ pub(crate) fn reconstruct_retained_yjs_engine_at(
     head: &DocumentHeadRow,
     target_head_seq: i64,
 ) -> Result<Option<YrsDocumentEngine>, StoreError> {
+    check_request_interruption()?;
     if !head.is_live_yjs_authority() {
         return Err(corrupt(format!(
             "Document {} is not live Yjs authority",
@@ -283,6 +292,7 @@ pub(crate) fn reconstruct_retained_yjs_engine_at(
         repository.updates_between(&head.id, head.generation, snapshot_seq, target_head_seq)?;
     let mut expected_seq = snapshot_seq + 1;
     for update in updates {
+        check_request_interruption()?;
         if update.seq != expected_seq {
             return Ok(None);
         }
@@ -330,6 +340,7 @@ fn reconstruct_yjs_engine_inner(
     connection: &Connection,
     head: &DocumentHeadRow,
 ) -> Result<YrsDocumentEngine, StoreError> {
+    check_request_interruption()?;
     if !head.is_live_yjs_authority() {
         return Err(corrupt(format!(
             "Document {} is not live Yjs authority",
@@ -376,6 +387,7 @@ fn reconstruct_yjs_engine_inner(
         repository.updates_between(&head.id, head.generation, snapshot_seq, head.head_seq)?;
     let mut expected_seq = snapshot_seq + 1;
     for update in updates {
+        check_request_interruption()?;
         if update.seq != expected_seq || sha256(&update.update_blob) != update.update_hash {
             return Err(corrupt(format!(
                 "Document {} update tail is invalid at sequence {expected_seq}",
@@ -409,10 +421,12 @@ fn reconstruct_yjs_engine_inner(
             head.id
         )));
     }
+    check_request_interruption()?;
     let decoded = decode_block_document(engine.document(), schema)
         .map_err(|error| corrupt(format!("Document {} schema: {error}", head.id)))?;
     let actual = materialize_decoded_document(&decoded)
         .map_err(|error| corrupt(format!("Document {} materialization: {error}", head.id)))?;
+    check_request_interruption()?;
     let persisted = repository
         .materialization(&head.id)?
         .ok_or_else(|| corrupt(format!("Document {} has no materialization", head.id)))?;

--- a/crates/nodex-core/src/infrastructure/mod.rs
+++ b/crates/nodex-core/src/infrastructure/mod.rs
@@ -18,6 +18,7 @@ pub mod module_receipts;
 pub mod projection_impact;
 pub(crate) mod projection_requirement_extractor;
 pub(crate) mod projection_scope_head;
+pub mod request_execution;
 pub(crate) mod resource_authorization;
 pub(crate) mod resource_grant_migration;
 pub mod schema;

--- a/crates/nodex-core/src/infrastructure/request_execution.rs
+++ b/crates/nodex-core/src/infrastructure/request_execution.rs
@@ -53,6 +53,26 @@ pub fn request_is_cancelled() -> bool {
     })
 }
 
+/// Stops synchronous CPU work at the same cancellation/deadline boundary as
+/// SQLite work. Callers use this at bounded collection and transformation
+/// checkpoints so a cancelled request does not retain an execution permit
+/// until an entire reconstruction or transfer finishes.
+pub fn check_request_interruption() -> Result<(), super::sqlite::StoreError> {
+    CURRENT.with(|current| {
+        let current = current.borrow();
+        let Some(context) = current.last() else {
+            return Ok(());
+        };
+        if context.cancellation.is_cancelled() {
+            return Err(super::sqlite::query_interrupted(true));
+        }
+        if Instant::now() >= context.deadline {
+            return Err(super::sqlite::query_interrupted(false));
+        }
+        Ok(())
+    })
+}
+
 pub(crate) fn query_control(
     fallback_budget: Duration,
     cancellation: QueryCancellation,
@@ -116,6 +136,38 @@ mod tests {
                 let (deadline, _) =
                     query_control(Duration::from_secs(10), QueryCancellation::new());
                 assert_eq!(deadline, request_deadline);
+            },
+        );
+    }
+
+    #[test]
+    fn interruption_checkpoint_reports_request_cancellation_and_deadline() {
+        let cancellation = QueryCancellation::new();
+        within_request_execution(
+            RequestExecutionContext::new(
+                cancellation.clone(),
+                Instant::now() + Duration::from_secs(2),
+            ),
+            || {
+                cancellation.cancel();
+                assert_eq!(
+                    check_request_interruption()
+                        .expect_err("cancelled request passed an interruption checkpoint")
+                        .code,
+                    crate::infrastructure::sqlite::StoreErrorCode::QueryCancelled,
+                );
+            },
+        );
+
+        within_request_execution(
+            RequestExecutionContext::new(QueryCancellation::new(), Instant::now()),
+            || {
+                assert_eq!(
+                    check_request_interruption()
+                        .expect_err("expired request passed an interruption checkpoint")
+                        .code,
+                    crate::infrastructure::sqlite::StoreErrorCode::DeadlineExceeded,
+                );
             },
         );
     }

--- a/crates/nodex-core/src/infrastructure/request_execution.rs
+++ b/crates/nodex-core/src/infrastructure/request_execution.rs
@@ -1,0 +1,122 @@
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
+
+use super::sqlite::QueryCancellation;
+
+#[derive(Clone)]
+pub struct RequestExecutionContext {
+    cancellation: QueryCancellation,
+    deadline: Instant,
+}
+
+impl RequestExecutionContext {
+    pub fn new(cancellation: QueryCancellation, deadline: Instant) -> Self {
+        Self {
+            cancellation,
+            deadline,
+        }
+    }
+
+    pub fn cancellation(&self) -> QueryCancellation {
+        self.cancellation.clone()
+    }
+
+    pub fn deadline(&self) -> Instant {
+        self.deadline
+    }
+}
+
+thread_local! {
+    static CURRENT: RefCell<Vec<RequestExecutionContext>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Runs synchronous Core work inside the transport-owned execution context.
+/// Store readers and the writer inherit its absolute deadline and cancellation
+/// without exposing transport policy through semantic Module interfaces.
+pub fn within_request_execution<T>(
+    context: RequestExecutionContext,
+    operation: impl FnOnce() -> T,
+) -> T {
+    CURRENT.with(|current| current.borrow_mut().push(context));
+    let _guard = RequestExecutionGuard;
+    operation()
+}
+
+/// Reports whether the transport has cancelled the synchronous request that
+/// owns the current worker thread.
+pub fn request_is_cancelled() -> bool {
+    CURRENT.with(|current| {
+        current
+            .borrow()
+            .last()
+            .is_some_and(|context| context.cancellation.is_cancelled())
+    })
+}
+
+pub(crate) fn query_control(
+    fallback_budget: Duration,
+    cancellation: QueryCancellation,
+) -> (Instant, QueryCancellation) {
+    CURRENT.with(|current| {
+        let current = current.borrow();
+        let Some(context) = current.last() else {
+            return (Instant::now() + fallback_budget, cancellation);
+        };
+        (
+            // A transported Module request has exactly one semantic deadline.
+            // The fallback protects direct Store use, but must not become a
+            // hidden, shorter timeout inside the request-execution seam.
+            context.deadline,
+            cancellation.combined(&context.cancellation),
+        )
+    })
+}
+
+struct RequestExecutionGuard;
+
+impl Drop for RequestExecutionGuard {
+    fn drop(&mut self) {
+        CURRENT.with(|current| {
+            current.borrow_mut().pop();
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scopes_deadline_and_cancellation_without_leaking_to_later_work() {
+        let request_cancellation = QueryCancellation::new();
+        let explicit_cancellation = QueryCancellation::new();
+        let request_deadline = Instant::now() + Duration::from_secs(2);
+
+        within_request_execution(
+            RequestExecutionContext::new(request_cancellation.clone(), request_deadline),
+            || {
+                let (deadline, combined) =
+                    query_control(Duration::from_secs(10), explicit_cancellation.clone());
+                assert_eq!(deadline, request_deadline);
+                request_cancellation.cancel();
+                assert!(combined.is_cancelled());
+            },
+        );
+
+        let (_, independent) = query_control(Duration::from_secs(10), explicit_cancellation);
+        assert!(!independent.is_cancelled());
+    }
+
+    #[test]
+    fn transported_request_deadline_replaces_the_direct_store_fallback() {
+        let request_deadline = Instant::now() + Duration::from_secs(20);
+        within_request_execution(
+            RequestExecutionContext::new(QueryCancellation::new(), request_deadline),
+            || {
+                let (deadline, _) =
+                    query_control(Duration::from_secs(10), QueryCancellation::new());
+                assert_eq!(deadline, request_deadline);
+            },
+        );
+    }
+}

--- a/crates/nodex-core/src/infrastructure/sqlite.rs
+++ b/crates/nodex-core/src/infrastructure/sqlite.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use std::{os::unix::ffi::OsStrExt, path::Path};
@@ -16,6 +16,9 @@ pub const MAX_SQL_BYTES: i32 = 2 * 1024 * 1024;
 pub const MAX_VALUE_BYTES: i32 = 64 * 1024 * 1024;
 pub const MIN_SQLITE_VERSION: i32 = 3_045_000;
 const PROGRESS_HANDLER_OPS: i32 = 1_000;
+const QUERY_INTERRUPTION_NONE: u8 = 0;
+const QUERY_INTERRUPTION_CANCELLED: u8 = 1;
+const QUERY_INTERRUPTION_DEADLINE: u8 = 2;
 static TRANSACTION_DURATION: OnceLock<DurationMetric> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,6 +46,7 @@ pub enum StoreErrorCode {
     WriterClosed,
     ReaderPoolTimeout,
     QueryCancelled,
+    DeadlineExceeded,
     SqliteBusy,
     SqliteFailure,
     RuntimeIncompatible,
@@ -80,7 +84,7 @@ impl StoreError {
         if cancelled {
             return Self::new(
                 StoreErrorCode::QueryCancelled,
-                "SQLite work exceeded its budget or was cancelled",
+                "SQLite work was interrupted",
                 true,
             );
         }
@@ -103,22 +107,40 @@ impl From<rusqlite::Error> for StoreError {
 
 #[derive(Debug, Clone)]
 pub struct QueryCancellation {
-    cancelled: Arc<AtomicBool>,
+    cancelled: Vec<Arc<AtomicBool>>,
 }
 
 impl QueryCancellation {
     pub fn new() -> Self {
         Self {
-            cancelled: Arc::new(AtomicBool::new(false)),
+            cancelled: vec![Arc::new(AtomicBool::new(false))],
         }
     }
 
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
+        if let Some(cancelled) = self.cancelled.first() {
+            cancelled.store(true, Ordering::Release);
+        }
     }
 
-    fn flag(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.cancelled)
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled
+            .iter()
+            .any(|cancelled| cancelled.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn combined(&self, other: &Self) -> Self {
+        let mut cancelled = self.cancelled.clone();
+        for flag in &other.cancelled {
+            if cancelled
+                .iter()
+                .any(|candidate| Arc::ptr_eq(candidate, flag))
+            {
+                continue;
+            }
+            cancelled.push(Arc::clone(flag));
+        }
+        Self { cancelled }
     }
 }
 
@@ -235,21 +257,58 @@ pub fn apply_runtime_limits(connection: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// Gives every newly opened Store planner useful statistics, including Stores
+/// created before Nodex began maintaining SQLite's ANALYZE data.
+pub(crate) fn optimize_query_planner_on_open(connection: &Connection) -> Result<(), StoreError> {
+    connection.execute_batch("PRAGMA optimize=0x10002")?;
+    Ok(())
+}
+
+/// Lets SQLite refresh only statistics justified by this writer connection's
+/// observed workload. This is normally a no-op.
+pub(crate) fn optimize_query_planner_before_close(
+    connection: &Connection,
+) -> Result<(), StoreError> {
+    connection.execute_batch("PRAGMA optimize")?;
+    Ok(())
+}
+
 pub fn with_query_budget<T>(
     connection: &Connection,
     budget: Duration,
     cancellation: &QueryCancellation,
     operation: impl FnOnce(&Connection) -> Result<T, StoreError>,
 ) -> Result<T, StoreError> {
-    let deadline = Instant::now() + budget;
-    let cancelled = cancellation.flag();
+    with_query_deadline(connection, Instant::now() + budget, cancellation, operation)
+}
+
+pub fn with_query_deadline<T>(
+    connection: &Connection,
+    deadline: Instant,
+    cancellation: &QueryCancellation,
+    operation: impl FnOnce(&Connection) -> Result<T, StoreError>,
+) -> Result<T, StoreError> {
+    if let Some(error) = current_query_interruption(cancellation, deadline) {
+        return Err(error);
+    }
+    let cancellation = cancellation.clone();
+    let progress_cancellation = cancellation.clone();
+    let interruption = Arc::new(AtomicU8::new(QUERY_INTERRUPTION_NONE));
+    let progress_interruption = Arc::clone(&interruption);
     connection.progress_handler(
         PROGRESS_HANDLER_OPS,
-        Some(move || cancelled.load(Ordering::Acquire) || Instant::now() >= deadline),
+        Some(move || {
+            record_query_interruption(&progress_cancellation, deadline, &progress_interruption)
+        }),
     )?;
     let result = operation(connection);
     connection.progress_handler(0, None::<fn() -> bool>)?;
-    result
+    classify_query_interruption(
+        result,
+        &cancellation,
+        deadline,
+        interruption.load(Ordering::Acquire),
+    )
 }
 
 pub fn with_mut_query_budget<T>(
@@ -258,15 +317,106 @@ pub fn with_mut_query_budget<T>(
     cancellation: &QueryCancellation,
     operation: impl FnOnce(&mut Connection) -> Result<T, StoreError>,
 ) -> Result<T, StoreError> {
-    let deadline = Instant::now() + budget;
-    let cancelled = cancellation.flag();
+    with_mut_query_deadline(connection, Instant::now() + budget, cancellation, operation)
+}
+
+pub fn with_mut_query_deadline<T>(
+    connection: &mut Connection,
+    deadline: Instant,
+    cancellation: &QueryCancellation,
+    operation: impl FnOnce(&mut Connection) -> Result<T, StoreError>,
+) -> Result<T, StoreError> {
+    if let Some(error) = current_query_interruption(cancellation, deadline) {
+        return Err(error);
+    }
+    let cancellation = cancellation.clone();
+    let progress_cancellation = cancellation.clone();
+    let interruption = Arc::new(AtomicU8::new(QUERY_INTERRUPTION_NONE));
+    let progress_interruption = Arc::clone(&interruption);
     connection.progress_handler(
         PROGRESS_HANDLER_OPS,
-        Some(move || cancelled.load(Ordering::Acquire) || Instant::now() >= deadline),
+        Some(move || {
+            record_query_interruption(&progress_cancellation, deadline, &progress_interruption)
+        }),
     )?;
     let result = operation(connection);
     connection.progress_handler(0, None::<fn() -> bool>)?;
-    result
+    classify_query_interruption(
+        result,
+        &cancellation,
+        deadline,
+        interruption.load(Ordering::Acquire),
+    )
+}
+
+fn classify_query_interruption<T>(
+    result: Result<T, StoreError>,
+    cancellation: &QueryCancellation,
+    deadline: Instant,
+    recorded_interruption: u8,
+) -> Result<T, StoreError> {
+    match result {
+        Err(error) if error.code == StoreErrorCode::QueryCancelled => {
+            Err(recorded_query_interruption(recorded_interruption)
+                .or_else(|| current_query_interruption(cancellation, deadline))
+                .unwrap_or(error))
+        }
+        result => result,
+    }
+}
+
+fn record_query_interruption(
+    cancellation: &QueryCancellation,
+    deadline: Instant,
+    interruption: &AtomicU8,
+) -> bool {
+    let cause = if cancellation.is_cancelled() {
+        QUERY_INTERRUPTION_CANCELLED
+    } else if Instant::now() >= deadline {
+        QUERY_INTERRUPTION_DEADLINE
+    } else {
+        return false;
+    };
+    let _ = interruption.compare_exchange(
+        QUERY_INTERRUPTION_NONE,
+        cause,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    );
+    true
+}
+
+fn recorded_query_interruption(cause: u8) -> Option<StoreError> {
+    match cause {
+        QUERY_INTERRUPTION_CANCELLED => Some(query_interrupted(true)),
+        QUERY_INTERRUPTION_DEADLINE => Some(query_interrupted(false)),
+        _ => None,
+    }
+}
+
+fn current_query_interruption(
+    cancellation: &QueryCancellation,
+    deadline: Instant,
+) -> Option<StoreError> {
+    if cancellation.is_cancelled() {
+        return Some(query_interrupted(true));
+    }
+    (Instant::now() >= deadline).then(|| query_interrupted(false))
+}
+
+pub(crate) fn query_interrupted(cancelled: bool) -> StoreError {
+    if !cancelled {
+        return StoreError::new(
+            StoreErrorCode::DeadlineExceeded,
+            "SQLite work exceeded its request deadline",
+            true,
+        );
+    }
+    StoreError::new(
+        StoreErrorCode::QueryCancelled,
+        "SQLite work was cancelled",
+        true,
+    )
 }
 
 pub fn with_immediate_transaction<T>(
@@ -447,5 +597,69 @@ mod tests {
         )
         .expect("later query");
         assert!(observed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn progress_handler_preserves_deadline_and_cancellation_causes() {
+        let connection = Connection::open_in_memory().expect("memory database");
+        let long_query = |connection: &Connection| -> Result<(), StoreError> {
+            connection.query_row(
+                "WITH RECURSIVE values_cte(value) AS (\
+                   SELECT 1 UNION ALL SELECT value + 1 FROM values_cte WHERE value < 100000000\
+                 ) SELECT sum(value) FROM values_cte",
+                [],
+                |row| row.get::<_, i64>(0),
+            )?;
+            Ok(())
+        };
+
+        let deadline_error = with_query_budget(
+            &connection,
+            Duration::from_millis(1),
+            &QueryCancellation::new(),
+            long_query,
+        )
+        .expect_err("deadline query");
+        assert_eq!(deadline_error.code, StoreErrorCode::DeadlineExceeded);
+        assert_eq!(
+            deadline_error.message,
+            "SQLite work exceeded its request deadline"
+        );
+
+        let cancellation = QueryCancellation::new();
+        let cancellation_from_thread = cancellation.clone();
+        let cancel = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(1));
+            cancellation_from_thread.cancel();
+        });
+        let cancelled_error =
+            with_query_budget(&connection, DEFAULT_QUERY_BUDGET, &cancellation, long_query)
+                .expect_err("cancelled query");
+        cancel.join().expect("cancellation thread");
+        assert_eq!(cancelled_error.code, StoreErrorCode::QueryCancelled);
+        assert_eq!(cancelled_error.message, "SQLite work was cancelled");
+    }
+
+    #[test]
+    fn query_planner_optimization_creates_statistics_for_existing_indexes() {
+        let connection = Connection::open_in_memory().expect("memory database");
+        connection
+            .execute_batch(
+                "CREATE TABLE planner_values(id INTEGER PRIMARY KEY, value TEXT NOT NULL);\
+                 CREATE INDEX planner_values_by_value ON planner_values(value);\
+                 INSERT INTO planner_values(value) VALUES ('one'), ('two'), ('three');",
+            )
+            .expect("planner fixture");
+
+        optimize_query_planner_on_open(&connection).expect("planner optimization");
+
+        let statistic_count: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM sqlite_stat1 WHERE tbl = 'planner_values'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("planner statistics");
+        assert!(statistic_count > 0);
     }
 }

--- a/crates/nodex-core/src/infrastructure/store.rs
+++ b/crates/nodex-core/src/infrastructure/store.rs
@@ -11,7 +11,7 @@ use super::migration::{
 };
 #[cfg(test)]
 use super::schema::CURRENT_STORE_REVISION;
-use super::sqlite::{StoreError, StoreErrorCode, open_writer};
+use super::sqlite::{StoreError, StoreErrorCode, open_writer, optimize_query_planner_on_open};
 use super::store_lock::ProfileStoreLock;
 use super::store_replacement::recover_interrupted_store_replacement;
 use super::writer::{
@@ -40,6 +40,7 @@ impl SqliteStoreKernel {
         let database_path = profile_home.join(STORE_FILE_NAME);
         let mut connection = open_writer(&database_path)?;
         super::migration::prepare_test_current_store(&mut connection, profile_home)?;
+        optimize_query_planner_on_open(&connection)?;
         drop(connection);
         Self::start_runtime(
             database_path,
@@ -82,6 +83,7 @@ impl SqliteStoreKernel {
             )?,
         };
         validate_local_commit_index(&migration_connection)?;
+        optimize_query_planner_on_open(&migration_connection)?;
         drop(migration_connection);
 
         Self::start_runtime(database_path, preparation, lock)

--- a/crates/nodex-core/src/infrastructure/store.rs
+++ b/crates/nodex-core/src/infrastructure/store.rs
@@ -40,7 +40,12 @@ impl SqliteStoreKernel {
         let database_path = profile_home.join(STORE_FILE_NAME);
         let mut connection = open_writer(&database_path)?;
         super::migration::prepare_test_current_store(&mut connection, profile_home)?;
-        optimize_query_planner_on_open(&connection)?;
+        if let Err(error) = optimize_query_planner_on_open(&connection) {
+            tracing::warn!(
+                error = %error,
+                "SQLite query planner maintenance failed while opening the Store"
+            );
+        }
         drop(connection);
         Self::start_runtime(
             database_path,
@@ -83,7 +88,12 @@ impl SqliteStoreKernel {
             )?,
         };
         validate_local_commit_index(&migration_connection)?;
-        optimize_query_planner_on_open(&migration_connection)?;
+        if let Err(error) = optimize_query_planner_on_open(&migration_connection) {
+            tracing::warn!(
+                error = %error,
+                "SQLite query planner maintenance failed while opening the Store"
+            );
+        }
         drop(migration_connection);
 
         Self::start_runtime(database_path, preparation, lock)

--- a/crates/nodex-core/src/infrastructure/writer.rs
+++ b/crates/nodex-core/src/infrastructure/writer.rs
@@ -8,9 +8,11 @@ use std::time::{Duration, Instant};
 use rusqlite::Connection;
 
 use super::metrics::{DurationMetric, DurationMetricSnapshot};
+use super::request_execution::query_control;
 use super::sqlite::{
     DEFAULT_QUERY_BUDGET, QueryCancellation, StoreError, StoreErrorCode, open_reader, open_writer,
-    with_mut_query_budget, with_query_budget,
+    optimize_query_planner_before_close, query_interrupted, with_mut_query_deadline,
+    with_query_deadline,
 };
 
 pub const DEFAULT_WRITER_QUEUE_CAPACITY: usize = 64;
@@ -99,12 +101,18 @@ fn writer_loop(
     };
     while !shutdown.load(Ordering::Acquire) {
         let Ok(message) = receiver.recv() else {
-            return;
+            break;
         };
         match message {
             WriterMessage::Run(job) => job(&mut connection),
-            WriterMessage::Shutdown => return,
+            WriterMessage::Shutdown => break,
         }
+    }
+    if let Err(error) = optimize_query_planner_before_close(&connection) {
+        tracing::warn!(
+            error = %error,
+            "SQLite query planner maintenance failed during writer shutdown"
+        );
     }
 }
 
@@ -133,10 +141,17 @@ impl ReadPoolInner {
         }
     }
 
-    fn checkout(&self) -> Result<Connection, StoreError> {
-        let deadline = Instant::now() + READER_WAIT_TIMEOUT;
+    fn checkout(
+        &self,
+        request_deadline: Instant,
+        cancellation: &QueryCancellation,
+    ) -> Result<Connection, StoreError> {
+        let pool_deadline = (Instant::now() + READER_WAIT_TIMEOUT).min(request_deadline);
         let mut state = self.state.lock().map_err(|_| poisoned_pool())?;
         loop {
+            if cancellation.is_cancelled() || Instant::now() >= request_deadline {
+                return Err(query_interrupted(cancellation.is_cancelled()));
+            }
             if let Some(connection) = state.idle.pop() {
                 return Ok(connection);
             }
@@ -153,7 +168,7 @@ impl ReadPoolInner {
                     }
                 };
             }
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let remaining = pool_deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 return Err(StoreError::new(
                     StoreErrorCode::ReaderPoolTimeout,
@@ -161,12 +176,13 @@ impl ReadPoolInner {
                     true,
                 ));
             }
+            let poll = remaining.min(Duration::from_millis(50));
             let (next_state, wait) = self
                 .available
-                .wait_timeout(state, remaining)
+                .wait_timeout(state, poll)
                 .map_err(|_| poisoned_pool())?;
             state = next_state;
-            if wait.timed_out() && state.idle.is_empty() {
+            if wait.timed_out() && state.idle.is_empty() && Instant::now() >= pool_deadline {
                 return Err(StoreError::new(
                     StoreErrorCode::ReaderPoolTimeout,
                     "Timed out waiting for a SQLite read connection",
@@ -542,6 +558,7 @@ impl StoreWriter {
         cancellation: QueryCancellation,
         operation: impl FnOnce(&mut Connection) -> Result<T, StoreError> + Send + 'static,
     ) -> Result<T, StoreError> {
+        let (deadline, cancellation) = query_control(budget, cancellation);
         let (endpoint, _lease) = self.control.acquire_writer()?;
         let started_at = Instant::now();
         let writer_command_id = format!(
@@ -567,7 +584,8 @@ impl StoreWriter {
                 runtime_metrics.writer_queue_wait.record(queue_wait);
                 let queue_wait_ms = u64::try_from(queue_wait.as_millis()).unwrap_or(u64::MAX);
                 let operation_started_at = Instant::now();
-                let result = with_mut_query_budget(connection, budget, &cancellation, operation);
+                let result =
+                    with_mut_query_deadline(connection, deadline, &cancellation, operation);
                 let execution = operation_started_at.elapsed();
                 runtime_metrics.writer_execution.record(execution);
                 let duration_ms = u64::try_from(execution.as_millis()).unwrap_or(u64::MAX);
@@ -661,6 +679,7 @@ fn store_error_code_name(code: StoreErrorCode) -> &'static str {
         StoreErrorCode::WriterClosed => "writer_closed",
         StoreErrorCode::ReaderPoolTimeout => "reader_pool_timeout",
         StoreErrorCode::QueryCancelled => "query_cancelled",
+        StoreErrorCode::DeadlineExceeded => "deadline_exceeded",
         StoreErrorCode::SqliteBusy => "sqlite_busy",
         StoreErrorCode::SqliteFailure => "sqlite_failure",
         StoreErrorCode::RuntimeIncompatible => "runtime_incompatible",
@@ -705,9 +724,10 @@ impl StoreReaders {
         cancellation: &QueryCancellation,
         operation: impl FnOnce(&Connection) -> Result<T, StoreError>,
     ) -> Result<T, StoreError> {
+        let (deadline, cancellation) = query_control(budget, cancellation.clone());
         let (pool, _lease) = self.control.acquire_reader()?;
-        let connection = pool.checkout()?;
-        let result = with_query_budget(&connection, budget, cancellation, operation);
+        let connection = pool.checkout(deadline, &cancellation)?;
+        let result = with_query_deadline(&connection, deadline, &cancellation, operation);
         pool.checkin(connection);
         result
     }

--- a/crates/nodex-core/src/infrastructure/writer.rs
+++ b/crates/nodex-core/src/infrastructure/writer.rs
@@ -183,6 +183,9 @@ impl ReadPoolInner {
                 .map_err(|_| poisoned_pool())?;
             state = next_state;
             if wait.timed_out() && state.idle.is_empty() && Instant::now() >= pool_deadline {
+                if cancellation.is_cancelled() || Instant::now() >= request_deadline {
+                    return Err(query_interrupted(cancellation.is_cancelled()));
+                }
                 return Err(StoreError::new(
                     StoreErrorCode::ReaderPoolTimeout,
                     "Timed out waiting for a SQLite read connection",

--- a/crates/nodex-core/src/library/agent_search.rs
+++ b/crates/nodex-core/src/library/agent_search.rs
@@ -359,12 +359,14 @@ fn search_fts(
             parameters.extend(block_types.iter().cloned().map(SqlValue::Text));
         }
         parameters.push(SqlValue::Integer(MAX_FTS_HITS_PER_TERM as i64));
+        // Search candidates originate in FTS. CROSS JOIN preserves that loop
+        // order on statistics-free Stores and makes the rowid join O(matches).
         let sql = format!(
             "SELECT unit.owner_block_id, unit.block_id, source.type, unit.source_kind, \
                snippet(block_search_units_fts, 0, char(2), char(3), '…', 32), \
                bm25(block_search_units_fts) AS rank \
              FROM block_search_units_fts \
-             JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
+             CROSS JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
              JOIN documents document ON document.id = unit.document_id \
                AND document.library_id = unit.library_id \
              JOIN blocks source ON source.id = unit.block_id \

--- a/crates/nodex-core/src/library/block_transfer.rs
+++ b/crates/nodex-core/src/library/block_transfer.rs
@@ -57,6 +57,7 @@ use crate::infrastructure::durable_mutation::{
 use crate::infrastructure::local_commit;
 use crate::infrastructure::metrics::{DurationMetric, DurationMetricSnapshot};
 use crate::infrastructure::module_receipts::read_module_receipt;
+use crate::infrastructure::request_execution::check_request_interruption;
 use crate::infrastructure::sqlite::{StoreError, StoreErrorCode};
 
 use super::LibraryApplyOutcome;
@@ -451,6 +452,7 @@ pub(super) fn extract_agent_page_document_batch(
 ) -> Result<PreparedAgentPageDocumentBatch, StoreError> {
     let mut batch = PreparedAgentPageDocumentBatch::empty();
     for transfer in transfers {
+        check_request_interruption()?;
         let PreparedBlockTransfer::PageOwnership(prepared) = transfer else {
             return Err(corrupt(
                 "Agent Page movement requires Page ownership preparations",
@@ -490,6 +492,7 @@ pub(super) fn extract_agent_page_document_batch(
         }
     }
     for entry in batch.documents.values_mut() {
+        check_request_interruption()?;
         recompile_page_ownership_document_update(&mut entry.document, &entry.operations)?;
     }
     Ok(batch)
@@ -502,6 +505,7 @@ pub(super) fn prepare_agent_created_page_document_batch(
     destination: &LibraryPageCopyDestination,
     page_ids: &[String],
 ) -> Result<PreparedAgentPageDocumentBatch, StoreError> {
+    check_request_interruption()?;
     let LibraryPageCopyDestination::Page {
         page_id,
         expected_document_generation,
@@ -523,14 +527,15 @@ pub(super) fn prepare_agent_created_page_document_batch(
             true,
         ));
     }
-    let operations = page_ids
-        .iter()
-        .map(|page_id| DocumentBlockOperation::InsertBlock {
+    let mut operations = Vec::with_capacity(page_ids.len());
+    for page_id in page_ids {
+        check_request_interruption()?;
+        operations.push(DocumentBlockOperation::InsertBlock {
             block: embedded_page_shell(page_id),
             parent_block_id: None,
             before_block_id: before.as_ref().map(|anchor| anchor.block_id.clone()),
-        })
-        .collect::<Vec<_>>();
+        });
+    }
     let document = prepare_page_ownership_document_update(base, &operations)?;
     let mut batch = PreparedAgentPageDocumentBatch::empty();
     merge_agent_page_document(&mut batch, document, operations)?;
@@ -579,6 +584,7 @@ pub(super) fn apply_agent_page_document_batch(
     pre_detach_agent_page_moves(connection, &batch)?;
     let mut commits = Vec::with_capacity(batch.documents.len());
     for (index, entry) in batch.documents.into_values().enumerate() {
+        check_request_interruption()?;
         let placement_block_ids = aggregate_owned_placement_block_ids(&entry.operations);
         let structurally_detached_block_ids = deleted_operation_block_ids(&entry.operations);
         let update_id = format!(
@@ -746,6 +752,7 @@ pub(super) fn prepare_for_apply(
     store_epoch: &str,
     intent: &LibraryBlockTransferLogicalIntent,
 ) -> Result<PreparedBlockTransfer, StoreError> {
+    check_request_interruption()?;
     validate_id(operation_id, "operation_id")?;
     validate_intent(library_id, intent)?;
     let current_epoch = crate::document::read_store_epoch(connection)?;
@@ -1199,6 +1206,7 @@ fn prepare_transfer(
     intent: &LibraryBlockTransferLogicalIntent,
     cache: Option<&Arc<Mutex<crate::document::DocumentRuntimeCache>>>,
 ) -> Result<PreparedTransfer, StoreError> {
+    check_request_interruption()?;
     let project_id = bound_project_id(context)?;
     let source_page_id = match &intent.source {
         LibraryBlockTransferSource::Page { page_id } => Some(page_id.as_str()),
@@ -1241,12 +1249,15 @@ fn prepare_transfer(
         clone_runtime_engine(connection, &source_authority.head, cache)?;
     let (target_engine, target_full_state) =
         clone_runtime_engine(connection, &target_authority.head, cache)?;
+    check_request_interruption()?;
     let source_decoded = decode_block_document(source_engine.document(), source_schema)
         .map_err(|error| corrupt(error.to_string()))?;
+    check_request_interruption()?;
     let source_materialization = materialize_decoded_document(&source_decoded)
         .map_err(|error| corrupt(error.to_string()))?;
     let target_decoded = decode_block_document(target_engine.document(), target_schema)
         .map_err(|error| corrupt(error.to_string()))?;
+    check_request_interruption()?;
     let target_materialization = materialize_decoded_document(&target_decoded)
         .map_err(|error| corrupt(error.to_string()))?;
     let expected_location_revisions = validate_source_roots(
@@ -1325,6 +1336,7 @@ fn uses_page_ownership_parent_compiler(
         return Ok(true);
     }
     for block_id in &intent.root_block_ids {
+        check_request_interruption()?;
         let block_type = connection
             .query_row("SELECT type FROM blocks WHERE id = ?1", [block_id], |row| {
                 row.get::<_, String>(0)
@@ -1474,6 +1486,7 @@ fn prepare_page_ownership_transfer(
     agent_authority: Option<&AgentPageMoveTransferAuthority>,
     cache: Option<&Arc<Mutex<crate::document::DocumentRuntimeCache>>>,
 ) -> Result<PreparedPageOwnershipTransfer, StoreError> {
+    check_request_interruption()?;
     let requesting_project_id = bound_project_id(context)?;
     require_project_in_library(connection, requesting_project_id, library_id)?;
     let mut source_document_base = None;
@@ -1725,6 +1738,7 @@ fn prepare_page_ownership_transfer(
         } = &target
     {
         for root_page_id in &intent.root_block_ids {
+            check_request_interruption()?;
             let cycle = connection
                 .query_row(
                     "WITH RECURSIVE descendants(page_id) AS ( \
@@ -1748,6 +1762,7 @@ fn prepare_page_ownership_transfer(
 
     let mut roots = Vec::with_capacity(intent.root_block_ids.len());
     for page_id in &intent.root_block_ids {
+        check_request_interruption()?;
         let row = connection
             .query_row(
                 "SELECT block.library_id, block.type, block.lifecycle, \
@@ -1957,6 +1972,7 @@ fn prepare_page_ownership_transfer(
             });
         }
         for root in &roots {
+            check_request_interruption()?;
             copy_document_heads.extend(page_copy_closure_document_heads(
                 connection,
                 operation_id,
@@ -2158,6 +2174,7 @@ fn apply_page_ownership_transfer(
             )?);
         }
         for root in &prepared.roots {
+            check_request_interruption()?;
             let expected_membership_revision = root
                 .source_membership
                 .as_ref()
@@ -2557,6 +2574,7 @@ fn apply_page_ownership_copy(
         PageCopyParentDocumentMode::Commit
     };
     for root in &prepared.roots {
+        check_request_interruption()?;
         let execution = execute_page_copy(
             connection,
             context,
@@ -2716,6 +2734,7 @@ fn prepare_page_parent_transfer(
     intent: &LibraryBlockTransferLogicalIntent,
     cache: Option<&Arc<Mutex<crate::document::DocumentRuntimeCache>>>,
 ) -> Result<PreparedPageParentTransfer, StoreError> {
+    check_request_interruption()?;
     let prepare_started_at = Instant::now();
     let project_id = bound_project_id(context)?;
     require_project_in_library(connection, project_id, library_id)?;
@@ -2808,6 +2827,7 @@ fn prepare_page_parent_transfer(
     let mut new_block_ids = Vec::new();
     let transform_started_at = Instant::now();
     for source_root in &source_forest.roots {
+        check_request_interruption()?;
         let materialized = find_materialized_block(
             &source_materialization.block_tree,
             &source_root.root_block_id,
@@ -3460,6 +3480,7 @@ fn apply_page_parent_transfer(
             };
             let mut staged = Vec::with_capacity(prepared.roots.len());
             for root in &prepared.roots {
+                check_request_interruption()?;
                 let stage = stage_page_parent_root(
                     connection,
                     library_id,
@@ -3510,6 +3531,7 @@ fn apply_page_parent_transfer(
             let mut data_source_placements = Vec::new();
             let target_persistence_started_at = Instant::now();
             for stage in staged {
+                check_request_interruption()?;
                 let page_id = stage.page_id.clone();
                 let staged_revisions = StagedPagePlacementRevisions {
                     location_revision: stage.location_revision,

--- a/crates/nodex-core/src/library/content.rs
+++ b/crates/nodex-core/src/library/content.rs
@@ -243,6 +243,8 @@ pub(super) fn search(
         ),
     ]);
 
+    // Keep FTS as the outer loop even before an existing Store has planner
+    // statistics; otherwise SQLite may probe MATCH once per search unit.
     let sql = format!(
         "WITH ranked AS (\
            SELECT unit.library_id, unit.owner_block_id, unit.document_id, unit.block_id, \
@@ -251,7 +253,7 @@ pub(super) fn search(
              snippet(block_search_units_fts, 0, char(2), char(3), '…', 32) AS excerpt, \
              bm25(block_search_units_fts) AS rank, unit.rowid AS search_rowid \
            FROM block_search_units_fts \
-           JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
+           CROSS JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
            JOIN documents document ON document.id = unit.document_id \
              AND document.library_id = unit.library_id \
            JOIN blocks source ON source.id = unit.block_id \

--- a/crates/nodex-core/src/library/mod.rs
+++ b/crates/nodex-core/src/library/mod.rs
@@ -899,10 +899,12 @@ fn core_error(error: StoreError) -> CoreError {
         StoreErrorCode::MaintenanceInProgress => CoreErrorCode::MaintenanceInProgress,
         StoreErrorCode::ResourceExhausted => CoreErrorCode::ResourceExhausted,
         StoreErrorCode::Unauthorized => CoreErrorCode::Unauthorized,
-        StoreErrorCode::WriterQueueFull
-        | StoreErrorCode::WriterClosed
-        | StoreErrorCode::ReaderPoolTimeout
-        | StoreErrorCode::QueryCancelled
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::WriterClosed
         | StoreErrorCode::SqliteBusy
         | StoreErrorCode::SqliteFailure
         | StoreErrorCode::Internal => CoreErrorCode::CoreUnavailable,

--- a/crates/nodex-core/src/library/page_search.rs
+++ b/crates/nodex-core/src/library/page_search.rs
@@ -36,6 +36,22 @@ const MAX_PAGE_RESULTS: usize = 100;
 const MAX_FTS_HITS_PER_TERM: usize = 20_000;
 const MAX_FILTER_VALUES: usize = 64;
 const MAX_IDENTITY_BYTES: usize = 512;
+const MAX_EXCERPT_FRAGMENTS: usize = 3;
+const PAGE_BODY_SEARCH_SQL: &str = "SELECT unit.owner_block_id, unit.block_id, source.type, \
+            snippet(block_search_units_fts, 0, char(2), char(3), '…', 32), \
+            bm25(block_search_units_fts) AS rank \
+     FROM block_search_units_fts \
+     CROSS JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
+     JOIN documents document ON document.id = unit.document_id AND document.library_id = unit.library_id \
+     JOIN blocks source ON source.id = unit.block_id AND source.library_id = unit.library_id \
+     JOIN blocks owner ON owner.id = unit.owner_block_id AND owner.library_id = unit.library_id \
+     WHERE block_search_units_fts MATCH ?1 AND unit.library_id = ?2 \
+       AND unit.source_kind = 'document_block' AND unit.document_id IS NOT NULL \
+       AND document.readiness = 'ready' \
+       AND document.generation = unit.document_generation \
+       AND document.head_seq = unit.projected_seq \
+       AND source.lifecycle <> 'deleted' AND owner.lifecycle <> 'deleted' \
+     ORDER BY rank, unit.owner_block_id, unit.block_id LIMIT ?3";
 
 #[derive(Clone, Default)]
 pub(super) struct PageSearchIndexRegistry {
@@ -604,7 +620,7 @@ struct Aggregate {
     page_id: String,
     terms: HashSet<String>,
     evidence: Vec<Evidence>,
-    body_rank: f64,
+    body_ranks: HashMap<String, f64>,
 }
 
 struct SearchOutcome {
@@ -911,7 +927,7 @@ fn search_index(
                 page_id: page.id.clone(),
                 terms: HashSet::new(),
                 evidence: Vec::new(),
-                body_rank: 0.0,
+                body_ranks: HashMap::new(),
             })
             .collect());
     }
@@ -947,7 +963,7 @@ fn search_index(
                     edit_distance: evidence.edit_distance,
                     parts: evidence.parts.into_iter().map(core_text_part).collect(),
                 },
-                0.0,
+                None,
             );
         }
     }
@@ -973,7 +989,7 @@ fn search_index(
                 edit_distance: 0,
                 parts,
             },
-            0.0,
+            None,
         );
     }
     if is_explicit_page_key_search(query) {
@@ -995,7 +1011,7 @@ fn search_index(
                     edit_distance: 0,
                     parts: hit.parts,
                 },
-                hit.rank,
+                Some(hit.rank),
             );
         }
     }
@@ -1024,7 +1040,7 @@ fn add_evidence(
     aggregates: &mut HashMap<String, Aggregate>,
     page_id: &str,
     evidence: Evidence,
-    body_rank: f64,
+    body_rank: Option<f64>,
 ) {
     let aggregate = aggregates
         .entry(page_id.to_owned())
@@ -1032,10 +1048,16 @@ fn add_evidence(
             page_id: page_id.to_owned(),
             terms: HashSet::new(),
             evidence: Vec::new(),
-            body_rank,
+            body_ranks: HashMap::new(),
         });
     aggregate.terms.insert(evidence.term.clone());
-    aggregate.body_rank = aggregate.body_rank.min(body_rank);
+    if let Some(body_rank) = body_rank {
+        aggregate
+            .body_ranks
+            .entry(evidence.term.clone())
+            .and_modify(|rank| *rank = rank.min(body_rank))
+            .or_insert(body_rank);
+    }
     let duplicate = aggregate.evidence.iter().any(|existing| {
         existing.term == evidence.term
             && existing.matched_token == evidence.matched_token
@@ -1076,24 +1098,11 @@ fn search_body_term(
     } else {
         quote_fts_term(term)
     };
+    // FTS MATCH is the selective operation and must drive rowid lookups. A
+    // plain JOIN lets a statistics-free Store put `unit` in the outer loop,
+    // which re-evaluates the virtual table once for every search unit.
     let mut hits = connection
-        .prepare(
-            "SELECT unit.owner_block_id, unit.block_id, source.type, \
-                    snippet(block_search_units_fts, 0, char(2), char(3), '…', 32), \
-                    bm25(block_search_units_fts) AS rank \
-             FROM block_search_units_fts \
-             JOIN block_search_units unit ON unit.rowid = block_search_units_fts.rowid \
-             JOIN documents document ON document.id = unit.document_id AND document.library_id = unit.library_id \
-             JOIN blocks source ON source.id = unit.block_id AND source.library_id = unit.library_id \
-             JOIN blocks owner ON owner.id = unit.owner_block_id AND owner.library_id = unit.library_id \
-             WHERE block_search_units_fts MATCH ?1 AND unit.library_id = ?2 \
-               AND unit.source_kind = 'document_block' AND unit.document_id IS NOT NULL \
-               AND document.readiness = 'ready' \
-               AND document.generation = unit.document_generation \
-               AND document.head_seq = unit.projected_seq \
-               AND source.lifecycle <> 'deleted' AND owner.lifecycle <> 'deleted' \
-             ORDER BY rank, unit.owner_block_id, unit.block_id LIMIT ?3",
-        )?
+        .prepare(PAGE_BODY_SEARCH_SQL)?
         .query_map(
             params![match_query, library_id, (MAX_FTS_HITS_PER_TERM + 1) as i64],
             |row| {
@@ -1324,11 +1333,7 @@ fn compare_outcomes(
     aggregate_rank(&left.aggregate)
         .cmp(&aggregate_rank(&right.aggregate))
         .then_with(|| compare_context(left, right, preferred_project_id))
-        .then_with(|| {
-            left.aggregate
-                .body_rank
-                .total_cmp(&right.aggregate.body_rank)
-        })
+        .then_with(|| compare_body_ranks(&left.aggregate, &right.aggregate))
         .then_with(|| right_page.updated_at.cmp(&left_page.updated_at))
         .then_with(|| left_page.id.cmp(&right_page.id))
 }
@@ -1376,6 +1381,24 @@ fn aggregate_rank(aggregate: &Aggregate) -> (usize, usize, usize, usize, usize) 
         ranks.iter().map(|(_, edit_distance)| *edit_distance).sum(),
         usize::MAX - aggregate.evidence.len(),
     )
+}
+
+fn compare_body_ranks(left: &Aggregate, right: &Aggregate) -> Ordering {
+    let score = |aggregate: &Aggregate| {
+        let worst = aggregate
+            .body_ranks
+            .values()
+            .copied()
+            .max_by(f64::total_cmp)
+            .unwrap_or(0.0);
+        let total = aggregate.body_ranks.values().sum::<f64>();
+        (worst, total)
+    };
+    let left = score(left);
+    let right = score(right);
+    left.0
+        .total_cmp(&right.0)
+        .then_with(|| left.1.total_cmp(&right.1))
 }
 
 fn evidence_rank(evidence: &Evidence) -> usize {
@@ -1606,21 +1629,13 @@ fn excerpt_parts(
     page: &IndexedPage,
     evidence: &[Evidence],
 ) -> (Option<String>, Vec<LibraryPageSearchTextPart>) {
-    if let Some(body) = evidence
-        .iter()
-        .filter(|evidence| matches!(evidence.kind, EvidenceKind::Body { .. }))
-        .min_by_key(|evidence| evidence_rank(evidence))
-    {
-        let excerpt = join_parts(&body.parts);
-        return (Some(excerpt), body.parts.clone());
-    }
-    if let Some(property) = evidence
-        .iter()
-        .filter(|evidence| matches!(evidence.kind, EvidenceKind::Property { .. }))
-        .min_by_key(|evidence| evidence_rank(evidence))
-    {
-        let excerpt = join_parts(&property.parts);
-        return (Some(excerpt), property.parts.clone());
+    if let Some(parts) = compose_excerpt_parts(evidence, |kind| {
+        matches!(
+            kind,
+            EvidenceKind::Body { .. } | EvidenceKind::Property { .. }
+        )
+    }) {
+        return (Some(join_parts(&parts)), parts);
     }
     if evidence.iter().any(|evidence| {
         matches!(
@@ -1640,6 +1655,86 @@ fn excerpt_parts(
             highlighted: false,
         }],
     )
+}
+
+/// Builds one bounded preview that proves multiple query terms. Evidence for
+/// the same source excerpt is merged; terms from different excerpts are shown
+/// as separate fragments instead of silently dropping every term but one.
+fn compose_excerpt_parts(
+    evidence: &[Evidence],
+    accepts: impl Fn(&EvidenceKind) -> bool,
+) -> Option<Vec<LibraryPageSearchTextPart>> {
+    let mut seen_terms = HashSet::new();
+    let selected = evidence
+        .iter()
+        .filter(|candidate| accepts(&candidate.kind))
+        .filter(|candidate| seen_terms.insert(candidate.term.as_str()))
+        .take(MAX_EXCERPT_FRAGMENTS)
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        return None;
+    }
+
+    let mut fragments = Vec::<(String, Vec<LibraryPageSearchTextPart>)>::new();
+    for candidate in selected {
+        let text = join_parts(&candidate.parts);
+        if text.is_empty() {
+            continue;
+        }
+        if let Some((_, parts)) = fragments.iter_mut().find(|(existing, _)| existing == &text) {
+            *parts = merge_highlights(parts, &candidate.parts);
+            continue;
+        }
+        fragments.push((text, candidate.parts.clone()));
+    }
+    if fragments.is_empty() {
+        return None;
+    }
+
+    let mut combined = Vec::new();
+    for (_, parts) in fragments {
+        if !combined.is_empty() {
+            push_part(&mut combined, "  ·  ".to_owned(), false);
+        }
+        for part in parts {
+            push_part(&mut combined, part.text, part.highlighted);
+        }
+    }
+    Some(combined)
+}
+
+fn merge_highlights(
+    left: &[LibraryPageSearchTextPart],
+    right: &[LibraryPageSearchTextPart],
+) -> Vec<LibraryPageSearchTextPart> {
+    let characters = join_parts(left).chars().collect::<Vec<_>>();
+    let mut highlighted = vec![false; characters.len()];
+    for parts in [left, right] {
+        let mut offset = 0;
+        for part in parts {
+            let length = part.text.chars().count();
+            if part.highlighted {
+                highlighted[offset..offset + length].fill(true);
+            }
+            offset += length;
+        }
+    }
+    let mut merged = Vec::new();
+    let mut buffer = String::new();
+    let mut state = None;
+    for (character, is_highlighted) in characters.into_iter().zip(highlighted) {
+        if state.is_some_and(|current| current != is_highlighted) {
+            push_part(
+                &mut merged,
+                std::mem::take(&mut buffer),
+                state.unwrap_or(false),
+            );
+        }
+        buffer.push(character);
+        state = Some(is_highlighted);
+    }
+    push_part(&mut merged, buffer, state.unwrap_or(false));
+    merged
 }
 
 fn strongest_source(evidence: &[Evidence]) -> LibraryPageReferenceMatchSource {
@@ -1877,14 +1972,54 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
     use nodex_core_contracts::library::{
-        LibraryPageSearchTagMode, LibraryPageWorkflowStatus, LibraryProjectPageSearchFilters,
+        LibraryPageSearchMatch, LibraryPageSearchTagMode, LibraryPageWorkflowStatus,
+        LibraryProjectPageSearchFilters,
     };
     use nodex_page_search_kernel::MetadataSearchIndex;
+    use rusqlite::{Connection, params};
+    use tempfile::tempdir;
+
+    use crate::infrastructure::store::SqliteStoreKernel;
 
     use super::{
-        Aggregate, Evidence, EvidenceKind, IndexedPage, PageSearchIndex, ProjectSearchRequest,
-        SearchTermMatchQuality, aggregate_rank, highlight_text, rank_project_outcomes,
+        Aggregate, Evidence, EvidenceKind, IndexedPage, PAGE_BODY_SEARCH_SQL, PageSearchIndex,
+        ProjectSearchRequest, SearchTermMatchQuality, aggregate_rank, compare_body_ranks,
+        highlight_text, rank_project_outcomes, search_projects,
     };
+
+    #[test]
+    fn page_body_search_is_fts_driven_without_planner_statistics() {
+        let directory = tempdir().expect("Store directory");
+        let kernel = SqliteStoreKernel::open_test(directory.path()).expect("current Store");
+        let plan = kernel
+            .writer()
+            .call(|connection| {
+                connection.execute("DELETE FROM sqlite_stat1", [])?;
+                connection.execute_batch("ANALYZE sqlite_schema")?;
+                let mut statement =
+                    connection.prepare(&format!("EXPLAIN QUERY PLAN {PAGE_BODY_SEARCH_SQL}"))?;
+                let details = statement
+                    .query_map(params!["\"needle\"*", "library:test", 20_001_i64], |row| {
+                        row.get::<_, String>(3)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(details)
+            })
+            .expect("Page search query plan");
+        let fts_loop = plan
+            .iter()
+            .position(|detail| detail.contains("block_search_units_fts VIRTUAL TABLE"))
+            .expect("FTS loop");
+        let unit_loop = plan
+            .iter()
+            .position(|detail| detail.contains("unit USING INTEGER PRIMARY KEY"))
+            .expect("search-unit rowid loop");
+
+        assert!(
+            fts_loop < unit_loop,
+            "query plan was not FTS-driven: {plan:?}"
+        );
+    }
 
     #[test]
     fn highlight_parts_preserve_original_unicode_text() {
@@ -1904,6 +2039,165 @@ mod tests {
                     highlighted: false,
                 },
             ],
+        );
+    }
+
+    #[test]
+    fn project_search_keeps_multi_term_body_evidence_visible() {
+        let connection = Connection::open_in_memory().expect("search database");
+        connection
+            .execute_batch(
+                "CREATE TABLE documents(\
+                   id TEXT NOT NULL, library_id TEXT NOT NULL, readiness TEXT NOT NULL,\
+                   generation INTEGER NOT NULL, head_seq INTEGER NOT NULL\
+                 );\
+                 CREATE TABLE blocks(\
+                   id TEXT NOT NULL, library_id TEXT NOT NULL, type TEXT NOT NULL,\
+                   lifecycle TEXT NOT NULL\
+                 );\
+                 CREATE TABLE block_search_units(\
+                   rowid INTEGER PRIMARY KEY, library_id TEXT NOT NULL, block_id TEXT NOT NULL,\
+                   owner_block_id TEXT NOT NULL, document_id TEXT, document_generation INTEGER,\
+                   projected_seq INTEGER, source_kind TEXT NOT NULL, text TEXT NOT NULL\
+                 );\
+                 CREATE VIRTUAL TABLE block_search_units_fts USING fts5(\
+                   text, content='block_search_units', content_rowid='rowid'\
+                 );\
+                 INSERT INTO documents VALUES(\
+                   'document:multi-term', 'library:test', 'ready', 1, 1\
+                 ), (\
+                   'document:split-terms', 'library:test', 'ready', 1, 1\
+                 );\
+                 INSERT INTO blocks VALUES\
+                   ('page:multi-term', 'library:test', 'page', 'active'),\
+                   ('block:multi-term', 'library:test', 'paragraph', 'active'),\
+                   ('page:split-terms', 'library:test', 'page', 'active'),\
+                   ('block:codex', 'library:test', 'paragraph', 'active'),\
+                   ('block:electron', 'library:test', 'paragraph', 'active');\
+                 INSERT INTO block_search_units VALUES(\
+                   1, 'library:test', 'block:multi-term', 'page:multi-term',\
+                   'document:multi-term', 1, 1, 'document_block',\
+                   'Run codex with electron'\
+                 ), (\
+                   2, 'library:test', 'block:codex', 'page:split-terms',\
+                   'document:split-terms', 1, 1, 'document_block',\
+                   'Codex runtime details'\
+                 ), (\
+                   3, 'library:test', 'block:electron', 'page:split-terms',\
+                   'document:split-terms', 1, 1, 'document_block',\
+                   'Electron shell details'\
+                 );\
+                 INSERT INTO block_search_units_fts(rowid, text) VALUES\
+                   (1, 'Run codex with electron'),\
+                   (2, 'Codex runtime details'),\
+                   (3, 'Electron shell details');",
+            )
+            .expect("body search fixture");
+        let indexed_page = |page_id: &str| IndexedPage {
+            id: page_id.to_owned(),
+            title: "Search architecture".to_owned(),
+            preview: String::new(),
+            lifecycle: "active".to_owned(),
+            parent_kind: "library".to_owned(),
+            parent_id: "library:test".to_owned(),
+            updated_at: "2026-08-19T00:00:00.000Z".to_owned(),
+            properties: Vec::new(),
+            status: None,
+            priority: None,
+            tags: Vec::new(),
+            assignee: None,
+            page_key: None,
+            location_label: "Pages".to_owned(),
+            data_source_ids: BTreeSet::new(),
+            authorized_project_ids: BTreeSet::from(["project:test".to_owned()]),
+        };
+        let index = PageSearchIndex {
+            pages: BTreeMap::from([
+                (
+                    "page:multi-term".to_owned(),
+                    indexed_page("page:multi-term"),
+                ),
+                (
+                    "page:split-terms".to_owned(),
+                    indexed_page("page:split-terms"),
+                ),
+            ]),
+            data_source_databases: HashMap::new(),
+            metadata_index: MetadataSearchIndex::default(),
+        };
+        let project_ids = vec!["project:test".to_owned()];
+        let hits = search_projects(
+            &connection,
+            &index,
+            "library:test",
+            ProjectSearchRequest {
+                project_ids: &project_ids,
+                query: "codex electron",
+                filters: None,
+                preferred_project_id: None,
+                recent_page_ids: &[],
+                limit: Some(10),
+            },
+        )
+        .expect("Project Page search");
+        assert_eq!(hits.len(), 2);
+        let hit = hits
+            .iter()
+            .find(|hit| hit.page_id == "page:multi-term")
+            .expect("same-block multi-term hit");
+
+        let highlighted = hit
+            .excerpt_parts
+            .iter()
+            .filter(|part| part.highlighted)
+            .map(|part| part.text.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(hit.excerpt.as_deref(), Some("Run codex with electron"));
+        assert_eq!(highlighted, ["codex", "electron"]);
+        assert_eq!(
+            hit.matches
+                .iter()
+                .filter(|evidence| matches!(evidence, LibraryPageSearchMatch::Body { .. }))
+                .count(),
+            2
+        );
+
+        let split_hit = hits
+            .iter()
+            .find(|hit| hit.page_id == "page:split-terms")
+            .expect("cross-block multi-term hit");
+        let split_highlights = split_hit
+            .excerpt_parts
+            .iter()
+            .filter(|part| part.highlighted)
+            .map(|part| part.text.to_lowercase())
+            .collect::<Vec<_>>();
+        assert_eq!(split_highlights, ["codex", "electron"]);
+        assert!(
+            split_hit
+                .excerpt
+                .as_deref()
+                .is_some_and(|excerpt| excerpt.contains(" · "))
+        );
+    }
+
+    #[test]
+    fn weakest_body_term_contributes_to_multi_term_rank() {
+        let aggregate = |page_id: &str, codex: f64, electron: f64| Aggregate {
+            page_id: page_id.to_owned(),
+            terms: HashSet::from(["codex".to_owned(), "electron".to_owned()]),
+            evidence: Vec::new(),
+            body_ranks: HashMap::from([
+                ("codex".to_owned(), codex),
+                ("electron".to_owned(), electron),
+            ]),
+        };
+        let one_dominant_term = aggregate("page:dominant", -10.0, -1.0);
+        let balanced_terms = aggregate("page:balanced", -6.0, -6.0);
+
+        assert_eq!(
+            compare_body_ranks(&balanced_terms, &one_dominant_term),
+            std::cmp::Ordering::Less
         );
     }
 
@@ -1930,7 +2224,7 @@ mod tests {
                     SearchTermMatchQuality::Prefix,
                 ),
             ],
-            body_rank: -1.0,
+            body_ranks: HashMap::from([("canonical".to_owned(), -1.0)]),
         };
         let property_only = Aggregate {
             page_id: "page:property".to_owned(),
@@ -1942,7 +2236,7 @@ mod tests {
                 },
                 SearchTermMatchQuality::Exact,
             )],
-            body_rank: 0.0,
+            body_ranks: HashMap::new(),
         };
 
         assert!(aggregate_rank(&title_and_body) < aggregate_rank(&property_only));
@@ -1999,7 +2293,7 @@ mod tests {
                     edit_distance: 0,
                     parts: Vec::new(),
                 }],
-                body_rank: 0.0,
+                body_ranks: HashMap::new(),
             });
         }
         let index = PageSearchIndex {

--- a/crates/nodex-core/src/workspace/mod.rs
+++ b/crates/nodex-core/src/workspace/mod.rs
@@ -207,10 +207,12 @@ fn core_error(error: StoreError) -> CoreError {
         | StoreErrorCode::AlreadyOwned
         | StoreErrorCode::InvalidProfile
         | StoreErrorCode::RuntimeIncompatible => CoreErrorCode::SchemaUnsupported,
-        StoreErrorCode::WriterQueueFull
-        | StoreErrorCode::WriterClosed
-        | StoreErrorCode::ReaderPoolTimeout
-        | StoreErrorCode::QueryCancelled
+        StoreErrorCode::WriterQueueFull | StoreErrorCode::ReaderPoolTimeout => {
+            CoreErrorCode::Overloaded
+        }
+        StoreErrorCode::QueryCancelled => CoreErrorCode::Cancelled,
+        StoreErrorCode::DeadlineExceeded => CoreErrorCode::DeadlineExceeded,
+        StoreErrorCode::WriterClosed
         | StoreErrorCode::SqliteBusy
         | StoreErrorCode::SqliteFailure
         | StoreErrorCode::Internal => CoreErrorCode::CoreUnavailable,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,8 @@ Each public Module presents a versioned `read`/`apply` Interface in [`crates/nod
 
 [`crates/nodex-core-protocol`](crates/nodex-core-protocol) owns authenticated transport envelopes, compatibility negotiation, generated OpenAPI artifacts, event versions, and bounded codecs. [`crates/nodex-core-server`](crates/nodex-core-server) owns socket transport, connections, process lifecycle, stream admission, and health metrics. Transport code depends on semantic contracts; semantic Modules never depend on transport code.
 
+Core Server also owns one request-execution boundary for synchronous Module work. It admits bounded `interactive`, `background`, and `maintenance` classes, preserves capacity for interactive requests, runs admitted work outside async transport workers, and carries one absolute deadline and cancellation token through reader checkout, writer queueing, and SQLite execution. Electron supplies request identity and intent but does not decide when Core work has actually stopped. A semantic deadline, caller cancellation, admission overload, and authority/transport loss are distinct typed outcomes.
+
 Store formats and migration sequences are implementation/recovery contracts, not architecture prose. Their executable authority is under [`crates/nodex-core/src/infrastructure`](crates/nodex-core/src/infrastructure), [`crates/nodex-core/schema`](crates/nodex-core/schema), and the corresponding Core tests. Operational expectations belong in [Reliability](docs/RELIABILITY.md).
 
 ### Electron Main / Desktop Host
@@ -138,6 +140,8 @@ Store formats and migration sequences are implementation/recovery contracts, not
 Main is an Adapter, coordinator, and runtime host. It may bind Profile/Library/Project/Session identity, perform host preflight, and coordinate external effects around a Core command. It must not open SQLite, reconstruct a semantic transaction, infer authorization from renderer state, or provide a fallback data authority when Core is unavailable.
 
 Long-lived Core adapters target the process-lifetime authority supervisor, not one raw socket generation. A replacement Core generation is acceptable only when it proves the same Profile, Library, and Store epoch. Authority drift is an application relaunch boundary. The lifecycle decision is detailed in [ADR 0034](docs/adr/0034-core-generations-are-supervised-runtime-sessions.md).
+
+Main propagates renderer cancellation across IPC and the Core transport using the same request identity. Its transport timer is only a short liveness grace after Core's declared semantic deadline; it is not a competing execution deadline and cannot classify an ambiguous response loss as generation failure.
 
 ### Preload and renderer
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -64,6 +64,20 @@ schedulers, cursors, and logical subscriptions survive the physical generation.
 Repeated failures produce one app-wide unavailable state and a bounded circuit,
 not many feature-local retry loops.
 
+Core, rather than Electron, owns request admission and completion. Interactive
+work retains reserved execution capacity while background and maintenance work
+use bounded subordinate lanes. One absolute request deadline and cancellation
+token reach queued readers, the writer, and SQLite progress handlers. Deadline,
+explicit cancellation, overload, and transport loss remain distinct failures;
+Electron waits a short liveness grace beyond the semantic deadline before it
+may report a transport timeout. Stale interactive searches actively cancel
+their Core request as non-error control flow, and Store maintenance is
+single-flight across all lanes. SQLite planner statistics are maintained when
+the Store opens and after writer use; FTS-backed searches keep the virtual
+table as their driving loop even before an existing Store has statistics.
+Health evidence includes active and queued requests, admission and execution
+duration, and deadline/cancellation/overload counts.
+
 Store migrations always protect the recognized source, migrate a staged copy,
 validate semantic authority, and atomically publish the target. Exact accepted
 source/current version inventories are executable data owned by Core migration

--- a/docs/product-specs/command-palette-behavior.md
+++ b/docs/product-specs/command-palette-behavior.md
@@ -65,6 +65,7 @@ Page mode is opened by `Cmd/Ctrl+P`, the sidebar `Search` row, or the root-mode 
 - Empty query shows default Page suggestions.
 - Page mode keeps a trailing `Filter` button on the search-input row.
 - Query-fresh metadata rows appear in the input event. While Core body enrichment is pending, the final result slot is reserved for `Loading more Pages…`; `No matching pages.` appears only after the current query, filters, Project scope, and projection revision have settled with no matches.
+- Typing a newer query or closing the palette cancels obsolete body enrichment as normal control flow. Superseded work never produces a Main-process error or changes the current query to an unavailable state.
 - A failed enrichment keeps synchronous metadata rows and shows `Full Page search is unavailable`. It never falls back to an incomplete corpus assembled from mounted Boards.
 - Clicking `Filter` opens a transient popover with property filters for status, priority, tags, assignee, and project.
 - When any palette filters are active, the palette shows a compact summary row directly under the input, using the same compact pill language as the DB view toolbar.
@@ -155,8 +156,9 @@ They are intentionally compact and subdued so they explain why a result appeared
 ### Description preview
 If the query matched body or Property text, the result renders a contextual preview below the subtitle:
 
-- excerpt is selected by Core from the authoritative matched source
-- excerpt centers around an actual matched term
+- excerpt is selected by Core from authoritative matched sources
+- a multi-term query keeps up to three distinct matched fragments; spans from the same excerpt are merged so an earlier term cannot suppress later-term highlights
+- each excerpt fragment centers around an actual matched term
 - excerpt is trimmed with leading/trailing ellipses when taken from the middle of the source
 - preview is clamped to `3` lines
 - Core-provided matched spans are highlighted inline

--- a/docs/product-specs/nfm-editor-page-reference-behavior.md
+++ b/docs/product-specs/nfm-editor-page-reference-behavior.md
@@ -54,7 +54,7 @@ The expanded section replaces the utility row with its remaining candidates; oth
 
 Rows are title-only by default.
 A second line appears only when it explains a content match, disambiguates duplicate titles, reports an unavailable embed, or shows a Page key that the user explicitly queried.
-Search excerpts are bounded around the matching location and highlight matching text in titles, Page keys, and excerpts.
+Search excerpts are bounded around matched locations and highlight matching text in titles, Page keys, and excerpts. Multi-term content matches merge highlights from the same excerpt or compose up to three distinct fragments, so one term cannot hide the evidence for another.
 Page search uses the same Rust metadata kernel, normalized token, prefix, typo-tolerant title ranking, and indexed match evidence as the Command palette. The prewarmed Core-authorized metadata projection supplies query-fresh rows in the input event; complete Core search only enriches those rows or adds body-only matches.
 Core decides corpus visibility and authorization; the shared kernel decides metadata ordering, matched terms, and display-text highlights before the result bound. The renderer only groups semantic providers or adds presentation-only disambiguation.
 If complete Core search fails, the menu keeps its synchronous metadata rows and presents Page-search unavailability as a status item rather than an empty match set.

--- a/docs/reliability/core-lifecycle-and-store.md
+++ b/docs/reliability/core-lifecycle-and-store.md
@@ -27,6 +27,42 @@ Reads and writes with stable idempotency identity may retry once with their
 original input. Ephemeral Awareness triggers recovery but is never replayed.
 A request timeout alone is ambiguous and does not prove writer loss.
 
+## Request execution
+
+Every Core Module request has a connection-scoped request ID, an execution
+class, and one absolute Core-owned deadline. The production executor admits at
+most 128 requests, runs at most four synchronous Module operations at once,
+allows at most three background operations and one maintenance operation, and
+therefore always preserves one execution slot for interactive work. Default
+deadlines are 20 seconds for interactive work, 60 seconds for background work,
+and 120 seconds for maintenance; clients may declare a bounded deadline from
+250 milliseconds through five minutes.
+
+Admitted synchronous work runs on Tokio's blocking pool rather than the async
+HTTP workers. The request context follows the work into Store reader checkout,
+writer queueing, and SQLite progress handlers. Transported work uses that one
+request deadline throughout; the Store's defensive fallback budget applies
+only to direct calls outside a request context and never shadows the declared
+request lifetime. Caller cancellation is sent to `/core/v1/requests/cancel`
+with the same connection/request identity and interrupts SQLite cooperatively;
+Core attributes SQLite's generic interrupt outcome back to the originating
+deadline or cancellation token. A response may return before an uncooperative
+blocking closure exits, but its execution permits remain held until the closure
+actually stops.
+
+Core reports `deadline_exceeded`, `cancelled`, and `overloaded` as semantic
+Module errors. Electron's HTTP timer is the semantic deadline plus a five-second
+liveness grace. Crossing only that outer grace is a transport timeout and still
+does not prove Core generation loss or mutation failure. Interactive Page
+search releases cancel stale enrichment requests end to end. Scheduled Store
+maintenance is globally single-flight before it enters Core, then also uses the
+executor's maintenance lane.
+
+Core health reports active and queued requests, admission wait and execution
+duration, and cumulative deadline, cancellation, and overload counts. Store
+writer/reader/query metrics remain the next-level evidence for locating where
+admitted work spent its time.
+
 Repeated independently authenticated losses open a bounded local circuit. The
 renderer shows one app-wide unavailable state with explicit Retry and Restart
 rather than accumulating feature-local errors. Shutdown advances a lifecycle

--- a/docs/reliability/core-lifecycle-and-store.md
+++ b/docs/reliability/core-lifecycle-and-store.md
@@ -54,7 +54,7 @@ Core reports `deadline_exceeded`, `cancelled`, and `overloaded` as semantic
 Module errors. Electron's HTTP timer is the semantic deadline plus a five-second
 liveness grace. Crossing only that outer grace is a transport timeout and still
 does not prove Core generation loss or mutation failure. Interactive Page
-search releases cancel stale enrichment requests end to end. Scheduled Store
+search cancels stale enrichment requests end to end. Scheduled Store
 maintenance is globally single-flight before it enters Core, then also uses the
 executor's maintenance lane.
 

--- a/packages/core-protocol/openapi.json
+++ b/packages/core-protocol/openapi.json
@@ -132,25 +132,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }

--- a/packages/core-protocol/openapi.json
+++ b/packages/core-protocol/openapi.json
@@ -190,25 +190,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -248,25 +261,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -306,25 +332,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -364,25 +403,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -422,25 +474,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -480,25 +545,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -538,25 +616,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -596,25 +687,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -654,25 +758,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -712,25 +829,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -770,25 +900,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }
@@ -828,25 +971,38 @@
           {
             "name": "x-nodex-request-id",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {
             "name": "x-nodex-request-class",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/CoreRequestClass"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/CoreRequestClass"
+                }
+              ]
             }
           },
           {
             "name": "x-nodex-request-deadline-ms",
             "in": "header",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer",
+              "type": [
+                "integer",
+                "null"
+              ],
               "format": "int64",
               "minimum": 0
             }

--- a/packages/core-protocol/openapi.json
+++ b/packages/core-protocol/openapi.json
@@ -128,6 +128,34 @@
           "api"
         ],
         "operationId": "resolve_local_mutation",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -158,6 +186,34 @@
           "api"
         ],
         "operationId": "administration_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -188,6 +244,34 @@
           "api"
         ],
         "operationId": "administration_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -218,6 +302,34 @@
           "api"
         ],
         "operationId": "automation_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -248,6 +360,34 @@
           "api"
         ],
         "operationId": "automation_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -278,6 +418,34 @@
           "api"
         ],
         "operationId": "database_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -308,6 +476,34 @@
           "api"
         ],
         "operationId": "database_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -338,6 +534,34 @@
           "api"
         ],
         "operationId": "document_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -368,6 +592,34 @@
           "api"
         ],
         "operationId": "document_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -398,6 +650,34 @@
           "api"
         ],
         "operationId": "library_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -428,6 +708,34 @@
           "api"
         ],
         "operationId": "library_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -458,6 +766,34 @@
           "api"
         ],
         "operationId": "workspace_apply",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -488,6 +824,34 @@
           "api"
         ],
         "operationId": "workspace_read",
+        "parameters": [
+          {
+            "name": "x-nodex-request-id",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-nodex-request-class",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CoreRequestClass"
+            }
+          },
+          {
+            "name": "x-nodex-request-deadline-ms",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -505,6 +869,36 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProjectWorkspaceReadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/core/v1/requests/cancel": {
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "operationId": "cancel_request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CoreRequestCancelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoreRequestCancelResponse"
                 }
               }
             }
@@ -5426,6 +5820,9 @@
           "store_corrupt",
           "protocol_incompatible",
           "event_replay_unavailable",
+          "deadline_exceeded",
+          "cancelled",
+          "overloaded",
           "resource_exhausted",
           "core_unavailable"
         ]
@@ -5620,6 +6017,11 @@
             "format": "int64",
             "minimum": 0
           },
+          "active_requests": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
           "active_writer_commands": {
             "type": "integer",
             "format": "int64",
@@ -5719,6 +6121,32 @@
           "local_commit_publication_duration": {
             "$ref": "#/components/schemas/HealthDurationMetric"
           },
+          "queued_requests": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "request_admission_wait": {
+            "$ref": "#/components/schemas/HealthDurationMetric"
+          },
+          "request_cancelled": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "request_deadline_exceeded": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "request_execution_duration": {
+            "$ref": "#/components/schemas/HealthDurationMetric"
+          },
+          "request_overloaded": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
           "transaction_duration": {
             "$ref": "#/components/schemas/HealthDurationMetric"
           },
@@ -5781,6 +6209,36 @@
           }
         },
         "additionalProperties": false
+      },
+      "CoreRequestCancelRequest": {
+        "type": "object",
+        "required": [
+          "request_id"
+        ],
+        "properties": {
+          "request_id": {
+            "type": "string"
+          }
+        }
+      },
+      "CoreRequestCancelResponse": {
+        "type": "object",
+        "required": [
+          "cancelled"
+        ],
+        "properties": {
+          "cancelled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CoreRequestClass": {
+        "type": "string",
+        "enum": [
+          "interactive",
+          "background",
+          "maintenance"
+        ]
       },
       "CoreSelectionDisposition": {
         "type": "string",
@@ -5975,9 +6433,19 @@
           "ordinary_json_response_bytes",
           "event_frame_bytes",
           "document_json_request_bytes",
-          "document_response_bytes"
+          "document_response_bytes",
+          "request_deadline_min_ms",
+          "request_deadline_max_ms",
+          "interactive_request_deadline_ms",
+          "background_request_deadline_ms",
+          "maintenance_request_deadline_ms"
         ],
         "properties": {
+          "background_request_deadline_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
           "document_json_request_bytes": {
             "type": "integer",
             "format": "int64",
@@ -5993,12 +6461,32 @@
             "format": "int64",
             "minimum": 0
           },
+          "interactive_request_deadline_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "maintenance_request_deadline_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
           "ordinary_json_request_bytes": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
           "ordinary_json_response_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "request_deadline_max_ms": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "request_deadline_min_ms": {
             "type": "integer",
             "format": "int64",
             "minimum": 0

--- a/packages/core-protocol/src/compatibility.generated.ts
+++ b/packages/core-protocol/src/compatibility.generated.ts
@@ -2,8 +2,8 @@ import type { components } from "./generated";
 
 export const CORE_CLIENT_REQUIREMENTS = {
   "transport": {
-    "min": 10,
-    "max": 10
+    "min": 11,
+    "max": 11
   },
   "event_version": 8,
   "modules": [
@@ -46,5 +46,10 @@ export const CORE_TRANSPORT_BUDGETS = {
   "ordinary_json_response_bytes": 16777216,
   "event_frame_bytes": 2359296,
   "document_json_request_bytes": 67108864,
-  "document_response_bytes": 25165832
+  "document_response_bytes": 25165832,
+  "request_deadline_min_ms": 250,
+  "request_deadline_max_ms": 300000,
+  "interactive_request_deadline_ms": 20000,
+  "background_request_deadline_ms": 60000,
+  "maintenance_request_deadline_ms": 120000
 } as const satisfies components["schemas"]["CoreTransportBudgets"];

--- a/packages/core-protocol/src/generated.ts
+++ b/packages/core-protocol/src/generated.ts
@@ -7961,10 +7961,10 @@ export interface operations {
     readonly administration_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -7988,10 +7988,10 @@ export interface operations {
     readonly administration_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8015,10 +8015,10 @@ export interface operations {
     readonly automation_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8042,10 +8042,10 @@ export interface operations {
     readonly automation_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8069,10 +8069,10 @@ export interface operations {
     readonly database_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8096,10 +8096,10 @@ export interface operations {
     readonly database_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8123,10 +8123,10 @@ export interface operations {
     readonly document_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8150,10 +8150,10 @@ export interface operations {
     readonly document_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8177,10 +8177,10 @@ export interface operations {
     readonly library_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8204,10 +8204,10 @@ export interface operations {
     readonly library_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8231,10 +8231,10 @@ export interface operations {
     readonly workspace_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;
@@ -8258,10 +8258,10 @@ export interface operations {
     readonly workspace_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;

--- a/packages/core-protocol/src/generated.ts
+++ b/packages/core-protocol/src/generated.ts
@@ -276,6 +276,22 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/core/v1/requests/cancel": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post: operations["cancel_request"];
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1457,7 +1473,7 @@ export interface components {
             readonly retryable: boolean;
         };
         /** @enum {string} */
-        readonly CoreErrorCode: "invalid_input" | "unauthorized" | "not_found" | "ambiguous" | "conflict" | "stale_store_epoch" | "revision_conflict" | "generation_conflict" | "head_conflict" | "patch_not_found" | "patch_ambiguous" | "patch_overlap" | "idempotency_key_reused" | "protected_owner_deletion" | "document_update_missing_dependencies" | "invalid_document_schema" | "materialization_stale" | "maintenance_in_progress" | "schema_unsupported" | "store_corrupt" | "protocol_incompatible" | "event_replay_unavailable" | "resource_exhausted" | "core_unavailable";
+        readonly CoreErrorCode: "invalid_input" | "unauthorized" | "not_found" | "ambiguous" | "conflict" | "stale_store_epoch" | "revision_conflict" | "generation_conflict" | "head_conflict" | "patch_not_found" | "patch_ambiguous" | "patch_overlap" | "idempotency_key_reused" | "protected_owner_deletion" | "document_update_missing_dependencies" | "invalid_document_schema" | "materialization_stale" | "maintenance_in_progress" | "schema_unsupported" | "store_corrupt" | "protocol_incompatible" | "event_replay_unavailable" | "deadline_exceeded" | "cancelled" | "overloaded" | "resource_exhausted" | "core_unavailable";
         readonly CoreErrorRecovery: {
             /** @enum {string} */
             readonly kind: "none";
@@ -1504,6 +1520,8 @@ export interface components {
             /** Format: int64 */
             readonly active_read_commands: number;
             /** Format: int64 */
+            readonly active_requests?: number;
+            /** Format: int64 */
             readonly active_writer_commands: number;
             readonly backup_duration: components["schemas"]["HealthDurationMetric"];
             readonly block_transfer_apply_duration: components["schemas"]["HealthDurationMetric"];
@@ -1541,6 +1559,16 @@ export interface components {
             /** Format: int64 */
             readonly event_replay_lag_max: number;
             readonly local_commit_publication_duration: components["schemas"]["HealthDurationMetric"];
+            /** Format: int64 */
+            readonly queued_requests?: number;
+            readonly request_admission_wait?: components["schemas"]["HealthDurationMetric"];
+            /** Format: int64 */
+            readonly request_cancelled?: number;
+            /** Format: int64 */
+            readonly request_deadline_exceeded?: number;
+            readonly request_execution_duration?: components["schemas"]["HealthDurationMetric"];
+            /** Format: int64 */
+            readonly request_overloaded?: number;
             readonly transaction_duration: components["schemas"]["HealthDurationMetric"];
             /** Format: int64 */
             readonly wal_size_bytes: number;
@@ -1559,6 +1587,14 @@ export interface components {
             readonly launcher: components["schemas"]["LauncherKind"];
             readonly policy: components["schemas"]["CoreSelectionPolicy"];
         };
+        readonly CoreRequestCancelRequest: {
+            readonly request_id: string;
+        };
+        readonly CoreRequestCancelResponse: {
+            readonly cancelled: boolean;
+        };
+        /** @enum {string} */
+        readonly CoreRequestClass: "interactive" | "background" | "maintenance";
         /** @enum {string} */
         readonly CoreSelectionDisposition: "started" | "reused";
         /** @enum {string} */
@@ -1610,15 +1646,25 @@ export interface components {
         };
         readonly CoreTransportBudgets: {
             /** Format: int64 */
+            readonly background_request_deadline_ms: number;
+            /** Format: int64 */
             readonly document_json_request_bytes: number;
             /** Format: int64 */
             readonly document_response_bytes: number;
             /** Format: int64 */
             readonly event_frame_bytes: number;
             /** Format: int64 */
+            readonly interactive_request_deadline_ms: number;
+            /** Format: int64 */
+            readonly maintenance_request_deadline_ms: number;
+            /** Format: int64 */
             readonly ordinary_json_request_bytes: number;
             /** Format: int64 */
             readonly ordinary_json_response_bytes: number;
+            /** Format: int64 */
+            readonly request_deadline_max_ms: number;
+            /** Format: int64 */
+            readonly request_deadline_min_ms: number;
         };
         readonly DatabaseAgentDataSourceQuery: {
             readonly authorization: components["schemas"]["AgentExecutionAuthorization"];
@@ -7888,7 +7934,11 @@ export interface operations {
     readonly resolve_local_mutation: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -7911,7 +7961,11 @@ export interface operations {
     readonly administration_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -7934,7 +7988,11 @@ export interface operations {
     readonly administration_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -7957,7 +8015,11 @@ export interface operations {
     readonly automation_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -7980,7 +8042,11 @@ export interface operations {
     readonly automation_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8003,7 +8069,11 @@ export interface operations {
     readonly database_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8026,7 +8096,11 @@ export interface operations {
     readonly database_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8049,7 +8123,11 @@ export interface operations {
     readonly document_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8072,7 +8150,11 @@ export interface operations {
     readonly document_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8095,7 +8177,11 @@ export interface operations {
     readonly library_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8118,7 +8204,11 @@ export interface operations {
     readonly library_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8141,7 +8231,11 @@ export interface operations {
     readonly workspace_apply: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8164,7 +8258,11 @@ export interface operations {
     readonly workspace_read: {
         readonly parameters: {
             readonly query?: never;
-            readonly header?: never;
+            readonly header: {
+                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms": number;
+                readonly "x-nodex-request-id": string;
+            };
             readonly path?: never;
             readonly cookie?: never;
         };
@@ -8180,6 +8278,29 @@ export interface operations {
                 };
                 content: {
                     readonly "application/json": components["schemas"]["ProjectWorkspaceReadResponse"];
+                };
+            };
+        };
+    };
+    readonly cancel_request: {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly requestBody: {
+            readonly content: {
+                readonly "application/json": components["schemas"]["CoreRequestCancelRequest"];
+            };
+        };
+        readonly responses: {
+            readonly 200: {
+                headers: {
+                    readonly [name: string]: unknown;
+                };
+                content: {
+                    readonly "application/json": components["schemas"]["CoreRequestCancelResponse"];
                 };
             };
         };

--- a/packages/core-protocol/src/generated.ts
+++ b/packages/core-protocol/src/generated.ts
@@ -7934,10 +7934,10 @@ export interface operations {
     readonly resolve_local_mutation: {
         readonly parameters: {
             readonly query?: never;
-            readonly header: {
-                readonly "x-nodex-request-class": components["schemas"]["CoreRequestClass"];
-                readonly "x-nodex-request-deadline-ms": number;
-                readonly "x-nodex-request-id": string;
+            readonly header?: {
+                readonly "x-nodex-request-class"?: null | components["schemas"]["CoreRequestClass"];
+                readonly "x-nodex-request-deadline-ms"?: number | null;
+                readonly "x-nodex-request-id"?: string | null;
             };
             readonly path?: never;
             readonly cookie?: never;

--- a/scripts/audit-rust-core-boundaries.ts
+++ b/scripts/audit-rust-core-boundaries.ts
@@ -235,6 +235,7 @@ const expectedRoutes = new Set([
   "/core/v1/handshake",
   "/core/v1/health",
   "/core/v1/local-mutations/resolve",
+  "/core/v1/requests/cancel",
   ...["administration", "automation", "database", "document", "library", "workspace"]
     .flatMap((module) => ["apply", "read"].map((operation) =>
       `/core/v1/modules/${module}/${operation}`)),

--- a/src/main/core-client/core-client.ts
+++ b/src/main/core-client/core-client.ts
@@ -371,6 +371,7 @@ export class CoreClient implements CoreClientPort {
         "/core/v1/modules/administration/read",
         { contract_version: MODULE_CONTRACT_VERSIONS.storeAdministration, read },
         this.#moduleHeaders(),
+        { class: "background" },
       );
     if (response.status === "ok") return response.payload;
     throw new CoreModuleResponseError(response.payload);

--- a/src/main/core-client/core-client.ts
+++ b/src/main/core-client/core-client.ts
@@ -45,6 +45,7 @@ import type {
   CoreLocalMutationResolveRequest,
   CoreLocalMutationResolveResponse,
   CoreModuleError,
+  CoreRequestOptions,
   AutomationApplyInput,
   AutomationApplyResponse,
   AutomationApplyResult,
@@ -186,7 +187,7 @@ export class CoreClient implements CoreClientPort {
         },
       },
       {},
-      input.signal,
+      { signal: input.signal },
     );
     assertHandshake(runtime.descriptor, handshake);
     transport.configureEventContract({
@@ -228,12 +229,16 @@ export class CoreClient implements CoreClientPort {
     );
   }
 
-  async libraryRead(read: LibraryRead): Promise<LibraryReadSnapshot> {
+  async libraryRead(
+    read: LibraryRead,
+    options: CoreRequestOptions = {},
+  ): Promise<LibraryReadSnapshot> {
     const response = await this.#transport.requestJson<LibraryReadResponse>(
       "POST",
       "/core/v1/modules/library/read",
       { contract_version: MODULE_CONTRACT_VERSIONS.library, read },
       this.#moduleHeaders(),
+      options,
     );
     if (response.status === "ok") return response.payload;
     throw new CoreModuleResponseError(response.payload);
@@ -385,6 +390,7 @@ export class CoreClient implements CoreClientPort {
           intent: input.intent,
         },
         this.#moduleHeaders(),
+        { class: "maintenance" },
       );
     if (response.status === "ok") return response.payload;
     throw new CoreModuleResponseError(response.payload);

--- a/src/main/core-client/desktop-core-authority-supervisor.ts
+++ b/src/main/core-client/desktop-core-authority-supervisor.ts
@@ -17,6 +17,7 @@ import type {
   CoreEventSubscription,
   CoreDocumentEventSubscription,
   CoreProjectionEventSubscription,
+  CoreRequestOptions,
   CoreStreamCheckpoint,
   CoreHandshakeResponse,
   CoreLocalMutationResolveRequest,
@@ -449,8 +450,11 @@ class SupervisedCoreClient implements DesktopCoreClient {
     return this.#execute((client) => client.resolveLocalMutation(input));
   }
 
-  libraryRead(read: LibraryRead): Promise<LibraryReadSnapshot> {
-    return this.#execute((client) => client.libraryRead(read));
+  libraryRead(
+    read: LibraryRead,
+    options?: CoreRequestOptions,
+  ): Promise<LibraryReadSnapshot> {
+    return this.#execute((client) => client.libraryRead(read, options));
   }
 
   libraryApply(input: LibraryApplyInput): Promise<LibraryApplyResult> {

--- a/src/main/core-client/desktop-library-module-bridge.ts
+++ b/src/main/core-client/desktop-library-module-bridge.ts
@@ -77,7 +77,7 @@ export interface DesktopLibraryModuleBridge {
   listPageHistory(
     request: ListPageHistoryRequest,
   ): Promise<PageHistoryCommandResult>;
-  searchPages(input: PageSearchInput): Promise<PageSearchSnapshot>;
+  searchPages(input: PageSearchInput, signal?: AbortSignal): Promise<PageSearchSnapshot>;
   pageSearchMetadata(projectIds: string[], pageIds?: string[]): Promise<PageSearchMetadataSnapshot>;
   pageSearchFacets(projectIds: string[]): Promise<PageSearchFacets>;
   resolvePageTarget(
@@ -182,9 +182,9 @@ export function createDesktopLibraryModuleBridge(
       return await projectCoreAdapter(runtime, request.requestingProjectId)
         .listPageHistory(request);
     },
-    searchPages: async (searchInput) => {
+    searchPages: async (searchInput, signal) => {
       const runtime = await input.authority;
-      return await rootAdapter(runtime).searchPages(searchInput);
+      return await rootAdapter(runtime).searchPages(searchInput, signal);
     },
     pageSearchMetadata: async (projectIds, pageIds) => {
       const runtime = await input.authority;

--- a/src/main/core-client/library-module-adapter.ts
+++ b/src/main/core-client/library-module-adapter.ts
@@ -118,7 +118,7 @@ export interface CoreLibraryModuleAdapter {
   listPageHistory(
     request: ListPageHistoryRequest,
   ): Promise<PageHistoryCommandResult>;
-  searchPages(input: PageSearchInput): Promise<PageSearchSnapshot>;
+  searchPages(input: PageSearchInput, signal?: AbortSignal): Promise<PageSearchSnapshot>;
   pageSearchMetadata(
     projectIds: string[],
     pageIds?: string[],
@@ -1967,7 +1967,7 @@ export const createCoreLibraryModuleAdapter = (
         return { ok: false, error: pageHistoryError(error) };
       }
     },
-    searchPages: async (searchInput) => {
+    searchPages: async (searchInput, signal) => {
       const snapshot = await input.client.libraryRead({
         kind: "project_page_search",
         project_ids: searchInput.projectIds,
@@ -1989,7 +1989,7 @@ export const createCoreLibraryModuleAdapter = (
         preferred_project_id: searchInput.preferredProjectId ?? null,
         recent_page_ids: searchInput.recentPageIds ?? [],
         limit: searchInput.limit ?? null,
-      });
+      }, { signal });
       if (
         snapshot.store_epoch !== input.storeEpoch
         || snapshot.value.kind !== "project_page_search"

--- a/src/main/core-client/testing/fake-core-client.ts
+++ b/src/main/core-client/testing/fake-core-client.ts
@@ -305,7 +305,11 @@ export class FakeCoreClient implements CoreClientPort {
     return result;
   }
 
-  async libraryRead(read: LibraryRead): Promise<LibraryReadSnapshot> {
+  async libraryRead(
+    read: LibraryRead,
+    options?: import("../types").CoreRequestOptions,
+  ): Promise<LibraryReadSnapshot> {
+    void options;
     this.reads.push(read);
     const result = this.#readResults.shift();
     if (!result) throw new Error("Fake Core client has no queued Library read");

--- a/src/main/core-client/types.ts
+++ b/src/main/core-client/types.ts
@@ -233,11 +233,22 @@ export interface CoreProjectionEventSubscription extends CoreEventSubscription {
   readonly barrier: ProjectionLiveBarrier;
 }
 
+export type CoreRequestClass = components["schemas"]["CoreRequestClass"];
+
+export interface CoreRequestOptions {
+  readonly class?: CoreRequestClass;
+  readonly deadlineMs?: number;
+  readonly signal?: AbortSignal;
+}
+
 export interface CoreClientPort {
   resolveLocalMutation(
     input: CoreLocalMutationResolveRequest,
   ): Promise<CoreLocalMutationResolveResponse>;
-  libraryRead(read: LibraryRead): Promise<LibraryReadSnapshot>;
+  libraryRead(
+    read: LibraryRead,
+    options?: CoreRequestOptions,
+  ): Promise<LibraryReadSnapshot>;
   libraryApply(input: LibraryApplyInput): Promise<LibraryApplyResult>;
   filterProjectionImpactForProject(
     projectId: string,

--- a/src/main/core-client/uds-http.node.test.ts
+++ b/src/main/core-client/uds-http.node.test.ts
@@ -112,6 +112,46 @@ const servePendingResponse = async (): Promise<string> => {
   return socketPath;
 };
 
+const serveManagedRequest = async (): Promise<{
+  readonly socketPath: string;
+  readonly requestHeaders: Promise<import("node:http").IncomingHttpHeaders>;
+  readonly cancelledRequestId: Promise<string>;
+}> => {
+  const directory = mkdtempSync(path.join(tmpdir(), "nodex-core-uds-test-"));
+  directories.push(directory);
+  const socketPath = path.join(directory, "core.sock");
+  let resolveHeaders!: (headers: import("node:http").IncomingHttpHeaders) => void;
+  let resolveCancellation!: (requestId: string) => void;
+  const requestHeaders = new Promise<import("node:http").IncomingHttpHeaders>((resolve) => {
+    resolveHeaders = resolve;
+  });
+  const cancelledRequestId = new Promise<string>((resolve) => {
+    resolveCancellation = resolve;
+  });
+  const server = createServer((request, response) => {
+    if (request.url !== "/core/v1/requests/cancel") {
+      resolveHeaders(request.headers);
+      return;
+    }
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        readonly request_id: string;
+      };
+      resolveCancellation(body.request_id);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end('{"cancelled":true}');
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  return { socketPath, requestHeaders, cancelledRequestId };
+};
+
 const serveJsonResponse = async (
   serialized: string,
   mode: "content-length" | "chunked" = "content-length",
@@ -244,6 +284,30 @@ describe("UDS Core event replay boundaries", () => {
     expect(error).toBeInstanceOf(CoreTransportError);
     expect(error).toMatchObject({ kind: "timeout", phase: "response" });
     expect(isDefinitiveCoreGenerationLoss(error)).toBe(false);
+  });
+
+  test("sends execution metadata and propagates aborts to Core cancellation", async () => {
+    const managed = await serveManagedRequest();
+    const transport = new UdsHttpTransport(managed.socketPath, "test-capability");
+    const controller = new AbortController();
+    const pending = transport.requestJson(
+      "POST",
+      "/core/v1/modules/library/read",
+      { read: { kind: "metadata" } },
+      {
+        "x-nodex-connection-id": "connection-1",
+        "x-nodex-connection-binding": "binding-1",
+      },
+      { class: "interactive", deadlineMs: 12_345, signal: controller.signal },
+    );
+    const headers = await managed.requestHeaders;
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ code: "ABORT_ERR", kind: "aborted" });
+    expect(headers["x-nodex-request-class"]).toBe("interactive");
+    expect(headers["x-nodex-request-deadline-ms"]).toBe("12345");
+    expect(await managed.cancelledRequestId).toBe(headers["x-nodex-request-id"]);
   });
 
   test("bounds caller-specific response and timeout budgets", () => {

--- a/src/main/core-client/uds-http.ts
+++ b/src/main/core-client/uds-http.ts
@@ -1,4 +1,5 @@
 import { request as httpRequest, type IncomingMessage } from "node:http";
+import { randomUUID } from "node:crypto";
 import { CORE_TRANSPORT_BUDGETS } from "@nodex/core-protocol";
 
 import {
@@ -20,6 +21,8 @@ import type {
   CoreDocumentEventSubscription,
   CoreProjectionEventSubscription,
   CoreStreamCheckpoint,
+  CoreRequestClass,
+  CoreRequestOptions,
   DocumentLiveBarrier,
   DocumentLiveRepair,
   ProjectionLiveBarrier,
@@ -35,14 +38,55 @@ const MAX_DOCUMENT_JSON_REQUEST_BYTES =
 const MAX_DOCUMENT_RESPONSE_BYTES =
   CORE_TRANSPORT_BUDGETS.document_response_bytes;
 const MAX_EVENT_FRAME_BYTES = CORE_TRANSPORT_BUDGETS.event_frame_bytes;
-const REQUEST_TIMEOUT_MS = 5_000;
+const TRANSPORT_LIVENESS_TIMEOUT_MS = 5_000;
 const MAX_CONFIGURED_REQUEST_TIMEOUT_MS = 120_000;
 const DOCUMENT_ROUTE_PREFIX = "/core/v1/modules/document/";
+const MODULE_ROUTE_PREFIX = "/core/v1/modules/";
+const LOCAL_MUTATION_ROUTE = "/core/v1/local-mutations/resolve";
+const DEFAULT_REQUEST_DEADLINES_MS: Readonly<Record<CoreRequestClass, number>> = {
+  interactive: CORE_TRANSPORT_BUDGETS.interactive_request_deadline_ms,
+  background: CORE_TRANSPORT_BUDGETS.background_request_deadline_ms,
+  maintenance: CORE_TRANSPORT_BUDGETS.maintenance_request_deadline_ms,
+};
 
 export interface UdsHttpTransportOptions {
   readonly maximumJsonResponseBytes?: number;
   readonly requestTimeoutMs?: number;
 }
+
+interface RequestExecutionHeaders {
+  readonly requestId: string;
+  readonly class: CoreRequestClass;
+  readonly deadlineMs: number;
+}
+
+const requestExecution = (
+  requestPath: string,
+  options: CoreRequestOptions,
+): RequestExecutionHeaders | null => {
+  if (
+    !requestPath.startsWith(MODULE_ROUTE_PREFIX)
+    && requestPath !== LOCAL_MUTATION_ROUTE
+  ) {
+    return null;
+  }
+  const requestClass = options.class ?? "interactive";
+  const deadlineMs = boundedPositiveInteger(
+    options.deadlineMs ?? DEFAULT_REQUEST_DEADLINES_MS[requestClass],
+    CORE_TRANSPORT_BUDGETS.request_deadline_max_ms,
+    "Core request deadline",
+  );
+  if (deadlineMs < CORE_TRANSPORT_BUDGETS.request_deadline_min_ms) {
+    throw new Error(
+      `Core request deadline must be at least ${CORE_TRANSPORT_BUDGETS.request_deadline_min_ms}`,
+    );
+  }
+  return {
+    requestId: randomUUID(),
+    class: requestClass,
+    deadlineMs,
+  };
+};
 
 export type DocumentFrameResponse<Response> =
   | { readonly kind: "binary"; readonly bytes: Uint8Array }
@@ -183,7 +227,7 @@ interface ProjectionLiveStreamOptions {
 
 export class UdsHttpTransport {
   readonly #maximumJsonResponseBytes: number;
-  readonly #requestTimeoutMs: number;
+  readonly #transportLivenessTimeoutMs: number;
   #eventContract: CoreEventContract | null = null;
 
   constructor(
@@ -196,8 +240,8 @@ export class UdsHttpTransport {
       MAX_JSON_RESPONSE_BYTES,
       "Core JSON response limit",
     );
-    this.#requestTimeoutMs = boundedPositiveInteger(
-      options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+    this.#transportLivenessTimeoutMs = boundedPositiveInteger(
+      options.requestTimeoutMs ?? TRANSPORT_LIVENESS_TIMEOUT_MS,
       MAX_CONFIGURED_REQUEST_TIMEOUT_MS,
       "Core request timeout",
     );
@@ -224,7 +268,7 @@ export class UdsHttpTransport {
     requestPath: string,
     body?: unknown,
     requestHeaders: Readonly<Record<string, string>> = {},
-    signal?: AbortSignal,
+    options: CoreRequestOptions = {},
   ): Promise<Response> {
     const documentRoute = requestPath.startsWith(DOCUMENT_ROUTE_PREFIX);
     const maximumRequestBytes = documentRoute
@@ -236,13 +280,22 @@ export class UdsHttpTransport {
     const encodedBody = body === undefined
       ? undefined
       : encodeBoundedJson(body, maximumRequestBytes, "Core request");
+    const execution = requestExecution(requestPath, options);
+    const transportTimeoutMs = execution
+      ? execution.deadlineMs + this.#transportLivenessTimeoutMs
+      : this.#transportLivenessTimeoutMs;
 
     return new Promise<Response>((resolve, reject) => {
       let settled = false;
       const settle = (action: () => void): void => {
         if (settled) return;
         settled = true;
+        options.signal?.removeEventListener("abort", cancelCoreRequest);
         action();
+      };
+      const cancelCoreRequest = (): void => {
+        if (!execution) return;
+        void this.#cancelRequest(execution.requestId, requestHeaders);
       };
       const request = httpRequest(
         {
@@ -250,9 +303,16 @@ export class UdsHttpTransport {
           path: requestPath,
           method,
           agent: false,
-          signal,
+          signal: options.signal,
           headers: {
             ...requestHeaders,
+            ...(execution
+              ? {
+                  "x-nodex-request-id": execution.requestId,
+                  "x-nodex-request-class": execution.class,
+                  "x-nodex-request-deadline-ms": String(execution.deadlineMs),
+                }
+              : {}),
             accept: "application/json",
             authorization: `Bearer ${this.authCapability}`,
             ...(encodedBody
@@ -283,7 +343,13 @@ export class UdsHttpTransport {
             );
         },
       );
-      request.setTimeout(this.#requestTimeoutMs, () => {
+      if (options.signal?.aborted) {
+        cancelCoreRequest();
+      } else {
+        options.signal?.addEventListener("abort", cancelCoreRequest, { once: true });
+      }
+      request.setTimeout(transportTimeoutMs, () => {
+        cancelCoreRequest();
         request.destroy(new CoreTransportError("timeout", "response", "ETIMEDOUT", null));
       });
       request.on("error", (error) =>
@@ -299,13 +365,24 @@ export class UdsHttpTransport {
     body: Uint8Array,
     requestHeaders: Readonly<Record<string, string>>,
     maximumResponseBytes: number,
+    options: CoreRequestOptions = {},
   ): Promise<DocumentFrameResponse<Response>> {
+    const execution = requestExecution(requestPath, options);
+    if (!execution) {
+      return Promise.reject(new Error("Document requests require Core execution metadata"));
+    }
+    const transportTimeoutMs = execution.deadlineMs + this.#transportLivenessTimeoutMs;
     return new Promise((resolve, reject) => {
       let settled = false;
       const settle = (action: () => void): void => {
         if (settled) return;
         settled = true;
+        options.signal?.removeEventListener("abort", cancelCoreRequest);
         action();
+      };
+      const cancelCoreRequest = (): void => {
+        if (!execution) return;
+        void this.#cancelRequest(execution.requestId, requestHeaders);
       };
       const request = httpRequest(
         {
@@ -313,8 +390,12 @@ export class UdsHttpTransport {
           path: requestPath,
           method: "POST",
           agent: false,
+          signal: options.signal,
           headers: {
             ...requestHeaders,
+            "x-nodex-request-id": execution.requestId,
+            "x-nodex-request-class": execution.class,
+            "x-nodex-request-deadline-ms": String(execution.deadlineMs),
             accept: `${DOCUMENT_HTTP_CONTENT_TYPE}, application/json`,
             authorization: `Bearer ${this.authCapability}`,
             "content-length": body.byteLength,
@@ -355,7 +436,13 @@ export class UdsHttpTransport {
             );
         },
       );
-      request.setTimeout(this.#requestTimeoutMs, () => {
+      if (options.signal?.aborted) {
+        cancelCoreRequest();
+      } else {
+        options.signal?.addEventListener("abort", cancelCoreRequest, { once: true });
+      }
+      request.setTimeout(transportTimeoutMs, () => {
+        cancelCoreRequest();
         request.destroy(new CoreTransportError("timeout", "response", "ETIMEDOUT", null));
       });
       request.on("error", (error) =>
@@ -364,6 +451,18 @@ export class UdsHttpTransport {
       request.write(body);
       request.end();
     });
+  }
+
+  #cancelRequest(
+    requestId: string,
+    requestHeaders: Readonly<Record<string, string>>,
+  ): Promise<unknown> {
+    return this.requestJson(
+      "POST",
+      "/core/v1/requests/cancel",
+      { request_id: requestId },
+      requestHeaders,
+    ).catch(() => undefined);
   }
 
   openEventStream(
@@ -574,7 +673,7 @@ export class UdsHttpTransport {
         }
         if (!closed) rejectDone?.(normalizeTransportError(error, "response"));
       });
-      request.setTimeout(this.#requestTimeoutMs, () => {
+      request.setTimeout(this.#transportLivenessTimeoutMs, () => {
         request.destroy(new CoreTransportError("timeout", "open", "ETIMEDOUT", null));
       });
       request.end();

--- a/src/main/core-result-ipc.node.test.ts
+++ b/src/main/core-result-ipc.node.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vitest";
 
 import { CoreModuleResponseError } from "./core-client/core-client";
-import { coreResultFrom } from "./core-result-ipc";
+import { cancellableCoreResultFrom, coreResultFrom } from "./core-result-ipc";
+import { CoreTransportError } from "./core-client/uds-http";
 
 describe("Core IPC result envelope", () => {
   test("preserves an ordinary conflict without relabeling it as stale state", async () => {
@@ -23,5 +24,24 @@ describe("Core IPC result envelope", () => {
         recovery: { kind: "none" },
       },
     });
+  });
+
+  test("returns caller cancellation as control flow instead of a rejected IPC handler", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(cancellableCoreResultFrom(controller.signal, async () => {
+      throw new CoreTransportError("aborted", "connect", "ABORT_ERR", null);
+    })).resolves.toEqual({ status: "cancelled" });
+  });
+
+  test("does not hide unrelated failures after a caller abort", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const failure = new Error("search adapter invariant failed");
+
+    await expect(cancellableCoreResultFrom(controller.signal, async () => {
+      throw failure;
+    })).rejects.toBe(failure);
   });
 });

--- a/src/main/core-result-ipc.node.test.ts
+++ b/src/main/core-result-ipc.node.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import { CoreModuleResponseError } from "./core-client/core-client";
 import { cancellableCoreResultFrom, coreResultFrom } from "./core-result-ipc";
-import { CoreTransportError } from "./core-client/uds-http";
+import { CoreHttpError, CoreTransportError } from "./core-client/uds-http";
 
 describe("Core IPC result envelope", () => {
   test("preserves an ordinary conflict without relabeling it as stale state", async () => {
@@ -32,6 +32,15 @@ describe("Core IPC result envelope", () => {
 
     await expect(cancellableCoreResultFrom(controller.signal, async () => {
       throw new CoreTransportError("aborted", "connect", "ABORT_ERR", null);
+    })).resolves.toEqual({ status: "cancelled" });
+  });
+
+  test("treats Core HTTP 499 as the cancellation response", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(cancellableCoreResultFrom(controller.signal, async () => {
+      throw new CoreHttpError(499, "Core request was cancelled");
     })).resolves.toEqual({ status: "cancelled" });
   });
 

--- a/src/main/core-result-ipc.ts
+++ b/src/main/core-result-ipc.ts
@@ -1,5 +1,10 @@
 import type { CoreResult } from "../shared/core-result";
 import { CoreModuleResponseError } from "./core-client/core-client";
+import { CoreTransportError } from "./core-client/uds-http";
+
+export type CancellableCoreResult<T> =
+  | { readonly status: "completed"; readonly value: T }
+  | { readonly status: "cancelled" };
 
 /**
  * Converts a Core call into the IPC-safe result envelope. Non-Core failures
@@ -22,4 +27,37 @@ export async function coreResultFrom<T>(
       },
     };
   }
+}
+
+/**
+ * Turns caller-requested Core cancellation into an IPC value. Electron treats
+ * rejected invoke handlers as errors, while query supersession is routine
+ * control flow and should remain quiet in Main diagnostics.
+ */
+export async function cancellableCoreResultFrom<T>(
+  signal: AbortSignal,
+  operation: () => Promise<T>,
+): Promise<CancellableCoreResult<T>> {
+  try {
+    const value = await operation();
+    if (signal.aborted) return { status: "cancelled" };
+    return { status: "completed", value };
+  } catch (error) {
+    if (signal.aborted && isCoreCancellation(error)) {
+      return { status: "cancelled" };
+    }
+    throw error;
+  }
+}
+
+function isCoreCancellation(error: unknown): boolean {
+  if (error instanceof CoreTransportError) return error.kind === "aborted";
+  if (error instanceof CoreModuleResponseError) {
+    return error.coreError.code === "cancelled";
+  }
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "ABORT_ERR";
 }

--- a/src/main/core-result-ipc.ts
+++ b/src/main/core-result-ipc.ts
@@ -1,6 +1,6 @@
 import type { CoreResult } from "../shared/core-result";
 import { CoreModuleResponseError } from "./core-client/core-client";
-import { CoreTransportError } from "./core-client/uds-http";
+import { CoreHttpError, CoreTransportError } from "./core-client/uds-http";
 
 export type CancellableCoreResult<T> =
   | { readonly status: "completed"; readonly value: T }
@@ -51,6 +51,7 @@ export async function cancellableCoreResultFrom<T>(
 }
 
 function isCoreCancellation(error: unknown): boolean {
+  if (error instanceof CoreHttpError) return error.status === 499;
   if (error instanceof CoreTransportError) return error.kind === "aborted";
   if (error instanceof CoreModuleResponseError) {
     return error.coreError.code === "cancelled";

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -201,7 +201,7 @@ import { createProjectWithDefaultSource } from "./default-project-source";
 import { resolveNodexProjectsDirectory } from "./nodex-projects-directory";
 import type { DesktopDatabaseModuleBridge } from "./core-client/desktop-database-module-bridge";
 import type { CoreResult } from "../shared/core-result";
-import { coreResultFrom } from "./core-result-ipc";
+import { cancellableCoreResultFrom, coreResultFrom } from "./core-result-ipc";
 import type { DesktopAutomationModulePort } from "./core-client/desktop-automation-module-bridge";
 import type { DesktopStoreAdministrationPort } from "./core-client/desktop-store-administration-bridge";
 import type { GitWorkerHost } from "./git-worker-host";
@@ -1167,6 +1167,7 @@ export function registerIpcHandlers(
   options: RegisterIpcHandlersOptions = {},
 ): void {
   ensureBrowserGuestBridge();
+  const pageSearchRequests = new Map<string, AbortController>();
   ipcMain.removeAllListeners(CLIPBOARD_INSPECT_PASTE_SYNC_CHANNEL);
   ipcMain.on(CLIPBOARD_INSPECT_PASTE_SYNC_CHANNEL, (event) => {
     try {
@@ -2458,17 +2459,44 @@ export function registerIpcHandlers(
     await databaseModule.getLibraryDatabaseViewGroups(input));
 
   // Database Pages
-  registerHandle("pages:search", async (_, input) => {
+  registerHandle("pages:search", async (event, requestId, input) => {
+    if (!requestId || requestId.length > 128 || requestId.trim() !== requestId) {
+      throw new Error("Page search request identity is invalid");
+    }
+    const key = `${event.sender.id}:${requestId}`;
+    if (pageSearchRequests.has(key)) {
+      throw new Error("Page search request identity is already active");
+    }
+    const controller = new AbortController();
+    pageSearchRequests.set(key, controller);
     const startedAt = performance.now();
-    const snapshot = await libraryModule.searchPages(input);
-    ipcPayloadLogger.info("page search payload served", {
-      channel: "pages:search",
-      projectCount: input.projectIds.length,
-      resultCount: snapshot.results.length,
-      approxPayloadBytes: approximateJsonPayloadBytes(snapshot),
-      durationMs: Math.round(performance.now() - startedAt),
-    });
-    return snapshot;
+    try {
+      const result = await cancellableCoreResultFrom(
+        controller.signal,
+        async () => await libraryModule.searchPages(input, controller.signal),
+      );
+      if (result.status === "cancelled") return result;
+      const snapshot = result.value;
+      ipcPayloadLogger.info("page search payload served", {
+        channel: "pages:search",
+        projectCount: input.projectIds.length,
+        resultCount: snapshot.results.length,
+        approxPayloadBytes: approximateJsonPayloadBytes(snapshot),
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+      return { status: "completed" as const, snapshot };
+    } finally {
+      if (pageSearchRequests.get(key) === controller) {
+        pageSearchRequests.delete(key);
+      }
+    }
+  });
+
+  registerHandle("pages:search:cancel", (event, requestId) => {
+    const controller = pageSearchRequests.get(`${event.sender.id}:${requestId}`);
+    if (!controller) return false;
+    controller.abort();
+    return true;
   });
 
   registerHandle("pages:search-metadata", async (_, projectIds, pageIds) => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1163,11 +1163,12 @@ function createGitActionWorkerPort(
   };
 }
 
+const pageSearchRequests = new Map<string, AbortController>();
+
 export function registerIpcHandlers(
   options: RegisterIpcHandlersOptions = {},
 ): void {
   ensureBrowserGuestBridge();
-  const pageSearchRequests = new Map<string, AbortController>();
   ipcMain.removeAllListeners(CLIPBOARD_INSPECT_PASTE_SYNC_CHANNEL);
   ipcMain.on(CLIPBOARD_INSPECT_PASTE_SYNC_CHANNEL, (event) => {
     try {

--- a/src/main/store-administration-maintenance-scheduler.test.ts
+++ b/src/main/store-administration-maintenance-scheduler.test.ts
@@ -13,6 +13,33 @@ const createPort = (): DesktopStoreAdministrationPort => ({
 });
 
 describe("Store Administration maintenance scheduler", () => {
+  it("runs at most one maintenance lane across the whole Store", async () => {
+    let release: (() => void) | undefined;
+    const administration = createPort();
+    vi.mocked(administration.runMaintenance).mockImplementationOnce(
+      async () => await new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const scheduler = startStoreAdministrationMaintenanceScheduler({
+      administration,
+      readBlockRetentionCount: () => 10,
+      setTimeoutImpl: () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setTimeout>,
+      logger: { warn: vi.fn() },
+    });
+
+    const revision = scheduler.runNow("revision");
+    await Promise.resolve();
+    await scheduler.runNow("document");
+
+    expect(administration.runMaintenance).toHaveBeenCalledTimes(1);
+    release?.();
+    await revision;
+    await scheduler.runNow("document");
+    expect(administration.runMaintenance).toHaveBeenCalledTimes(2);
+    scheduler.dispose();
+  });
+
   it("submits semantic lanes, samples retention policy, and disposes timers", async () => {
     const administration = createPort();
     const callbacks: Array<() => void> = [];

--- a/src/main/store-administration-maintenance-scheduler.ts
+++ b/src/main/store-administration-maintenance-scheduler.ts
@@ -88,12 +88,12 @@ export function startStoreAdministrationMaintenanceScheduler(
     },
   };
   const timers = new Map<MaintenanceLane, MaintenanceTimer>();
-  const running = new Set<MaintenanceLane>();
+  let runningLane: MaintenanceLane | null = null;
   let disposed = false;
 
   const runNow = async (lane: MaintenanceLane): Promise<void> => {
-    if (disposed || running.has(lane) || !isAuthorityAvailable()) return;
-    running.add(lane);
+    if (disposed || runningLane !== null || !isAuthorityAvailable()) return;
+    runningLane = lane;
     try {
       await options.administration.runMaintenance(
         laneInput(lane, options.readBlockRetentionCount),
@@ -104,7 +104,7 @@ export function startStoreAdministrationMaintenanceScheduler(
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      running.delete(lane);
+      runningLane = null;
     }
   };
 

--- a/src/renderer/components/workbench/command-palette.test.tsx
+++ b/src/renderer/components/workbench/command-palette.test.tsx
@@ -41,6 +41,8 @@ const apiMock: {
 
 vi.mock("../../lib/api", () => ({
   invoke: (...args: unknown[]) => apiMock.invokeImplementation(...args),
+  searchPages: (input: unknown) =>
+    apiMock.invokeImplementation("pages:search", "test-request", input),
   subscribeLibraryChanges: () => () => undefined,
 }));
 
@@ -1070,8 +1072,9 @@ describe("CommandPaletteSurface", () => {
   test("deduplicates only concurrent Page requests and keeps no renderer result cache", async () => {
     const { searchCommandPalettePages } = await import("../../lib/command-palette-page-results");
     const searchedQueries: string[] = [];
-    apiMock.invokeImplementation = async (channel: unknown, input: unknown) => {
+    apiMock.invokeImplementation = async (channel: unknown, ...args: unknown[]) => {
       if (channel === "pages:search") {
+        const input = args[1];
         const query = typeof input === "object" && input !== null && "query" in input
           ? String((input as { query?: unknown }).query ?? "")
           : "";

--- a/src/renderer/components/workbench/workbench-shell.layout-panel-actions.test.tsx
+++ b/src/renderer/components/workbench/workbench-shell.layout-panel-actions.test.tsx
@@ -2173,7 +2173,7 @@ describe("workbench session shell / layout-panel-actions", () => {
     });
     expect(invokeCalls.some((call) =>
       call[0] === "pages:search"
-      && (call[1] as { query?: string } | undefined)?.query === "beta card"
+      && (call[2] as { query?: string } | undefined)?.query === "beta card"
     )).toBe(true);
     await act(async () => {
       fireEvent.click(screen.getByRole("option", { name: /Beta Card/ }));

--- a/src/renderer/components/workbench/workbench-testkit/workbench-shell-harness.tsx
+++ b/src/renderer/components/workbench/workbench-testkit/workbench-shell-harness.tsx
@@ -501,6 +501,11 @@ vi.mock("@/lib/api", () => {
     invokeCalls.push([channel, ...args]);
     return mockInvokeImpl?.(channel, ...args) ?? null;
   },
+  searchPages: async (input: unknown) => {
+    const requestId = "test-page-search-request";
+    invokeCalls.push(["pages:search", requestId, input]);
+    return mockInvokeImpl?.("pages:search", requestId, input) ?? null;
+  },
   readDatabaseViewWindow: async (projectId: string, input: unknown) => {
     invokeCalls.push(["database:view-window:get", projectId, input]);
     return mockInvokeImpl?.("database:view-window:get", projectId, input) ?? null;
@@ -2385,7 +2390,7 @@ export function renderWorkbench({
       return snapshot;
     }
     if (channel === "pages:search") {
-      const input = args[0] as {
+      const input = args[1] as {
         projectIds?: string[];
         query?: string;
         limit?: number;

--- a/src/renderer/lib/api.node.test.ts
+++ b/src/renderer/lib/api.node.test.ts
@@ -41,4 +41,88 @@ describe("renderer api transport", () => {
     }
   });
 
+  test("decodes completed and cancelled Page search IPC outcomes", async () => {
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    let cancelled = false;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: {
+        api: {
+          invoke: async (channel: string) => {
+            if (channel !== "pages:search") return false;
+            if (cancelled) return { status: "cancelled" };
+            return {
+              status: "completed",
+              snapshot: {
+                libraryId: "library-1",
+                storeEpoch: "epoch-1",
+                commitSeq: 1,
+                results: [],
+              },
+            };
+          },
+        },
+      },
+    });
+
+    try {
+      const { searchPages } = await import("./api");
+      const input = { projectIds: ["project-1"], query: "codex electron" };
+
+      await expect(searchPages(input)).resolves.toMatchObject({
+        libraryId: "library-1",
+        results: [],
+      });
+      cancelled = true;
+      await expect(searchPages(input)).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      restoreWindow(originalWindowDescriptor);
+    }
+  });
+
+  test("preserves local abort semantics when cancellation races IPC completion", async () => {
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    let resolveSearch!: (value: unknown) => void;
+    const searchResult = new Promise<unknown>((resolve) => {
+      resolveSearch = resolve;
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: {
+        api: {
+          invoke: async (channel: string) => {
+            if (channel !== "pages:search") return false;
+            return await searchResult;
+          },
+        },
+      },
+    });
+
+    try {
+      const { searchPages } = await import("./api");
+      const controller = new AbortController();
+      const search = searchPages(
+        { projectIds: ["project-1"], query: "codex electron" },
+        controller.signal,
+      );
+
+      controller.abort();
+      resolveSearch({
+        status: "completed",
+        snapshot: {
+          libraryId: "library-1",
+          storeEpoch: "epoch-1",
+          commitSeq: 1,
+          results: [],
+        },
+      });
+
+      await expect(search).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      restoreWindow(originalWindowDescriptor);
+    }
+  });
+
 });

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -109,6 +109,7 @@ import type {
 } from "../../shared/pasted-text-attachments";
 import { GitWorkerClient } from "./git-worker-client";
 import { admitLocalCommitApply } from "./local-commit-ingress";
+import type { PageSearchInput, PageSearchSnapshot } from "../../shared/types";
 
 let gitWorkerClient: GitWorkerClient | null = null;
 
@@ -136,6 +137,27 @@ export async function invoke(
 ): Promise<unknown> {
   const transport = resolveInvokeTransport();
   return transport.invoke(channel, ...args);
+}
+
+export async function searchPages(
+  input: PageSearchInput,
+  signal?: AbortSignal,
+): Promise<PageSearchSnapshot> {
+  if (signal?.aborted) throw new DOMException("Page search was aborted", "AbortError");
+  const requestId = globalThis.crypto.randomUUID();
+  const cancel = (): void => {
+    void invoke("pages:search:cancel", requestId).catch(() => undefined);
+  };
+  signal?.addEventListener("abort", cancel, { once: true });
+  try {
+    const result = await invoke("pages:search", requestId, input);
+    if (signal?.aborted || result.status === "cancelled") {
+      throw new DOMException("Page search was aborted", "AbortError");
+    }
+    return result.snapshot;
+  } finally {
+    signal?.removeEventListener("abort", cancel);
+  }
 }
 
 export function createDocumentSyncAdapter(

--- a/src/renderer/lib/command-palette-page-results.ts
+++ b/src/renderer/lib/command-palette-page-results.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { isPriority, PRIORITY_VALUES } from "../../shared/priority";
 import { WORKFLOW_STATUS_ORDER } from "../../shared/workflow-status";
-import { invoke } from "./api";
+import { invoke, searchPages } from "./api";
 import type {
   CommandMenuMode,
   CommandPalettePage,
@@ -263,7 +263,7 @@ export async function searchCommandPalettePages({
   const requestKey = JSON.stringify(request);
   const existing = inFlightPageSearches.get(requestKey);
   if (existing) return await existing;
-  const pending = invoke("pages:search", request)
+  const pending = searchPages(request)
     .then((snapshot) => snapshot.results);
   inFlightPageSearches.set(requestKey, pending);
   try {

--- a/src/renderer/lib/interactive-page-search.test.tsx
+++ b/src/renderer/lib/interactive-page-search.test.tsx
@@ -3,15 +3,21 @@ import { useState } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { PageSearchResult, PageSearchSnapshot } from "../../shared/types";
 import { render, textContent } from "../test/dom";
-import { invoke } from "./api";
+import { invoke, searchPages } from "./api";
 import {
   __testing,
   configureInteractivePageSearch,
   useInteractivePageSearch,
 } from "./interactive-page-search";
 
-vi.mock("./api", () => ({
+const apiMocks = vi.hoisted(() => ({
   invoke: vi.fn(() => new Promise(() => undefined)),
+  searchPages: vi.fn(() => new Promise(() => undefined)),
+}));
+
+vi.mock("./api", () => ({
+  invoke: apiMocks.invoke,
+  searchPages: apiMocks.searchPages,
   subscribeLibraryChanges: () => () => undefined,
 }));
 
@@ -49,9 +55,11 @@ function deferred<Value>() {
 
 function Harness() {
   const [query, setQuery] = useState("");
+  const [unrelated, setUnrelated] = useState(0);
   const search = useInteractivePageSearch({ projectIds: PROJECT_IDS, query, limit: 10 });
   return <>
     <input aria-label="Search Pages" value={query} onChange={(event) => setQuery(event.currentTarget.value)} />
+    <button onClick={() => setUnrelated((value) => value + 1)}>Rerender {unrelated}</button>
     {search.rows.map((row) => <div data-page-id={row.pageId} key={row.pageId}>{row.title}</div>)}
     {search.enrichment === "loading" ? <div>Loading more Pages…</div> : null}
     {search.enrichment === "unavailable" ? <div>Full Page search is unavailable</div> : null}
@@ -59,10 +67,27 @@ function Harness() {
   </>;
 }
 
+function SharedHarness() {
+  const first = useInteractivePageSearch({ projectIds: PROJECT_IDS, query: "shared", limit: 10 });
+  const second = useInteractivePageSearch({ projectIds: PROJECT_IDS, query: "shared", limit: 10 });
+  return <>
+    <div data-shared="first">{first.enrichment}:{first.rows[0]?.title ?? "none"}</div>
+    <div data-shared="second">{second.enrichment}:{second.rows[0]?.title ?? "none"}</div>
+  </>;
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.mocked(invoke).mockReset();
   vi.mocked(invoke).mockImplementation(() => new Promise(() => undefined));
+  vi.mocked(searchPages).mockReset();
+  vi.mocked(searchPages).mockImplementation(
+    (input) => vi.mocked(invoke)(
+      "pages:search",
+      "test-request",
+      input,
+    ) as Promise<PageSearchSnapshot>,
+  );
   __testing.reset();
 });
 
@@ -101,6 +126,7 @@ describe("InteractivePageSearch", () => {
     await act(async () => vi.advanceTimersByTimeAsync(175));
     act(() => fireEvent.change(input, { target: { value: "current" } }));
     await act(async () => vi.advanceTimersByTimeAsync(175));
+    expect(vi.mocked(searchPages).mock.calls[0]?.[1]?.aborted).toBe(true);
     await act(async () => older.resolve(snapshot([hit("older complete")])));
 
     expect(textContent(container)).toContain("Canonical current");
@@ -131,6 +157,52 @@ describe("InteractivePageSearch", () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(175));
     expect(previewIds()).toEqual(["page-preview-second", "page-preview-first"]);
+  });
+
+  test("keeps the current complete request across unrelated renders", async () => {
+    vi.useFakeTimers();
+    const current = deferred<PageSearchSnapshot>();
+    vi.mocked(invoke).mockReturnValueOnce(current.promise);
+    __testing.installIndex(PROJECT_IDS, {
+      replace: () => undefined,
+      applyDelta: () => undefined,
+      search: (request: { query?: string }) => request.query ? [hit(request.query)] : [],
+    });
+    const { container } = render(<Harness />);
+
+    act(() => fireEvent.change(container.querySelector("input")!, { target: { value: "stable" } }));
+    await act(async () => vi.advanceTimersByTimeAsync(175));
+    const signal = vi.mocked(searchPages).mock.calls[0]?.[1];
+    expect(signal?.aborted).toBe(false);
+
+    act(() => fireEvent.click(container.querySelector("button")!));
+
+    expect(signal?.aborted).toBe(false);
+    await act(async () => current.resolve(snapshot([hit("stable complete")])));
+    expect(textContent(container)).toContain("Canonical stable complete");
+  });
+
+  test("shares one complete request across concurrent consumers of a revision", async () => {
+    vi.useFakeTimers();
+    const shared = deferred<PageSearchSnapshot>();
+    vi.mocked(invoke).mockReturnValueOnce(shared.promise);
+    __testing.installIndex(PROJECT_IDS, {
+      replace: () => undefined,
+      applyDelta: () => undefined,
+      search: () => [],
+    });
+    const { container } = render(<SharedHarness />);
+
+    await act(async () => vi.advanceTimersByTimeAsync(175));
+    expect(searchPages).toHaveBeenCalledTimes(1);
+    await act(async () => shared.resolve(snapshot([hit("shared complete")])));
+
+    const rows = Array.from(container.querySelectorAll("[data-shared]"))
+      .map((element) => element.textContent);
+    expect(rows).toEqual([
+      "settled:Canonical shared complete",
+      "settled:Canonical shared complete",
+    ]);
   });
 
   test("keeps metadata rows when complete search is unavailable", async () => {

--- a/src/renderer/lib/interactive-page-search.ts
+++ b/src/renderer/lib/interactive-page-search.ts
@@ -295,6 +295,19 @@ function mergeResults(
   return rows.slice(0, limit);
 }
 
+function filterCompleteResults(
+  rows: readonly PageSearchResult[],
+  dataSourceIds: readonly string[] | undefined,
+): readonly PageSearchResult[] {
+  if (!dataSourceIds || dataSourceIds.length === 0) return rows;
+  const requestedDataSourceIds = new Set(dataSourceIds);
+  return rows.filter((row) => {
+    const document = documents.get(row.pageId);
+    return document !== undefined
+      && document.dataSourceIds.some((dataSourceId) => requestedDataSourceIds.has(dataSourceId));
+  });
+}
+
 export function useInteractivePageSearch(intent: PageSearchIntent): InteractivePageSearchResult {
   const projection = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const intendedScope = scopeKey(intent.projectIds);
@@ -321,11 +334,12 @@ export function useInteractivePageSearch(intent: PageSearchIntent): InteractiveP
     projectIds: normalizedProjectIds,
   });
   const excluded = new Set(intent.excludePageIds ?? []);
+  const completeRows = filterCompleteResults(complete.rows, intent.dataSourceIds);
   const rows = complete.status === "settled"
-    ? complete.rows.filter((row) => !excluded.has(row.pageId)).slice(0, intent.limit ?? 20)
+    ? completeRows.filter((row) => !excluded.has(row.pageId)).slice(0, intent.limit ?? 20)
     : mergeResults(
         preview.filter((row) => !excluded.has(row.pageId)),
-        complete.rows.filter((row) => !excluded.has(row.pageId)),
+        completeRows.filter((row) => !excluded.has(row.pageId)),
         intent.limit ?? 20,
       );
   if (projection.status !== "ready" && complete.status !== "settled") {
@@ -363,8 +377,17 @@ interface CompleteStore {
   hasSubscribers(): boolean;
   dispose(): void;
 }
+interface CompleteRequest {
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): CompleteSnapshot;
+  hasSubscribers(): boolean;
+  dispose(): void;
+  cancelEviction(): void;
+}
+
 const MAX_COMPLETE_STORES = 64;
 const completeStores = new Map<string, CompleteStore>();
+const completeRequests = new Map<string, CompleteRequest>();
 
 function completeStoreFor(
   revision: string,
@@ -373,16 +396,25 @@ function completeStoreFor(
 ): CompleteStore {
   const existing = completeStores.get(revision);
   if (existing) return existing;
-  const store = createCompleteStore(revision, enabled, intent);
-  completeStores.set(revision, store);
-  if (completeStores.size <= MAX_COMPLETE_STORES) return store;
+  // Store creation is render-safe. Registration and eviction happen when the
+  // store receives a committed subscription, so abandoned renders cannot
+  // mutate or dispose shared state.
+  return createCompleteStore(revision, enabled, intent);
+}
+
+function registerCompleteStore(revision: string, store: CompleteStore): void {
+  if (!completeStores.has(revision)) completeStores.set(revision, store);
+  evictCompleteStores();
+}
+
+function evictCompleteStores(): void {
+  if (completeStores.size <= MAX_COMPLETE_STORES) return;
   for (const [candidateRevision, candidate] of completeStores) {
-    if (candidate === store || candidate.hasSubscribers()) continue;
+    if (candidate.hasSubscribers()) continue;
     candidate.dispose();
     completeStores.delete(candidateRevision);
     if (completeStores.size <= MAX_COMPLETE_STORES) break;
   }
-  return store;
 }
 
 function createCompleteStore(
@@ -390,11 +422,80 @@ function createCompleteStore(
   enabled: boolean,
   intent: PageSearchIntent,
 ): CompleteStore {
+  const existingRequest = completeRequests.get(revision);
+  let snapshot: CompleteSnapshot = existingRequest?.getSnapshot()
+    ?? { rows: [], status: enabled ? "loading" : "idle" };
+  let requestUnsubscribe: (() => void) | null = null;
+  let storeEvictionTimer: ReturnType<typeof setTimeout> | null = null;
+  const subscribers = new Set<() => void>();
+  const store: CompleteStore = {
+    subscribe(listener) {
+      subscribers.add(listener);
+      if (subscribers.size === 1) {
+        if (storeEvictionTimer) clearTimeout(storeEvictionTimer);
+        storeEvictionTimer = null;
+        registerCompleteStore(revision, store);
+        const request = completeRequestFor(revision, enabled, intent);
+        requestUnsubscribe = request.subscribe(() => {
+          snapshot = request.getSnapshot();
+          subscribers.forEach((subscriber) => subscriber());
+        });
+        snapshot = request.getSnapshot();
+      }
+      return () => {
+        if (!subscribers.delete(listener) || subscribers.size > 0) return;
+        requestUnsubscribe?.();
+        requestUnsubscribe = null;
+        storeEvictionTimer = setTimeout(() => {
+          storeEvictionTimer = null;
+          if (subscribers.size === 0 && completeStores.get(revision) === store) {
+            completeStores.delete(revision);
+            store.dispose();
+            evictCompleteStores();
+          }
+        }, 0);
+      };
+    },
+    getSnapshot: () => snapshot,
+    hasSubscribers: () => subscribers.size > 0,
+    dispose() {
+      requestUnsubscribe?.();
+      requestUnsubscribe = null;
+      if (storeEvictionTimer) clearTimeout(storeEvictionTimer);
+      storeEvictionTimer = null;
+    },
+  };
+  return store;
+}
+
+function completeRequestFor(
+  revision: string,
+  enabled: boolean,
+  intent: PageSearchIntent,
+): CompleteRequest {
+  const existing = completeRequests.get(revision);
+  if (existing) {
+    existing.cancelEviction();
+    return existing;
+  }
+  const request = createCompleteRequest(revision, enabled, intent);
+  completeRequests.set(revision, request);
+  return request;
+}
+
+function createCompleteRequest(
+  revision: string,
+  enabled: boolean,
+  intent: PageSearchIntent,
+): CompleteRequest {
   let snapshot: CompleteSnapshot = { rows: [], status: enabled ? "loading" : "idle" };
   let timer: ReturnType<typeof setTimeout> | null = null;
   let evictionTimer: ReturnType<typeof setTimeout> | null = null;
   let controller: AbortController | null = null;
   const subscribers = new Set<() => void>();
+  const notify = (): void => {
+    subscribers.forEach((listener) => listener());
+  };
   const start = (): void => {
     if (evictionTimer) clearTimeout(evictionTimer);
     evictionTimer = null;
@@ -403,6 +504,8 @@ function createCompleteStore(
       timer = null;
       controller = new AbortController();
       const activeController = controller;
+      // Core returns the complete candidate set. Data-source scoping is
+      // applied against the same authorized metadata projection by the hook.
       void searchPages({
         projectIds: [...intent.projectIds], query: intent.query,
         filters: intent.filters, preferredProjectId: intent.preferredProjectId ?? undefined,
@@ -415,11 +518,11 @@ function createCompleteStore(
           || result.commitSeq < state.commitSeq
         ) return;
         snapshot = { rows: result.results, status: "settled" };
-        subscribers.forEach((listener) => listener());
+        notify();
       }).catch(() => {
         if (controller !== activeController || activeController.signal.aborted) return;
         snapshot = { rows: [], status: "unavailable" };
-        subscribers.forEach((listener) => listener());
+        notify();
       }).finally(() => {
         if (controller === activeController) controller = null;
       });
@@ -431,20 +534,23 @@ function createCompleteStore(
     controller?.abort();
     controller = null;
   };
-  const store: CompleteStore = {
+  const scheduleEviction = (): void => {
+    if (evictionTimer) clearTimeout(evictionTimer);
+    evictionTimer = setTimeout(() => {
+      evictionTimer = null;
+      if (subscribers.size > 0 || completeRequests.get(revision) !== request) return;
+      completeRequests.delete(revision);
+      request.dispose();
+    }, 0);
+  };
+  const request: CompleteRequest = {
     subscribe(listener) {
       subscribers.add(listener);
       if (subscribers.size === 1) start();
       return () => {
-        subscribers.delete(listener);
-        if (subscribers.size > 0) return;
+        if (!subscribers.delete(listener) || subscribers.size > 0) return;
         stop();
-        evictionTimer = setTimeout(() => {
-          evictionTimer = null;
-          if (subscribers.size === 0 && completeStores.get(revision) === store) {
-            completeStores.delete(revision);
-          }
-        }, 0);
+        scheduleEviction();
       };
     },
     getSnapshot: () => snapshot,
@@ -454,8 +560,12 @@ function createCompleteStore(
       if (evictionTimer) clearTimeout(evictionTimer);
       evictionTimer = null;
     },
+    cancelEviction() {
+      if (evictionTimer) clearTimeout(evictionTimer);
+      evictionTimer = null;
+    },
   };
-  return store;
+  return request;
 }
 
 export const __testing = {
@@ -496,6 +606,7 @@ export const __testing = {
     nextScopeLeaseId = 1;
     state = EMPTY_STATE; index?.free?.(); index = null; documents.clear(); configuredProjectIds = [];
     completeStores.forEach((store) => store.dispose());
-    completeStores.clear(); listeners.clear();
+    completeRequests.forEach((request) => request.dispose());
+    completeStores.clear(); completeRequests.clear(); listeners.clear();
   },
 };

--- a/src/renderer/lib/interactive-page-search.ts
+++ b/src/renderer/lib/interactive-page-search.ts
@@ -5,7 +5,7 @@ import type {
   PageSearchMetadataSnapshot,
   PageSearchResult,
 } from "../../shared/types";
-import { invoke, subscribeLibraryChanges } from "./api";
+import { invoke, searchPages, subscribeLibraryChanges } from "./api";
 
 type WasmIndex = {
   free?(): void;
@@ -352,63 +352,107 @@ function useCompletePageSearch(
   revision: string,
   intent: PageSearchIntent,
 ): { readonly rows: readonly PageSearchResult[]; readonly status: InteractivePageSearchResult["enrichment"] } {
-  // The registry makes the revision the store identity. The other dependencies
-  // keep the creation inputs explicit without recreating an already registered
-  // store when a caller allocates an equivalent intent object on re-render.
-  const store = useMemo(
-    () => completeStores.get(revision) ?? createCompleteStore(revision, enabled, intent),
-    [enabled, intent, revision],
-  );
-  useEffect(() => {
-    const activeStore = completeStores.get(revision) ?? store;
-    completeStores.set(revision, activeStore);
-    activeStore.start();
-    return () => activeStore.release();
-  }, [revision, store]);
+  const store = completeStoreFor(revision, enabled, intent);
   return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 }
 
 interface CompleteSnapshot { readonly rows: readonly PageSearchResult[]; readonly status: InteractivePageSearchResult["enrichment"] }
-interface CompleteStore { subscribe(listener: () => void): () => void; getSnapshot(): CompleteSnapshot; start(): void; release(): void }
+interface CompleteStore {
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): CompleteSnapshot;
+  hasSubscribers(): boolean;
+  dispose(): void;
+}
+const MAX_COMPLETE_STORES = 64;
 const completeStores = new Map<string, CompleteStore>();
 
-function createCompleteStore(revision: string, enabled: boolean, intent: PageSearchIntent): CompleteStore {
+function completeStoreFor(
+  revision: string,
+  enabled: boolean,
+  intent: PageSearchIntent,
+): CompleteStore {
+  const existing = completeStores.get(revision);
+  if (existing) return existing;
+  const store = createCompleteStore(revision, enabled, intent);
+  completeStores.set(revision, store);
+  if (completeStores.size <= MAX_COMPLETE_STORES) return store;
+  for (const [candidateRevision, candidate] of completeStores) {
+    if (candidate === store || candidate.hasSubscribers()) continue;
+    candidate.dispose();
+    completeStores.delete(candidateRevision);
+    if (completeStores.size <= MAX_COMPLETE_STORES) break;
+  }
+  return store;
+}
+
+function createCompleteStore(
+  revision: string,
+  enabled: boolean,
+  intent: PageSearchIntent,
+): CompleteStore {
   let snapshot: CompleteSnapshot = { rows: [], status: enabled ? "loading" : "idle" };
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let users = 0;
+  let evictionTimer: ReturnType<typeof setTimeout> | null = null;
+  let controller: AbortController | null = null;
   const subscribers = new Set<() => void>();
+  const start = (): void => {
+    if (evictionTimer) clearTimeout(evictionTimer);
+    evictionTimer = null;
+    if (!enabled || timer || controller || snapshot.status !== "loading") return;
+    timer = setTimeout(() => {
+      timer = null;
+      controller = new AbortController();
+      const activeController = controller;
+      void searchPages({
+        projectIds: [...intent.projectIds], query: intent.query,
+        filters: intent.filters, preferredProjectId: intent.preferredProjectId ?? undefined,
+        recentPageIds: [...(intent.recentPageIds ?? [])], limit: intent.limit,
+      }, activeController.signal).then((result) => {
+        if (controller !== activeController || activeController.signal.aborted) return;
+        if (
+          (state.libraryId !== null && result.libraryId !== state.libraryId)
+          || (state.storeEpoch !== null && result.storeEpoch !== state.storeEpoch)
+          || result.commitSeq < state.commitSeq
+        ) return;
+        snapshot = { rows: result.results, status: "settled" };
+        subscribers.forEach((listener) => listener());
+      }).catch(() => {
+        if (controller !== activeController || activeController.signal.aborted) return;
+        snapshot = { rows: [], status: "unavailable" };
+        subscribers.forEach((listener) => listener());
+      }).finally(() => {
+        if (controller === activeController) controller = null;
+      });
+    }, 175);
+  };
+  const stop = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    controller?.abort();
+    controller = null;
+  };
   const store: CompleteStore = {
-    subscribe(listener) { subscribers.add(listener); return () => subscribers.delete(listener); },
-    getSnapshot: () => snapshot,
-    start() {
-      users += 1;
-      if (!enabled || timer || snapshot.status !== "loading") return;
-      timer = setTimeout(() => {
-        timer = null;
-        void invoke("pages:search", {
-          projectIds: [...intent.projectIds], query: intent.query,
-          filters: intent.filters, preferredProjectId: intent.preferredProjectId ?? undefined,
-          recentPageIds: [...(intent.recentPageIds ?? [])], limit: intent.limit,
-        }).then((result) => {
-          if (
-            (state.libraryId !== null && result.libraryId !== state.libraryId)
-            || (state.storeEpoch !== null && result.storeEpoch !== state.storeEpoch)
-            || result.commitSeq < state.commitSeq
-          ) return;
-          snapshot = { rows: result.results, status: "settled" };
-          subscribers.forEach((listener) => listener());
-        }).catch(() => {
-          snapshot = { rows: [], status: "unavailable" };
-          subscribers.forEach((listener) => listener());
-        });
-      }, 175);
+    subscribe(listener) {
+      subscribers.add(listener);
+      if (subscribers.size === 1) start();
+      return () => {
+        subscribers.delete(listener);
+        if (subscribers.size > 0) return;
+        stop();
+        evictionTimer = setTimeout(() => {
+          evictionTimer = null;
+          if (subscribers.size === 0 && completeStores.get(revision) === store) {
+            completeStores.delete(revision);
+          }
+        }, 0);
+      };
     },
-    release() {
-      if (users === 0) return;
-      users -= 1;
-      if (users > 0) return;
-      if (timer) clearTimeout(timer);
-      if (completeStores.get(revision) === store) completeStores.delete(revision);
+    getSnapshot: () => snapshot,
+    hasSubscribers: () => subscribers.size > 0,
+    dispose() {
+      stop();
+      if (evictionTimer) clearTimeout(evictionTimer);
+      evictionTimer = null;
     },
   };
   return store;
@@ -451,6 +495,7 @@ export const __testing = {
     scopeLeases.clear();
     nextScopeLeaseId = 1;
     state = EMPTY_STATE; index?.free?.(); index = null; documents.clear(); configuredProjectIds = [];
+    completeStores.forEach((store) => store.dispose());
     completeStores.clear(); listeners.clear();
   },
 };

--- a/src/shared/ipc-api.ts
+++ b/src/shared/ipc-api.ts
@@ -318,9 +318,9 @@ import type {
   PageOccurrenceUpdateInput,
   DatabasePage,
   DatabasePageSummary,
+  PageSearchCommandResult,
   PageSearchFacets,
   PageSearchInput,
-  PageSearchSnapshot,
   PageSearchMetadataSnapshot,
   CommandPaletteThreadSearchInput,
   CommandPaletteThreadSearchResult,
@@ -967,8 +967,12 @@ export interface IpcApi {
     result: CoreResult<LibraryDatabaseViewGroupsSnapshot>;
   };
   "pages:search": {
-    args: [input: PageSearchInput];
-    result: PageSearchSnapshot;
+    args: [requestId: string, input: PageSearchInput];
+    result: PageSearchCommandResult;
+  };
+  "pages:search:cancel": {
+    args: [requestId: string];
+    result: boolean;
   };
   "pages:search-metadata": {
     args: [projectIds: string[], pageIds?: string[]];

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -488,6 +488,11 @@ export interface PageSearchSnapshot {
   results: PageSearchResult[];
 }
 
+/** Cancellation is expected control flow for query-as-you-type IPC. */
+export type PageSearchCommandResult =
+  | { status: "completed"; snapshot: PageSearchSnapshot }
+  | { status: "cancelled" };
+
 export interface PageSearchMetadataProperty {
   propertyId: string;
   propertyName: string;


### PR DESCRIPTION
## What changed

Core-backed interactive work now has a Core-owned request executor with bounded admission, reserved interactive capacity, blocking-worker isolation, absolute deadlines, cooperative SQLite cancellation, typed failures, and health evidence.

Request identity and cancellation now propagate through Electron IPC. Stale Page searches cancel as control flow, Store maintenance is serialized, Full Page search keeps FTS as the driving loop, and multi-term evidence remains complete.

## Why

Large reads and maintenance could exhaust synchronous Core capacity, causing Electron's fixed transport timeout to abandon requests without stopping the underlying work. Search could also hit a pathological SQLite plan or report expected stale-search cancellation as an error.

## Impact

Interactive search remains responsive under load, stale work releases capacity end to end, and slow requests report the actual Core outcome instead of an ambiguous transport failure.

## Validation

- `git diff --check`
- GitHub Actions checks are running for this PR.

Depends on #58. This PR is intentionally based on `codex/pr/core-migration` and should be retargeted to `main` after #58 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request deadlines, cancellation, prioritization, and overload handling across Core operations.
  * Added cancellation support for page searches and improved stale-search handling.
  * Added request activity, queue, timing, cancellation, and overload metrics.
  * Improved multi-term search ranking and excerpts, preserving more matching evidence.

* **Bug Fixes**
  * Search planning now consistently prioritizes full-text search results.
  * Slow requests now report distinct cancellation, deadline, and overload outcomes.
  * Event streams emit a final checkpoint when the underlying store changes.

* **Documentation**
  * Updated reliability and architecture guidance for request execution and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->