### PR TITLE
test(vitest): keep stress variants out of default main suite

### DIFF
--- a/vitest.main.config.ts
+++ b/vitest.main.config.ts
@@ -7,7 +7,7 @@ assertElectronTestRuntime("main");
 const testFiles = selectTieredTestFiles({
   defaultExclude: ["src/main/**/*.integration.ts"],
   defaultInclude: ["src/main/**/*.test.ts"],
-  stressInclude: ["src/main/**/*.stress.test.ts"],
+  stressInclude: ["src/main/**/*.stress*.test.ts"],
 });
 
 export default defineConfig({


### PR DESCRIPTION
The default Electron app suite was accidentally picking up `*.stress.node.test.ts` files because the main Vitest config only excluded the narrower `*.stress.test.ts` pattern. That made a production-scale CoreClient scenario run in the parallel 20s default suite, where it was timing out under CI load.

This widens the stress-file glob so all stress variants run only in the single-worker, longer-timeout stress tier. The change keeps the default app suite focused and preserves the intended stress coverage boundary.

Validation:
- `pnpm exec vitest run --config vitest.renderer.config.ts src/renderer/components/ui/context-menu.test.tsx`
- `pnpm test:main src/main/core-client/database-context-menu-scenario.stress.node.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded stress test file matching to include filenames with additional text before the `.stress.test.ts` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->