### PR TITLE
test(ci): prepare resources before stress suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/fetch-legacy-migrator
       - uses: ./.github/actions/setup-rust-ci
+      - run: pnpm run build-resources:prepare
       - uses: ./.github/actions/setup-playwright
       - name: Run selected stress suites
         run: pnpm exec tsx scripts/ci/run-timed.ts --name stress-tests -- xvfb-run --auto-servernum pnpm run test:stress


### PR DESCRIPTION
The separated stress-test job was missing prerequisites that the application-test job already prepares. That made the stress tier fail before exercising the product because the generated legacy migrator resource was absent.

This PR gives the stress job ownership of its complete setup by fetching the legacy migrator fixture and running `pnpm run build-resources:prepare` before the selected stress suites. It keeps the stress tier separate while making it reproducible and mergeable on its own.

Validation:
- Local targeted CoreClient stress scenario passes.
- CI will validate the workflow and all required checks.