### PR TITLE
perf(ci): cut required feedback time with parallel gates

### DIFF
--- a/.github/workflows/_app-tests.yml
+++ b/.github/workflows/_app-tests.yml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI_TIMING_JOB: ${{ inputs.timing_prefix }}-${{ matrix.suite }}
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -44,14 +42,29 @@ jobs:
         run: pnpm exec tsx scripts/ci/app-test-suite.ts --suite "${{ matrix.suite }}"
       - uses: ./.github/actions/setup-rust-ci
         if: steps.suite.outputs.needs_rust == 'true'
-      - run: pnpm run build-resources:prepare
+      - name: Prepare build resources
+        env:
+          NEEDS_RUST: ${{ steps.suite.outputs.needs_rust }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${NEEDS_RUST}" == "true" ]]; then
+            export RUSTC_WRAPPER=sccache
+            export SCCACHE_GHA_ENABLED=true
+          fi
+          pnpm run build-resources:prepare
       - name: Run application suite
         env:
+          NEEDS_RUST: ${{ steps.suite.outputs.needs_rust }}
           NEEDS_XVFB: ${{ steps.suite.outputs.needs_xvfb }}
           PACKAGE_SCRIPT: ${{ steps.suite.outputs.package_script }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${NEEDS_RUST}" == "true" ]]; then
+            export RUSTC_WRAPPER=sccache
+            export SCCACHE_GHA_ENABLED=true
+          fi
           if [[ "${NEEDS_XVFB}" == "true" ]]; then
             pnpm exec tsx scripts/ci/run-timed.ts \
               --name "app-${{ matrix.suite }}" \

--- a/.github/workflows/_app-tests.yml
+++ b/.github/workflows/_app-tests.yml
@@ -1,0 +1,79 @@
+name: Reusable Application Tests
+
+on:
+  workflow_call:
+    inputs:
+      suites_json:
+        description: JSON array of canonical application test suites.
+        required: true
+        type: string
+      timing_prefix:
+        description: Stable prefix for timing artifacts and summaries.
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  test:
+    name: app ${{ matrix.suite }}
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(inputs.suites_json) }}
+    runs-on: ubuntu-latest
+    env:
+      CI_TIMING_JOB: ${{ inputs.timing_prefix }}-${{ matrix.suite }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - name: Resolve suite prerequisites
+        id: suite
+        run: pnpm exec tsx scripts/ci/app-test-suite.ts --suite "${{ matrix.suite }}"
+      - uses: ./.github/actions/setup-rust-ci
+        if: steps.suite.outputs.needs_rust == 'true'
+      - run: pnpm run build-resources:prepare
+      - name: Run application suite
+        env:
+          NEEDS_XVFB: ${{ steps.suite.outputs.needs_xvfb }}
+          PACKAGE_SCRIPT: ${{ steps.suite.outputs.package_script }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${NEEDS_XVFB}" == "true" ]]; then
+            pnpm exec tsx scripts/ci/run-timed.ts \
+              --name "app-${{ matrix.suite }}" \
+              -- xvfb-run --auto-servernum pnpm run "${PACKAGE_SCRIPT}"
+            exit 0
+          fi
+          pnpm exec tsx scripts/ci/run-timed.ts \
+            --name "app-${{ matrix.suite }}" \
+            -- pnpm run "${PACKAGE_SCRIPT}"
+      - name: Show renderer memory state
+        if: always() && matrix.suite == 'renderer'
+        run: free -h
+      - name: Upload application diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: app-${{ matrix.suite }}-failure-${{ github.run_attempt }}
+          path: |
+            .vitest-attachments/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Show Rust compiler cache statistics
+        if: always() && steps.suite.outputs.needs_rust == 'true'
+        run: sccache --show-stats || true

--- a/.github/workflows/_static-checks.yml
+++ b/.github/workflows/_static-checks.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   check:
     name: static ${{ matrix.group }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +39,9 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - name: Run static group
+        env:
+          STATIC_GROUP: ${{ matrix.group }}
         run: >-
           pnpm exec tsx scripts/ci/run-timed.ts
-          --name "static-${{ matrix.group }}"
-          -- pnpm exec tsx scripts/ci/verify-static.ts --group "${{ matrix.group }}"
+          --name "static-${STATIC_GROUP}"
+          -- pnpm exec tsx scripts/ci/verify-static.ts --group "${STATIC_GROUP}"

--- a/.github/workflows/_static-checks.yml
+++ b/.github/workflows/_static-checks.yml
@@ -1,0 +1,44 @@
+name: Reusable Static Checks
+
+on:
+  workflow_call:
+    inputs:
+      groups_json:
+        description: JSON array of canonical static check groups.
+        required: true
+        type: string
+      timing_prefix:
+        description: Stable prefix for timing artifacts and summaries.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  check:
+    name: static ${{ matrix.group }}
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJSON(inputs.groups_json) }}
+    runs-on: ubuntu-latest
+    env:
+      CI_TIMING_JOB: ${{ inputs.timing_prefix }}-${{ matrix.group }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - name: Run static group
+        run: >-
+          pnpm exec tsx scripts/ci/run-timed.ts
+          --name "static-${{ matrix.group }}"
+          -- pnpm run verify:static -- --group "${{ matrix.group }}"

--- a/.github/workflows/_static-checks.yml
+++ b/.github/workflows/_static-checks.yml
@@ -41,4 +41,4 @@ jobs:
         run: >-
           pnpm exec tsx scripts/ci/run-timed.ts
           --name "static-${{ matrix.group }}"
-          -- pnpm run verify:static -- --group "${{ matrix.group }}"
+          -- pnpm exec tsx scripts/ci/verify-static.ts --group "${{ matrix.group }}"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,36 +16,16 @@ concurrency:
 jobs:
   static-contracts:
     name: main static contracts
-    runs-on: ubuntu-latest
-    env:
-      CI_TIMING_JOB: main-static-contracts
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - uses: ./.github/actions/setup-rust-ci
-      - name: Verify runner CLI tools
-        run: rg --version
-      - name: Run static contracts
-        run: pnpm exec tsx scripts/ci/run-timed.ts --name static-contracts -- pnpm run verify:static
-      - name: Show Rust compiler cache statistics
-        if: always()
-        run: sccache --show-stats || true
+    uses: ./.github/workflows/_static-checks.yml
+    with:
+      groups_json: '["types","ui-contracts","ci-contracts","repository-contracts","generated","landing"]'
+      timing_prefix: main-static
 
-  rust-full:
-    name: full Rust verification
+  rust-quality:
+    name: Rust quality and protocol contracts
     runs-on: ubuntu-latest
     env:
-      CI_TIMING_JOB: main-rust-full
+      CI_TIMING_JOB: main-rust-quality
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -66,17 +46,17 @@ jobs:
         run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-format -- pnpm run core:fmt
       - name: Run Rust lint
         run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-clippy -- pnpm run core:clippy
-      - name: Run full Rust suite
-        run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-full -- pnpm run core:test:full
+      - name: Verify generated protocol contracts
+        run: pnpm exec tsx scripts/ci/run-timed.ts --name protocol-contracts -- pnpm run core:protocol:verify
       - name: Show Rust compiler cache statistics
         if: always()
         run: sccache --show-stats || true
 
-  app-tests:
-    name: full app tests
+  rust-workspace:
+    name: exhaustive Rust workspace tests
     runs-on: ubuntu-latest
     env:
-      CI_TIMING_JOB: main-app-tests
+      CI_TIMING_JOB: main-rust-workspace
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -89,14 +69,45 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - uses: ./.github/actions/setup-rust-ci
-      - run: pnpm run build-resources:prepare
-      - name: Run full application suites
-        run: pnpm exec tsx scripts/ci/run-timed.ts --name app-tests -- xvfb-run --auto-servernum pnpm test
+      - name: Run exhaustive workspace suite
+        run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-workspace -- pnpm run core:test:workspace
       - name: Show Rust compiler cache statistics
         if: always()
         run: sccache --show-stats || true
+
+  rust-migration:
+    name: exhaustive Store migration tests
+    runs-on: ubuntu-latest
+    env:
+      CI_TIMING_JOB: main-rust-migration
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - uses: ./.github/actions/setup-rust-ci
+      - name: Run exhaustive migration suite
+        run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-migration -- pnpm run core:test:migration
+      - name: Show Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats || true
+
+  app-tests:
+    name: full app tests
+    uses: ./.github/workflows/_app-tests.yml
+    with:
+      suites_json: '["unit","core-client","main","renderer","integration"]'
+      timing_prefix: main-app
 
   stress-tests:
     name: full stress tests
@@ -199,7 +210,9 @@ jobs:
     if: always()
     needs:
       - static-contracts
-      - rust-full
+      - rust-quality
+      - rust-workspace
+      - rust-migration
       - app-tests
       - stress-tests
       - browser-tests
@@ -207,30 +220,12 @@ jobs:
       - runtime-contracts
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Require every main gate
         env:
-          APP_RESULT: ${{ needs.app-tests.result }}
-          BROWSER_RESULT: ${{ needs.browser-tests.result }}
-          E2E_RESULT: ${{ needs.electron-e2e.result }}
-          RUNTIME_RESULT: ${{ needs.runtime-contracts.result }}
-          RUST_RESULT: ${{ needs.rust-full.result }}
-          STATIC_RESULT: ${{ needs.static-contracts.result }}
-          STRESS_RESULT: ${{ needs.stress-tests.result }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          for gate in \
-            "static-contracts:${STATIC_RESULT}" \
-            "rust-full:${RUST_RESULT}" \
-            "app-tests:${APP_RESULT}" \
-            "stress-tests:${STRESS_RESULT}" \
-            "browser-tests:${BROWSER_RESULT}" \
-            "electron-e2e:${E2E_RESULT}" \
-            "runtime-contracts:${RUNTIME_RESULT}"; do
-            name="${gate%%:*}"
-            result="${gate#*:}"
-            if [[ "${result}" != "success" ]]; then
-              echo "${name} finished with ${result}; expected success." >&2
-              exit 1
-            fi
-          done
+          CI_CLASSIFIER_RESULT: success
+          CI_NEEDS_JSON: ${{ toJSON(needs) }}
+          CI_SELECTED_GATES_JSON: '["static-contracts","rust-quality","rust-workspace","rust-migration","app-tests","stress-tests","browser-tests","electron-e2e","runtime-contracts"]'
+        run: node --no-warnings scripts/ci/verify-required-gates.ts

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -9,10 +9,6 @@ permissions:
   actions: write
   contents: read
 
-concurrency:
-  group: main-ci
-  cancel-in-progress: false
-
 jobs:
   static-contracts:
     name: main static contracts

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -223,5 +223,4 @@ jobs:
         env:
           CI_CLASSIFIER_RESULT: success
           CI_NEEDS_JSON: ${{ toJSON(needs) }}
-          CI_SELECTED_GATES_JSON: '["static-contracts","rust-quality","rust-workspace","rust-migration","app-tests","stress-tests","browser-tests","electron-e2e","runtime-contracts"]'
         run: node --no-warnings scripts/ci/verify-required-gates.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,29 +23,13 @@ jobs:
     name: classify
     runs-on: ubuntu-latest
     outputs:
-      app: ${{ steps.classify.outputs.app }}
-      browser: ${{ steps.classify.outputs.browser }}
-      dependency_kind: ${{ steps.classify.outputs.dependency_kind }}
-      docs_only: ${{ steps.classify.outputs.docs_only }}
-      electron_main: ${{ steps.classify.outputs.electron_main }}
-      full_required: ${{ steps.classify.outputs.full_required }}
-      landing_only: ${{ steps.classify.outputs.landing_only }}
-      migration: ${{ steps.classify.outputs.migration }}
-      protocol: ${{ steps.classify.outputs.protocol }}
-      release_metadata: ${{ steps.classify.outputs.release_metadata }}
-      renderer: ${{ steps.classify.outputs.renderer }}
-      rust: ${{ steps.classify.outputs.rust }}
-      runtime: ${{ steps.classify.outputs.runtime }}
-      storage: ${{ steps.classify.outputs.storage }}
-      stress_relevant: ${{ steps.classify.outputs.stress_relevant }}
+      plan: ${{ steps.outputs.outputs.plan }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-
       - name: Classify changed paths
-        id: classify
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' && inputs.full || false }}
@@ -62,22 +46,13 @@ jobs:
             arguments+=(--full)
           fi
           node --no-warnings scripts/ci/classify-change.ts "${arguments[@]}"
-          node -e '
-            const fs = require("node:fs");
-            const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-            const keys = [
-              "app", "browser", "dependencyKind", "docsOnly", "electronMain", "fullRequired", "landingOnly",
-              "migration", "protocol", "releaseMetadata", "renderer", "rust", "runtime",
-              "storage", "stressRelevant",
-            ];
-            const snake = (key) => key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, keys.map((key) => `${snake(key)}=${value[key]}`).join("\n") + "\n");
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `## Change classification\n\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\`\n`);
-          ' "${RUNNER_TEMP}/classification.json"
+      - name: Publish typed gate plan
+        id: outputs
+        run: node --no-warnings scripts/ci/write-github-outputs.ts --input "${RUNNER_TEMP}/classification.json"
 
   release-transition:
     name: release transition
-    if: needs.classify.outputs.release_metadata == 'true'
+    if: ${{ fromJSON(needs.classify.outputs.plan).releaseTransition }}
     needs: classify
     runs-on: ubuntu-latest
     steps:
@@ -131,34 +106,16 @@ jobs:
 
   static-contracts:
     name: static contracts
-    if: needs.classify.outputs.docs_only != 'true' && needs.classify.outputs.release_metadata != 'true'
+    if: ${{ toJSON(fromJSON(needs.classify.outputs.plan).staticGroups) != '[]' }}
     needs: classify
-    runs-on: ubuntu-latest
-    env:
-      CI_TIMING_JOB: static-contracts
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - uses: ./.github/actions/setup-rust-ci
-      - name: Run static contracts
-        run: pnpm exec tsx scripts/ci/run-timed.ts --name static-contracts -- pnpm run verify:static
-      - name: Show Rust compiler cache statistics
-        if: always()
-        run: sccache --show-stats || true
+    uses: ./.github/workflows/_static-checks.yml
+    with:
+      groups_json: ${{ toJSON(fromJSON(needs.classify.outputs.plan).staticGroups) }}
+      timing_prefix: pr-static
 
   rust-pr:
     name: Rust fast suite
-    if: needs.classify.outputs.app == 'true' && (needs.classify.outputs.rust == 'true' || needs.classify.outputs.full_required == 'true')
+    if: ${{ fromJSON(needs.classify.outputs.plan).rustFast }}
     needs: classify
     runs-on: ubuntu-latest
     env:
@@ -185,23 +142,18 @@ jobs:
         run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-format -- pnpm run core:fmt
       - name: Run Rust lint
         run: pnpm exec tsx scripts/ci/run-timed.ts --name rust-clippy -- pnpm run core:clippy
-      - name: Run selected Rust test tier
-        env:
-          FULL_REQUIRED: ${{ needs.classify.outputs.full_required }}
-        run: |
-          set -euo pipefail
-          test_command=core:test:pr
-          if [[ "${FULL_REQUIRED}" == "true" ]]; then
-            test_command=core:test:full
-          fi
-          pnpm exec tsx scripts/ci/run-timed.ts --name "${test_command}" -- pnpm run "${test_command}"
+      - name: Verify generated protocol contracts
+        if: ${{ fromJSON(needs.classify.outputs.plan).protocolContracts }}
+        run: pnpm exec tsx scripts/ci/run-timed.ts --name protocol-contracts -- pnpm run core:protocol:verify
+      - name: Run ordinary Rust test tier
+        run: pnpm exec tsx scripts/ci/run-timed.ts --name core:test:pr -- pnpm run core:test:pr
       - name: Show Rust compiler cache statistics
         if: always()
         run: sccache --show-stats || true
 
   rust-migration:
     name: Store baseline migration
-    if: needs.classify.outputs.app == 'true' && needs.classify.outputs.migration == 'true'
+    if: ${{ fromJSON(needs.classify.outputs.plan).rustMigration }}
     needs: classify
     runs-on: ubuntu-latest
     env:
@@ -228,35 +180,16 @@ jobs:
 
   app-tests:
     name: app tests
-    if: needs.classify.outputs.app == 'true'
+    if: ${{ toJSON(fromJSON(needs.classify.outputs.plan).appTestSuites) != '[]' }}
     needs: classify
-    runs-on: ubuntu-latest
-    env:
-      CI_TIMING_JOB: app-tests
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - uses: ./.github/actions/setup-rust-ci
-      - run: pnpm run build-resources:prepare
-      - name: Run application test suites
-        run: pnpm exec tsx scripts/ci/run-timed.ts --name app-tests -- xvfb-run --auto-servernum pnpm test
-      - name: Show Rust compiler cache statistics
-        if: always()
-        run: sccache --show-stats || true
+    uses: ./.github/workflows/_app-tests.yml
+    with:
+      suites_json: ${{ toJSON(fromJSON(needs.classify.outputs.plan).appTestSuites) }}
+      timing_prefix: pr-app
 
   stress-tests:
     name: selected stress tests
-    if: needs.classify.outputs.app == 'true' && (needs.classify.outputs.stress_relevant == 'true' || needs.classify.outputs.full_required == 'true')
+    if: ${{ fromJSON(needs.classify.outputs.plan).stress }}
     needs: classify
     runs-on: ubuntu-latest
     env:
@@ -271,7 +204,7 @@ jobs:
 
   browser-tests:
     name: browser tests
-    if: needs.classify.outputs.app == 'true' && (needs.classify.outputs.browser == 'true' || needs.classify.outputs.full_required == 'true')
+    if: ${{ fromJSON(needs.classify.outputs.plan).browser }}
     needs: classify
     runs-on: ubuntu-latest
     env:
@@ -303,11 +236,13 @@ jobs:
 
   electron-e2e:
     name: Electron E2E
-    if: needs.classify.outputs.app == 'true' && (needs.classify.outputs.electron_main == 'true' || needs.classify.outputs.browser == 'true' || needs.classify.outputs.full_required == 'true')
+    if: ${{ fromJSON(needs.classify.outputs.plan).electronE2e }}
     needs: classify
     runs-on: ubuntu-latest
     env:
       CI_TIMING_JOB: electron-e2e
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -319,6 +254,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-rust-ci
       - uses: ./.github/actions/setup-playwright
       - name: Run functional Electron E2E
         env:
@@ -334,10 +270,13 @@ jobs:
             test-results/
           if-no-files-found: ignore
           retention-days: 7
+      - name: Show Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats || true
 
   runtime-contracts:
     name: runtime contracts
-    if: needs.classify.outputs.runtime == 'true'
+    if: ${{ fromJSON(needs.classify.outputs.plan).runtimeMac }}
     needs: classify
     runs-on: macos-26
     env:
@@ -378,66 +317,11 @@ jobs:
       - runtime-contracts
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Require every selected gate
         env:
-          APP: ${{ needs.classify.outputs.app }}
-          APP_TESTS_RESULT: ${{ needs.app-tests.result }}
-          BROWSER: ${{ needs.classify.outputs.browser }}
-          BROWSER_RESULT: ${{ needs.browser-tests.result }}
-          CLASSIFY_RESULT: ${{ needs.classify.result }}
-          DOCS_ONLY: ${{ needs.classify.outputs.docs_only }}
-          ELECTRON_MAIN: ${{ needs.classify.outputs.electron_main }}
-          ELECTRON_RESULT: ${{ needs.electron-e2e.result }}
-          FULL_REQUIRED: ${{ needs.classify.outputs.full_required }}
-          LANDING_ONLY: ${{ needs.classify.outputs.landing_only }}
-          MIGRATION: ${{ needs.classify.outputs.migration }}
-          MIGRATION_RESULT: ${{ needs.rust-migration.result }}
-          RUNTIME: ${{ needs.classify.outputs.runtime }}
-          RUNTIME_RESULT: ${{ needs.runtime-contracts.result }}
-          RUST: ${{ needs.classify.outputs.rust }}
-          RUST_RESULT: ${{ needs.rust-pr.result }}
-          RELEASE_METADATA: ${{ needs.classify.outputs.release_metadata }}
-          RELEASE_TRANSITION_RESULT: ${{ needs.release-transition.result }}
-          STATIC_RESULT: ${{ needs.static-contracts.result }}
-          STRESS_RELEVANT: ${{ needs.classify.outputs.stress_relevant }}
-          STRESS_RESULT: ${{ needs.stress-tests.result }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          require_success() {
-            local name="$1"
-            local result="$2"
-            if [[ "${result}" != "success" ]]; then
-              echo "${name} finished with ${result}; expected success." >&2
-              exit 1
-            fi
-          }
-          require_success classify "${CLASSIFY_RESULT}"
-          if [[ "${RELEASE_METADATA}" == "true" ]]; then
-            require_success release-transition "${RELEASE_TRANSITION_RESULT}"
-            exit 0
-          fi
-          if [[ "${DOCS_ONLY}" != "true" ]]; then
-            require_success static-contracts "${STATIC_RESULT}"
-          fi
-          if [[ "${APP}" == "true" ]]; then
-            require_success app-tests "${APP_TESTS_RESULT}"
-          fi
-          if [[ "${APP}" == "true" && ( "${RUST}" == "true" || "${FULL_REQUIRED}" == "true" ) ]]; then
-            require_success rust-fast "${RUST_RESULT}"
-          fi
-          if [[ "${APP}" == "true" && "${MIGRATION}" == "true" ]]; then
-            require_success rust-migration "${MIGRATION_RESULT}"
-          fi
-          if [[ "${APP}" == "true" && ( "${STRESS_RELEVANT}" == "true" || "${FULL_REQUIRED}" == "true" ) ]]; then
-            require_success stress-tests "${STRESS_RESULT}"
-          fi
-          if [[ "${APP}" == "true" && ( "${BROWSER}" == "true" || "${FULL_REQUIRED}" == "true" ) ]]; then
-            require_success browser-tests "${BROWSER_RESULT}"
-          fi
-          if [[ "${APP}" == "true" && ( "${ELECTRON_MAIN}" == "true" || "${BROWSER}" == "true" || "${FULL_REQUIRED}" == "true" ) ]]; then
-            require_success electron-e2e "${ELECTRON_RESULT}"
-          fi
-          if [[ "${RUNTIME}" == "true" ]]; then
-            require_success runtime-contracts "${RUNTIME_RESULT}"
-          fi
+          CI_GATE_PLAN_JSON: ${{ needs.classify.outputs.plan }}
+          CI_NEEDS_JSON: ${{ toJSON(needs) }}
+        run: node --no-warnings scripts/ci/verify-required-gates.ts

--- a/config/renderer-worker-count.test.ts
+++ b/config/renderer-worker-count.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import { rendererWorkerCount } from "./renderer-worker-count";
+
+describe("renderer test worker selection", () => {
+  test("uses every GitHub Linux CPU for the normal CI tier", () => {
+    expect(rendererWorkerCount({ ci: true, stress: false })).toBe(4);
+  });
+
+  test("keeps the local default and serialized stress tier", () => {
+    expect(rendererWorkerCount({ ci: false, stress: false })).toBe(2);
+    expect(rendererWorkerCount({ ci: true, stress: true })).toBe(1);
+  });
+});

--- a/config/renderer-worker-count.ts
+++ b/config/renderer-worker-count.ts
@@ -1,0 +1,10 @@
+export const rendererWorkerCount = ({
+  ci,
+  stress,
+}: {
+  readonly ci: boolean;
+  readonly stress: boolean;
+}): number => {
+  if (stress) return 1;
+  return ci ? 4 : 2;
+};

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -35,6 +35,11 @@ unselected jobs are allowed to be skipped. A manual `workflow_dispatch` with
 `full=true` selects every ordinary PR gate. It does not promote the Rust job to
 the exhaustive Main tier.
 
+The classifier and final aggregators intentionally run before dependency setup
+with the runner's native Node 22 TypeScript stripping. Their relative
+TypeScript imports must include the `.ts` extension; `tsconfig.node.json`
+enables extension rewriting so the same entrypoints remain typecheck-safe.
+
 ## Parallel feedback topology
 
 `.github/workflows/_app-tests.yml` runs unit, CoreClient, Main, renderer, and

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -90,6 +90,11 @@ runner's system dependencies with Playwright's installer.
 ## Electron E2E isolation
 
 The E2E config uses two workers in CI while keeping `fullyParallel: false`.
+The functional Electron smoke suite opts its independent fresh-Profile
+scenarios into Playwright's parallel describe mode, so the large source file no
+longer collapses those workers into one serial lane. Tests tagged
+`@performance` are excluded from PR and Main functional E2E and are selected
+only by `pnpm run test:e2e:performance` in Performance CI.
 Each Electron scenario creates a disposable Profile under the operating
 system's owned temporary namespace. That Profile supplies its own `NODEX_HOME`,
 Core Unix socket, Electron user-data/session directories, workspace, agent home,

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -8,8 +8,11 @@ continuously exercised.
 ## Workflow tiers
 
 - `.github/workflows/ci.yml` runs on pull requests and owns the stable
-  `required` check. It selects Rust, migration, application, browser, Electron,
-  stress, and runtime gates from `scripts/ci/classify-change.ts`.
+  `required` check. `scripts/ci/classify-change.ts` returns one typed gate plan
+  containing the selected static groups, application suites, Rust, migration,
+  browser, Electron, stress, and runtime owners. The final job derives its
+  required jobs from that same plan and fails if a selected job is skipped,
+  cancelled, or failed.
 - An exact four-file stable release transition (`CHANGELOG.md`, `Cargo.lock`,
   `Cargo.toml`, and `package.json`) is a narrow CI mode: classification skips
   the application gates and `release transition` validates the semantic version
@@ -18,7 +21,9 @@ continuously exercised.
   Release workflow builds the signed application.
 - `.github/workflows/ci-main.yml` runs the complete static, runtime, Rust, app,
   browser, stress, and Electron non-performance suite after changes land on
-  `main`.
+  `main`. Main runs are exhaustive but may execute concurrently; the production
+  `Release` workflow owns release serialization through its `release-main`
+  concurrency group.
 - `.github/workflows/ci-nightly.yml` repeats the ignored-test, stress, and
   Electron suites. Its E2E matrix is an intentionally asynchronous
   soak signal, not a second pull-request merge requirement.
@@ -27,14 +32,36 @@ continuously exercised.
 
 The PR workflow fails closed: every selected job must finish successfully;
 unselected jobs are allowed to be skipped. A manual `workflow_dispatch` with
-`full=true` selects every PR gate.
+`full=true` selects every ordinary PR gate. It does not promote the Rust job to
+the exhaustive Main tier.
+
+## Parallel feedback topology
+
+`.github/workflows/_app-tests.yml` runs unit, CoreClient, Main, renderer, and
+integration suites as independent matrix cells. The integration cell builds
+its own Core test support instead of depending on a preceding suite. Renderer
+tests use four fork workers in CI, two locally, and one in the stress tier.
+
+`.github/workflows/_static-checks.yml` runs typed JavaScript checks, UI
+contracts, CI contracts, repository contracts, generated resources, and the
+landing build as independently selectable matrix cells. `pnpm run
+verify:static` remains the complete local command and also runs generated Core
+protocol verification. In CI that protocol command belongs to the Rust fast
+job on PRs and the Rust quality job on Main so it can share Rust setup and
+compiler cache.
+
+Changing CI orchestration or manually selecting `full` activates every
+ordinary PR job, but `core:test:pr` remains the only ordinary PR Rust command.
+The exhaustive workspace and Store-migration suites remain separate parallel
+jobs in Main CI. This separation means broad gate selection cannot accidentally
+turn a workflow-only PR into the slowest Rust tier.
 
 ## Canonical Rust commands
 
 Project-specific test semantics live in `package.json`, not in workflow YAML:
 
 - `pnpm run core:test:pr` runs the ordinary Rust suite through cargo-nextest
-  plus doctests.
+  plus doctests. It is the only ordinary PR Rust test tier.
 - `pnpm run core:test:full` runs the ordinary workspace suite and the complete
   supported Store-baseline migration layer.
 - `pnpm run core:test:migration` verifies fresh/current Store preparation, the
@@ -85,5 +112,20 @@ pnpm exec tsx scripts/ci/run-timed.ts \
 
 The helper appends JSONL records to `.generated/ci-timings/<job>.jsonl` and,
 when `GITHUB_STEP_SUMMARY` is available, adds a duration table to the job
-summary. Use repeated warm and cold-ish runs before changing tiers, worker
-counts, runner sizes, or artifact topology.
+summary. Records include the non-sensitive Actions run id, attempt, job, and
+SHA when available.
+
+Use the read-only historical report for workflow-level wall time, queue delay,
+and summed runner-minutes:
+
+```bash
+pnpm run ci:report-timings -- \
+  --workflow CI \
+  --limit 20 \
+  --output notes.local/ci-timings.json
+```
+
+The report deduplicates run attempts and computes nearest-rank p50/p90 only
+from successful first attempts; failures and cancellations remain visible as
+separate outcome counts. Use repeated comparable runs before changing tiers,
+worker counts, runner sizes, or artifact topology.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -46,6 +46,9 @@ enables extension rewriting so the same entrypoints remain typecheck-safe.
 integration suites as independent matrix cells. The integration cell builds
 its own Core test support instead of depending on a preceding suite. Renderer
 tests use four fork workers in CI, two locally, and one in the stress tier.
+Rust compiler-cache variables stay scoped to Rust-bearing steps: every cell
+prepares build-resource metadata, while unit and renderer intentionally skip
+the Rust and sccache setup action.
 
 `.github/workflows/_static-checks.yml` runs typed JavaScript checks, UI
 contracts, CI contracts, repository contracts, generated resources, and the
@@ -67,6 +70,8 @@ Project-specific test semantics live in `package.json`, not in workflow YAML:
 
 - `pnpm run core:test:pr` runs the ordinary Rust suite through cargo-nextest
   plus doctests. It is the only ordinary PR Rust test tier.
+- `pnpm run core:test:workspace` runs the exhaustive Rust workspace suite as a
+  separate parallel Main CI job.
 - `pnpm run core:test:full` runs the ordinary workspace suite and the complete
   supported Store-baseline migration layer.
 - `pnpm run core:test:migration` verifies fresh/current Store preparation, the

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -188,9 +188,10 @@ lockfiles only: CI derives third-party notices and their build-resource
 manifest in `.generated/build-resources/`, verifies two independent staging
 builds, and does not ask the bot branch to commit generated output.
 CI also classifies dependency-only changes as GitHub Actions, Rust, ordinary
-JavaScript, or editor dependencies for later matrix tuning; the first rollout
-keeps the existing full application/runtime coverage so classification cannot
-hide a dependency regression. The exact four-file stable release transition is
+JavaScript, or editor dependencies and maps them to explicit fail-closed gate
+plans. Broad dependency and orchestration changes select every relevant
+ordinary PR gate without promoting Rust to the exhaustive Main-only tier. The
+exact four-file stable release transition is
 the deliberate exception: its PR runs only the classifier and semantic release
 transition guard; the protected-main Main CI and production Release workflow
 still provide the post-merge source and signed-distribution gates.
@@ -371,11 +372,16 @@ successful protected-main CI run on that commit is the release trigger.
 
 ## Automatic production path
 
-The successful `CI` workflow for the main push wakes `Release` through
+The successful `Main CI` workflow for a main push wakes `Release` through
 `workflow_run`. Before repository code or secrets are used, it validates the
 triggering repository, `push` event, `main` branch, successful conclusion, and
 source reachability. It checks the commit has one parent and asks the Release
 Module to classify that parent-to-head transition.
+
+Main CI runs may overlap so a newer source push does not add an entire CI run
+to an older commit's queue. Release executions remain serialized by the
+`release-main` concurrency group, and each execution validates and publishes
+only its triggering Main CI source SHA.
 
 An ordinary main commit returns `shouldRelease: false` and exits successfully.
 A valid version transition runs this sequence:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:renderer": "vitest run --config vitest.renderer.config.ts",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:integration": "node scripts/run-vitest-in-electron.mjs --config vitest.integration.config.ts",
+    "test:integration:ci": "pnpm --silent run core:test-support:build:dev && pnpm run test:integration",
     "test:unit:stress": "NODEX_TEST_TIER=stress vitest run --config vitest.node.config.ts",
     "test:main:stress": "pnpm --silent run core:test-support:build:dev && NODEX_TEST_TIER=stress node scripts/run-vitest-in-electron.mjs --config vitest.main.config.ts",
     "test:renderer:stress": "NODEX_TEST_TIER=stress vitest run --config vitest.renderer.config.ts",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "release:verify:bundle": "tsx scripts/release/cli.ts verify-bundle",
     "release:verify:remote": "tsx scripts/release/cli.ts verify-remote",
     "browser-runtime:publish": "tsx scripts/release/cli.ts publish-browser-runtime",
-    "ci:workflow-contracts": "tsx scripts/ci/verify-reusable-workflow-secrets.ts",
+    "ci:workflow-contracts": "tsx scripts/ci/verify-reusable-workflow-secrets.ts && tsx scripts/ci/verify-ci-matrix-contracts.ts",
     "ci:stress-workflow-contracts": "tsx scripts/ci/verify-stress-workflow-contracts.ts",
     "ci:verify-ignored-rust-tests": "tsx scripts/ci/verify-ignored-rust-tests.ts",
     "ci:report-timings": "tsx scripts/ci/report-actions-timings.ts",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "ci:workflow-contracts": "tsx scripts/ci/verify-reusable-workflow-secrets.ts",
     "ci:stress-workflow-contracts": "tsx scripts/ci/verify-stress-workflow-contracts.ts",
     "ci:verify-ignored-rust-tests": "tsx scripts/ci/verify-ignored-rust-tests.ts",
+    "ci:report-timings": "tsx scripts/ci/report-actions-timings.ts",
     "verify:icons": "tsx scripts/ci/verify-icon-boundaries.ts",
     "dev": "tsx scripts/dev-launcher.ts",
     "build": "pnpm --silent run appshot-helper:build:dev && tsx scripts/prepared-electron-build.ts build",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:complete": "pnpm test && pnpm run test:stress",
     "test:e2e": "pnpm run core:binaries:build:dev && pnpm run build && playwright test --config playwright.e2e.config.ts",
     "test:e2e:subscription": "pnpm run core:binaries:build:dev && pnpm run build && playwright test --config playwright.subscription.e2e.config.ts",
-    "test:e2e:performance": "pnpm run core:binaries:build:dev && pnpm run build && playwright test --config playwright.e2e.config.ts --grep 'keeps representative large-content surfaces bounded|keeps Page ready and idle CPU bounded with 14k LocalCommit history|measures high-pressure nested Block transfer into a populated Board|keeps production-scale Database context menus inside the interaction budget'",
+    "test:e2e:performance": "pnpm run core:binaries:build:dev && pnpm run build && NODEX_E2E_INCLUDE_PERFORMANCE=1 playwright test --config playwright.e2e.config.ts --grep 'keeps representative large-content surfaces bounded|keeps Page ready and idle CPU bounded with 14k LocalCommit history|measures high-pressure nested Block transfer into a populated Board|keeps production-scale Database context menus inside the interaction budget'",
     "test:performance": "pnpm run core:benchmark:rust && pnpm run test:e2e:performance",
     "test:all": "pnpm run verify:source",
     "test:watch": "vitest --config vitest.node.config.ts",

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -11,6 +11,10 @@ export const baseElectronE2eConfig = defineConfig({
   },
 });
 
+const excludedElectronTests = process.env.NODEX_E2E_INCLUDE_PERFORMANCE === "1"
+  ? /@subscription-quota/
+  : /@performance|@subscription-quota/;
+
 export default defineConfig(baseElectronE2eConfig, {
-  grepInvert: /@subscription-quota/,
+  grepInvert: excludedElectronTests,
 });

--- a/scripts/ci/app-test-suite.test.ts
+++ b/scripts/ci/app-test-suite.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+
+import { APP_TEST_SUITES } from "./ci-gate-plan";
+import { parseAppTestSuite, planAppTestSuite } from "./app-test-suite";
+
+describe("application CI suite planning", () => {
+  test("maps every suite to one canonical package script", () => {
+    expect(APP_TEST_SUITES.map((suite) => [suite, planAppTestSuite(suite)])).toEqual([
+      ["unit", { needsRust: false, needsXvfb: false, packageScript: "test:unit" }],
+      ["core-client", { needsRust: true, needsXvfb: false, packageScript: "test:core-client" }],
+      ["main", { needsRust: true, needsXvfb: true, packageScript: "test:main" }],
+      ["renderer", { needsRust: false, needsXvfb: false, packageScript: "test:renderer" }],
+      ["integration", { needsRust: true, needsXvfb: true, packageScript: "test:integration:ci" }],
+    ]);
+  });
+
+  test("rejects unknown matrix values", () => {
+    expect(() => parseAppTestSuite("surprise")).toThrow("Unknown application test suite");
+  });
+});

--- a/scripts/ci/app-test-suite.ts
+++ b/scripts/ci/app-test-suite.ts
@@ -1,0 +1,55 @@
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+
+import { APP_TEST_SUITES, type AppTestSuite } from "./ci-gate-plan";
+
+export interface AppTestSuitePlan {
+  readonly needsRust: boolean;
+  readonly needsXvfb: boolean;
+  readonly packageScript: string;
+}
+
+const SUITE_PLANS: Readonly<Record<AppTestSuite, AppTestSuitePlan>> = {
+  "core-client": { needsRust: true, needsXvfb: false, packageScript: "test:core-client" },
+  integration: { needsRust: true, needsXvfb: true, packageScript: "test:integration:ci" },
+  main: { needsRust: true, needsXvfb: true, packageScript: "test:main" },
+  renderer: { needsRust: false, needsXvfb: false, packageScript: "test:renderer" },
+  unit: { needsRust: false, needsXvfb: false, packageScript: "test:unit" },
+};
+
+export const planAppTestSuite = (suite: AppTestSuite): AppTestSuitePlan => SUITE_PLANS[suite];
+
+export const parseAppTestSuite = (value: string): AppTestSuite => {
+  if ((APP_TEST_SUITES as readonly string[]).includes(value)) return value as AppTestSuite;
+  throw new Error(`Unknown application test suite: ${JSON.stringify(value)}.`);
+};
+
+const readOption = (args: readonly string[], name: string): string | undefined => {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}.`);
+  return value;
+};
+
+const main = (): void => {
+  const suite = parseAppTestSuite(readOption(process.argv.slice(2), "--suite") ?? "");
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) throw new Error("GITHUB_OUTPUT is required.");
+  const suitePlan = planAppTestSuite(suite);
+  appendFileSync(output, [
+    `needs_rust=${suitePlan.needsRust}`,
+    `needs_xvfb=${suitePlan.needsXvfb}`,
+    `package_script=${suitePlan.packageScript}`,
+    "",
+  ].join("\n"), "utf8");
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/ci-gate-plan.test.ts
+++ b/scripts/ci/ci-gate-plan.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  APP_TEST_SUITES,
+  assertCiGatePlan,
+  requiredJobIdsForGatePlan,
+  STATIC_GROUPS,
+  type CiGatePlan,
+} from "./ci-gate-plan";
+
+const fullPlan: CiGatePlan = {
+  allGates: true,
+  appTestSuites: APP_TEST_SUITES,
+  browser: true,
+  dependencyKind: "source",
+  docsOnly: false,
+  electronE2e: true,
+  landingOnly: false,
+  protocolContracts: true,
+  releaseTransition: false,
+  runtimeMac: true,
+  rustFast: true,
+  rustMigration: true,
+  staticGroups: STATIC_GROUPS,
+  stress: true,
+};
+
+describe("CI gate plan contract", () => {
+  test("derives every required workflow job from the full plan", () => {
+    expect(requiredJobIdsForGatePlan(fullPlan)).toEqual([
+      "static-contracts",
+      "app-tests",
+      "rust-pr",
+      "rust-migration",
+      "stress-tests",
+      "browser-tests",
+      "electron-e2e",
+      "runtime-contracts",
+    ]);
+  });
+
+  test("rejects unknown fields and protocol plans without a Rust owner", () => {
+    expect(() => assertCiGatePlan({ ...fullPlan, surprise: true })).toThrow("unknown fields");
+    expect(() => assertCiGatePlan({ ...fullPlan, rustFast: false })).toThrow("execution owner");
+  });
+
+  test("keeps release transition isolated from ordinary jobs", () => {
+    expect(requiredJobIdsForGatePlan({ ...fullPlan, releaseTransition: true }))
+      .toEqual(["release-transition"]);
+    expect(() => assertCiGatePlan({ ...fullPlan, releaseTransition: true })).toThrow("ordinary gates");
+  });
+});

--- a/scripts/ci/ci-gate-plan.ts
+++ b/scripts/ci/ci-gate-plan.ts
@@ -1,0 +1,178 @@
+export const STATIC_GROUPS = [
+  "types",
+  "ui-contracts",
+  "ci-contracts",
+  "repository-contracts",
+  "generated",
+  "landing",
+] as const;
+
+export type StaticGroup = typeof STATIC_GROUPS[number];
+
+export const APP_TEST_SUITES = [
+  "unit",
+  "core-client",
+  "main",
+  "renderer",
+  "integration",
+] as const;
+
+export type AppTestSuite = typeof APP_TEST_SUITES[number];
+
+export type DependencyKind =
+  | "editor"
+  | "github-actions"
+  | "javascript"
+  | "none"
+  | "rust"
+  | "source";
+
+export interface CiGatePlan {
+  readonly allGates: boolean;
+  readonly appTestSuites: readonly AppTestSuite[];
+  readonly browser: boolean;
+  readonly dependencyKind: DependencyKind;
+  readonly docsOnly: boolean;
+  readonly electronE2e: boolean;
+  readonly landingOnly: boolean;
+  readonly protocolContracts: boolean;
+  readonly releaseTransition: boolean;
+  readonly runtimeMac: boolean;
+  readonly rustFast: boolean;
+  readonly rustMigration: boolean;
+  readonly staticGroups: readonly StaticGroup[];
+  readonly stress: boolean;
+}
+
+const PLAN_KEYS = [
+  "allGates",
+  "appTestSuites",
+  "browser",
+  "dependencyKind",
+  "docsOnly",
+  "electronE2e",
+  "landingOnly",
+  "protocolContracts",
+  "releaseTransition",
+  "runtimeMac",
+  "rustFast",
+  "rustMigration",
+  "staticGroups",
+  "stress",
+] as const satisfies readonly (keyof CiGatePlan)[];
+
+const DEPENDENCY_KINDS = new Set<DependencyKind>([
+  "editor",
+  "github-actions",
+  "javascript",
+  "none",
+  "rust",
+  "source",
+]);
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const assertExactKeys = (value: Readonly<Record<string, unknown>>): void => {
+  const expected = new Set<string>(PLAN_KEYS);
+  const unknown = Object.keys(value).filter((key) => !expected.has(key));
+  const missing = PLAN_KEYS.filter((key) => !Object.hasOwn(value, key));
+  if (unknown.length > 0) throw new Error(`CI gate plan has unknown fields: ${unknown.join(", ")}.`);
+  if (missing.length > 0) throw new Error(`CI gate plan is missing fields: ${missing.join(", ")}.`);
+};
+
+function assertBoolean(value: unknown, name: keyof CiGatePlan): asserts value is boolean {
+  if (typeof value !== "boolean") throw new Error(`CI gate plan ${name} must be boolean.`);
+}
+
+function assertEnumArray<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  name: keyof CiGatePlan,
+): asserts value is readonly T[] {
+  const allowedValues = new Set<string>(allowed);
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string" && allowedValues.has(entry))) {
+    throw new Error(`CI gate plan ${name} contains an unsupported value.`);
+  }
+  if (new Set(value).size !== value.length) {
+    throw new Error(`CI gate plan ${name} must not contain duplicates.`);
+  }
+}
+
+const hasOrdinaryGates = (plan: CiGatePlan): boolean =>
+  plan.staticGroups.length > 0
+  || plan.appTestSuites.length > 0
+  || plan.protocolContracts
+  || plan.rustFast
+  || plan.rustMigration
+  || plan.stress
+  || plan.browser
+  || plan.electronE2e
+  || plan.runtimeMac;
+
+export function assertCiGatePlan(value: unknown): asserts value is CiGatePlan {
+  if (!isRecord(value)) throw new Error("CI gate plan must be an object.");
+  assertExactKeys(value);
+  for (const key of [
+    "allGates",
+    "browser",
+    "docsOnly",
+    "electronE2e",
+    "landingOnly",
+    "protocolContracts",
+    "releaseTransition",
+    "runtimeMac",
+    "rustFast",
+    "rustMigration",
+    "stress",
+  ] as const) {
+    assertBoolean(value[key], key);
+  }
+  assertEnumArray(value.appTestSuites, APP_TEST_SUITES, "appTestSuites");
+  assertEnumArray(value.staticGroups, STATIC_GROUPS, "staticGroups");
+  if (typeof value.dependencyKind !== "string" || !DEPENDENCY_KINDS.has(value.dependencyKind as DependencyKind)) {
+    throw new Error("CI gate plan dependencyKind is unsupported.");
+  }
+  const candidate = value as unknown as CiGatePlan;
+  const narrowModes = [candidate.docsOnly, candidate.landingOnly, candidate.releaseTransition].filter(Boolean);
+  if (narrowModes.length > 1) throw new Error("CI gate plan narrow modes are mutually exclusive.");
+  if (candidate.protocolContracts && !candidate.rustFast) {
+    throw new Error("Protocol contracts require the Rust fast job as their execution owner.");
+  }
+  if ((candidate.docsOnly || candidate.releaseTransition) && hasOrdinaryGates(candidate)) {
+    throw new Error("Docs-only and release-transition plans must not select ordinary gates.");
+  }
+  if (candidate.landingOnly && (
+    candidate.staticGroups.length !== 1
+    || candidate.staticGroups[0] !== "landing"
+    || candidate.appTestSuites.length > 0
+    || candidate.protocolContracts
+    || candidate.rustFast
+    || candidate.rustMigration
+    || candidate.stress
+    || candidate.browser
+    || candidate.electronE2e
+    || candidate.runtimeMac
+  )) {
+    throw new Error("Landing-only plans may select only the landing static group.");
+  }
+}
+
+export const parseCiGatePlan = (value: unknown): CiGatePlan => {
+  assertCiGatePlan(value);
+  return value;
+};
+
+export const requiredJobIdsForGatePlan = (plan: CiGatePlan): readonly string[] => {
+  if (plan.releaseTransition) return ["release-transition"];
+  const jobs: string[] = [];
+  if (plan.staticGroups.length > 0) jobs.push("static-contracts");
+  if (plan.appTestSuites.length > 0) jobs.push("app-tests");
+  if (plan.rustFast) jobs.push("rust-pr");
+  if (plan.rustMigration) jobs.push("rust-migration");
+  if (plan.stress) jobs.push("stress-tests");
+  if (plan.browser) jobs.push("browser-tests");
+  if (plan.electronE2e) jobs.push("electron-e2e");
+  if (plan.runtimeMac) jobs.push("runtime-contracts");
+  return jobs;
+};

--- a/scripts/ci/classify-change.test.ts
+++ b/scripts/ci/classify-change.test.ts
@@ -108,12 +108,19 @@ describe("CI change classification", () => {
   });
 
   test("routes each local action to its real consumers", () => {
-    expect(classifyChangedPaths([".github/actions/run-stress-tests/action.yml"]))
+    expect(classifyChangedPaths([
+      ".github/actions/run-stress-tests/action.yml",
+      ".github/actions/run-stress-tests/scripts/prepare.sh",
+    ]))
       .toMatchObject({ browser: false, rustFast: false, stress: true });
     expect(classifyChangedPaths([".github/actions/setup-playwright/action.yml"]))
       .toMatchObject({ browser: true, electronE2e: true, rustFast: false, stress: true });
     expect(classifyChangedPaths([".github/actions/setup-rust-ci/action.yml"]))
       .toMatchObject({ protocolContracts: true, runtimeMac: true, rustFast: true });
+    expect(classifyChangedPaths([
+      ".github/actions/setup-playwright/action.yml",
+      ".github/actions/setup-rust-ci/action.yml",
+    ])).toMatchObject({ allGates: true });
   });
 
   test("selects every ordinary gate for orchestration, unknown, empty, and explicit full inputs", () => {

--- a/scripts/ci/classify-change.test.ts
+++ b/scripts/ci/classify-change.test.ts
@@ -1,195 +1,140 @@
 import { describe, expect, test } from "vitest";
+
+import { APP_TEST_SUITES, STATIC_GROUPS } from "./ci-gate-plan";
 import { classifyChangedPaths } from "./classify-change";
 
 describe("CI change classification", () => {
-  test("keeps documentation and landing changes out of expensive application jobs", () => {
+  test("keeps documentation out of every expensive gate", () => {
     expect(classifyChangedPaths(["docs/release-macos.md", "docs/ARCHITECTURE.md"])).toEqual({
-      app: false,
-      dependencyKind: "none",
+      allGates: false,
+      appTestSuites: [],
       browser: false,
+      dependencyKind: "none",
       docsOnly: true,
-      electronMain: false,
-      fullRequired: false,
+      electronE2e: false,
       landingOnly: false,
-      migration: false,
-      protocol: false,
-      releaseMetadata: false,
-      renderer: false,
-      runtime: false,
-      rust: false,
-      storage: false,
-      stressRelevant: false,
+      protocolContracts: false,
+      releaseTransition: false,
+      runtimeMac: false,
+      rustFast: false,
+      rustMigration: false,
+      staticGroups: [],
+      stress: false,
     });
-    expect(classifyChangedPaths(["packages/landing/src/App.tsx"])).toEqual({
-      app: false,
-      dependencyKind: "none",
-      browser: false,
-      docsOnly: false,
-      electronMain: false,
-      fullRequired: false,
+  });
+
+  test("selects only the landing owner for landing plus documentation", () => {
+    expect(classifyChangedPaths(["packages/landing/src/App.tsx", "README.md"])).toMatchObject({
+      appTestSuites: [],
       landingOnly: true,
-      migration: false,
-      protocol: false,
-      releaseMetadata: false,
-      renderer: false,
-      runtime: false,
-      rust: false,
-      storage: false,
-      stressRelevant: false,
+      staticGroups: ["landing"],
     });
   });
 
-  test("routes an exact release metadata set to the narrow release guard", () => {
-    expect(classifyChangedPaths([
-      "Cargo.lock",
-      "Cargo.toml",
-      "CHANGELOG.md",
-      "package.json",
-    ])).toEqual({
-      app: false,
-      dependencyKind: "none",
-      browser: false,
-      docsOnly: false,
-      electronMain: false,
-      fullRequired: false,
-      landingOnly: false,
-      migration: false,
-      protocol: false,
-      releaseMetadata: true,
-      renderer: false,
-      runtime: false,
-      rust: false,
-      storage: false,
-      stressRelevant: false,
-    });
+  test("routes the exact release metadata set to the narrow transition guard", () => {
+    expect(classifyChangedPaths(["Cargo.lock", "Cargo.toml", "CHANGELOG.md", "package.json"]))
+      .toMatchObject({ releaseTransition: true, rustFast: false, staticGroups: [] });
   });
 
-  test("keeps an incomplete release metadata set on the ordinary gates", () => {
-    expect(classifyChangedPaths(["package.json"])).toMatchObject({
-      app: true,
-      fullRequired: true,
-      releaseMetadata: false,
-      runtime: true,
-    });
-    expect(classifyChangedPaths([
-      "Cargo.lock",
-      "Cargo.toml",
-      "CHANGELOG.md",
-      "package.json",
-      "README.md",
-    ])).toMatchObject({
-      app: true,
-      fullRequired: true,
-      releaseMetadata: false,
-      runtime: true,
-    });
-  });
-
-  test("distinguishes ordinary renderer work from runtime contract changes", () => {
+  test("routes ordinary renderer work to app, browser, and Electron without Rust", () => {
     expect(classifyChangedPaths(["src/renderer/components/app.tsx"])).toMatchObject({
-      app: true,
+      appTestSuites: APP_TEST_SUITES,
       browser: true,
-      renderer: true,
-      runtime: false,
-      rust: false,
-      stressRelevant: false,
-    });
-    expect(classifyChangedPaths(["resources/agent-runtime/openinterpreter.lock.json"])).toMatchObject({
-      app: true,
-      fullRequired: false,
-      runtime: true,
-    });
-    expect(classifyChangedPaths(["scripts/release/bundle.ts"])).toMatchObject({
-      app: true,
-      fullRequired: false,
-      runtime: true,
+      electronE2e: true,
+      runtimeMac: false,
+      rustFast: false,
+      staticGroups: ["types", "ui-contracts"],
+      stress: false,
     });
   });
 
-  test("selects deeper contracts for storage, protocol, and desktop changes", () => {
-    expect(classifyChangedPaths(["crates/nodex-core/src/infrastructure/migration.rs"])).toMatchObject({
-      migration: true,
-      protocol: false,
-      rust: true,
-      storage: true,
-      stressRelevant: true,
+  test("routes main, protocol, Rust, and migration ownership explicitly", () => {
+    expect(classifyChangedPaths(["src/main/window.ts"])).toMatchObject({
+      appTestSuites: APP_TEST_SUITES,
+      electronE2e: true,
+      runtimeMac: false,
+      rustFast: false,
+      staticGroups: ["types", "repository-contracts"],
     });
     expect(classifyChangedPaths(["src/main/core-client/core-client.ts"])).toMatchObject({
-      electronMain: true,
-      protocol: true,
-      runtime: true,
-      stressRelevant: true,
+      protocolContracts: true,
+      runtimeMac: true,
+      rustFast: true,
+      stress: true,
     });
+    expect(classifyChangedPaths(["crates/nodex-core/src/database/relation_projection.rs"]))
+      .toMatchObject({ rustFast: true, rustMigration: false, stress: true });
+    expect(classifyChangedPaths(["crates/nodex-core/src/infrastructure/migration.rs"]))
+      .toMatchObject({ rustFast: true, rustMigration: true, stress: true });
+  });
+
+  test("keeps generated-resource ownership separate from Store migration", () => {
     expect(classifyChangedPaths(["scripts/build-resources.ts"])).toMatchObject({
-      migration: false,
-      runtime: true,
-      storage: false,
+      rustMigration: false,
+      runtimeMac: true,
+      staticGroups: ["types", "generated"],
     });
   });
 
-  test("runs stress gates when their shared runtime or selection changes", () => {
+  test("selects stress when test infrastructure changes", () => {
     for (const path of [
       "vitest.main.config.ts",
       "config/vitest-test-tier.ts",
       "config/electron-test-runtime.ts",
       "scripts/run-vitest-in-electron.mjs",
     ]) {
-      expect(classifyChangedPaths([path]), path).toMatchObject({
-        app: true,
-        stressRelevant: true,
-      });
+      expect(classifyChangedPaths([path]), path).toMatchObject({ stress: true });
     }
   });
 
-  test("keeps mixed renderer and Rust changes broad without forcing release gates", () => {
-    expect(classifyChangedPaths([
-      "src/renderer/components/app.tsx",
-      "crates/nodex-core/src/database/relation_projection.rs",
-    ])).toMatchObject({
-      app: true,
-      browser: true,
-      electronMain: false,
-      fullRequired: false,
-      renderer: true,
-      rust: true,
-      stressRelevant: true,
+  test("runs ordinary gates, never exhaustive Rust, for dependency changes", () => {
+    expect(classifyChangedPaths(["package.json", "pnpm-lock.yaml"])).toMatchObject({
+      allGates: false,
+      dependencyKind: "javascript",
+      rustFast: true,
+      rustMigration: true,
+      staticGroups: STATIC_GROUPS,
     });
-  });
-
-  test("identifies dependency-only scopes without weakening the current gates", () => {
-    expect(classifyChangedPaths([".github/workflows/ci.yml"]).dependencyKind)
-      .toBe("github-actions");
-    expect(classifyChangedPaths([".github/actions/setup-rust-ci/action.yml"]).dependencyKind)
-      .toBe("github-actions");
-    expect(classifyChangedPaths(["Cargo.lock", "crates/nodex-core/Cargo.toml"]).dependencyKind)
-      .toBe("rust");
-    expect(classifyChangedPaths(["package.json", "pnpm-lock.yaml"]).dependencyKind)
-      .toBe("javascript");
+    expect(classifyChangedPaths(["Cargo.lock", "crates/nodex-core/Cargo.toml"]))
+      .toMatchObject({
+        dependencyKind: "rust",
+        rustFast: true,
+        rustMigration: true,
+      });
     expect(classifyChangedPaths([
       "third_party/blocknote/packages/core/package.json",
       "pnpm-lock.yaml",
-    ]).dependencyKind).toBe("editor");
+    ])).toMatchObject({ dependencyKind: "editor" });
   });
 
-  test("chooses the stronger gate for unknown, empty, and explicit full inputs", () => {
-    expect(classifyChangedPaths(["novel-build-input.xyz"])).toMatchObject({
-      app: true,
-      fullRequired: true,
-      runtime: true,
-    });
-    expect(classifyChangedPaths([])).toMatchObject({ app: true, fullRequired: true, runtime: true });
-    expect(classifyChangedPaths(["README.md"], { full: true })).toMatchObject({
-      app: true,
-      fullRequired: true,
-      runtime: true,
-    });
+  test("routes each local action to its real consumers", () => {
+    expect(classifyChangedPaths([".github/actions/run-stress-tests/action.yml"]))
+      .toMatchObject({ browser: false, rustFast: false, stress: true });
+    expect(classifyChangedPaths([".github/actions/setup-playwright/action.yml"]))
+      .toMatchObject({ browser: true, electronE2e: true, rustFast: false, stress: true });
+    expect(classifyChangedPaths([".github/actions/setup-rust-ci/action.yml"]))
+      .toMatchObject({ protocolContracts: true, runtimeMac: true, rustFast: true });
   });
 
-  test("treats CI policy files as broad changes", () => {
-    expect(classifyChangedPaths([".github/workflows/ci.yml"])).toMatchObject({
-      fullRequired: true,
-      runtime: true,
-    });
+  test("selects every ordinary gate for orchestration, unknown, empty, and explicit full inputs", () => {
+    for (const candidate of [
+      classifyChangedPaths([".github/workflows/ci.yml"]),
+      classifyChangedPaths(["scripts/ci/classify-change.ts"]),
+      classifyChangedPaths(["novel-build-input.xyz"]),
+      classifyChangedPaths([]),
+      classifyChangedPaths(["README.md"], { full: true }),
+    ]) {
+      expect(candidate).toMatchObject({
+        allGates: true,
+        appTestSuites: APP_TEST_SUITES,
+        browser: true,
+        protocolContracts: true,
+        rustFast: true,
+        rustMigration: true,
+        staticGroups: STATIC_GROUPS,
+        stress: true,
+      });
+    }
   });
 
   test("rejects paths that escape the repository", () => {

--- a/scripts/ci/classify-change.ts
+++ b/scripts/ci/classify-change.ts
@@ -209,14 +209,14 @@ const githubActionPlan = (paths: readonly string[]): CiGatePlan => {
   if (paths.some((path) => path.startsWith(".github/workflows/"))) {
     return allGatesPlan("github-actions");
   }
-  if (paths.every((path) => path === ".github/actions/run-stress-tests/action.yml")) {
+  if (paths.every((path) => path.startsWith(".github/actions/run-stress-tests/"))) {
     return createPlan({
       dependencyKind: "github-actions",
       staticGroups: ["ci-contracts"],
       stress: true,
     });
   }
-  if (paths.every((path) => path === ".github/actions/setup-playwright/action.yml")) {
+  if (paths.every((path) => path.startsWith(".github/actions/setup-playwright/"))) {
     return createPlan({
       browser: true,
       dependencyKind: "github-actions",
@@ -225,7 +225,7 @@ const githubActionPlan = (paths: readonly string[]): CiGatePlan => {
       stress: true,
     });
   }
-  if (paths.every((path) => path === ".github/actions/setup-rust-ci/action.yml")) {
+  if (paths.every((path) => path.startsWith(".github/actions/setup-rust-ci/"))) {
     return createPlan({
       appTestSuites: APP_TEST_SUITES,
       dependencyKind: "github-actions",

--- a/scripts/ci/classify-change.ts
+++ b/scripts/ci/classify-change.ts
@@ -3,34 +3,26 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export interface ChangeClassification {
-  readonly app: boolean;
-  readonly dependencyKind: "editor" | "github-actions" | "javascript" | "none" | "rust" | "source";
-  readonly browser: boolean;
-  readonly docsOnly: boolean;
-  readonly electronMain: boolean;
-  readonly fullRequired: boolean;
-  readonly landingOnly: boolean;
-  readonly migration: boolean;
-  readonly protocol: boolean;
-  readonly releaseMetadata: boolean;
-  readonly renderer: boolean;
-  readonly rust: boolean;
-  readonly runtime: boolean;
-  readonly storage: boolean;
-  readonly stressRelevant: boolean;
-}
+import {
+  APP_TEST_SUITES,
+  assertCiGatePlan,
+  STATIC_GROUPS,
+  type CiGatePlan,
+  type DependencyKind,
+  type StaticGroup,
+} from "./ci-gate-plan";
 
-const RELEASE_PATHS = new Set([
-  "Cargo.lock",
-  "Cargo.toml",
-  "CHANGELOG.md",
-  "package.json",
-]);
+export type {
+  AppTestSuite,
+  CiGatePlan,
+  DependencyKind,
+  StaticGroup,
+} from "./ci-gate-plan";
+
+const RELEASE_PATHS = new Set(["Cargo.lock", "Cargo.toml", "CHANGELOG.md", "package.json"]);
 
 const isDocumentationPath = (path: string): boolean =>
   path === "AGENTS.md"
-  || path === "docs/ARCHITECTURE.md"
   || path === "CONTEXT.md"
   || path.endsWith(".md")
   || path.startsWith("docs/");
@@ -46,14 +38,11 @@ const isRuntimePath = (path: string): boolean =>
   || path === "package.json"
   || path === "pnpm-lock.yaml"
   || path === "rust-toolchain.toml"
-  || path.startsWith(".github/workflows/")
-  || path.startsWith(".github/actions/")
   || path.startsWith("crates/")
   || path.startsWith("packages/codex-app-server-protocol/")
   || path.startsWith("resources/agent-runtime/")
   || path.startsWith("resources/browser-runtime/")
   || path.startsWith("resources/macos/")
-  || path.startsWith("scripts/ci/")
   || path === "scripts/build-resources.ts"
   || path === "scripts/generate-third-party-notices.ts"
   || path.startsWith("scripts/release/")
@@ -68,7 +57,7 @@ const isRendererPath = (path: string): boolean =>
   path.startsWith("src/renderer/")
   || path.startsWith("packages/storybook/")
   || path.startsWith("src/shared/")
-  || path.startsWith("config/renderer-vite")
+  || path.startsWith("config/renderer-")
   || path.startsWith("vitest.renderer")
   || path.startsWith("vitest.browser");
 
@@ -131,22 +120,20 @@ const isStressRelevantPath = (path: string): boolean =>
   || path.startsWith("src/main/core-client/")
   || path.startsWith("src/main/codex/");
 
-const isFullRequiredPath = (path: string): boolean =>
-  RELEASE_PATHS.has(path)
-  || path === "pnpm-lock.yaml"
-  || path === "rust-toolchain.toml"
-  || path.startsWith(".github/workflows/")
-  || path.startsWith(".github/actions/")
-  || path.startsWith("scripts/ci/");
+const isGeneratedResourcePath = (path: string): boolean =>
+  path === "scripts/build-resources.ts"
+  || path === "scripts/generate-third-party-notices.ts"
+  || path === "src/shared/build-resources.ts"
+  || path.startsWith("resources/");
 
 const isKnownAppPath = (path: string): boolean =>
   path.startsWith("src/")
-  || path.startsWith("packages/storybook/")
+  || path.startsWith("packages/")
+  || path.startsWith("third_party/")
   || path.startsWith("scripts/")
   || path.startsWith("resources/")
   || path.startsWith("crates/")
   || path.startsWith(".config/")
-  || path.startsWith(".github/")
   || path.startsWith("playwright")
   || path.startsWith("vitest")
   || path.startsWith("tsconfig")
@@ -154,33 +141,24 @@ const isKnownAppPath = (path: string): boolean =>
   || path === "electron-builder.yml"
   || path === "pnpm-workspace.yaml";
 
-const isGitHubActionPath = (path: string): boolean =>
-  path.startsWith(".github/workflows/")
-  || path.startsWith(".github/actions/");
+const isGitHubPath = (path: string): boolean => path.startsWith(".github/");
 
 const isRustDependencyPath = (path: string): boolean =>
   path === "Cargo.lock"
   || path === "Cargo.toml"
-  || (/^crates\/[^/]+\/Cargo\.toml$/u.test(path));
+  || /^crates\/[^/]+\/Cargo\.toml$/u.test(path);
 
 const isJavaScriptDependencyPath = (path: string): boolean =>
   path === "package.json"
   || path === "pnpm-lock.yaml"
   || /^(?:packages|third_party\/blocknote\/packages)\/[^/]+\/package\.json$/u.test(path);
 
-const isEditorDependencyPath = (path: string): boolean =>
-  path.startsWith("third_party/blocknote/") && path.endsWith("/package.json");
-
-const dependencyKindFor = (
-  paths: readonly string[],
-): ChangeClassification["dependencyKind"] => {
+const dependencyKindFor = (paths: readonly string[]): DependencyKind => {
   if (paths.length === 0) return "source";
-  if (paths.every(isGitHubActionPath)) return "github-actions";
+  if (paths.every(isGitHubPath)) return "github-actions";
   if (paths.every(isRustDependencyPath)) return "rust";
-  if (paths.every(isJavaScriptDependencyPath)) {
-    return paths.some(isEditorDependencyPath) ? "editor" : "javascript";
-  }
-  return "none";
+  if (!paths.every(isJavaScriptDependencyPath)) return "none";
+  return paths.some((path) => path.startsWith("third_party/blocknote/")) ? "editor" : "javascript";
 };
 
 const normalizePath = (value: string): string => {
@@ -191,62 +169,148 @@ const normalizePath = (value: string): string => {
   return path.replace(/^\.\//u, "");
 };
 
+const createPlan = (overrides: Partial<CiGatePlan>): CiGatePlan => {
+  const candidate: CiGatePlan = {
+    allGates: false,
+    appTestSuites: [],
+    browser: false,
+    dependencyKind: "none",
+    docsOnly: false,
+    electronE2e: false,
+    landingOnly: false,
+    protocolContracts: false,
+    releaseTransition: false,
+    runtimeMac: false,
+    rustFast: false,
+    rustMigration: false,
+    staticGroups: [],
+    stress: false,
+    ...overrides,
+  };
+  assertCiGatePlan(candidate);
+  return candidate;
+};
+
+const allGatesPlan = (dependencyKind: DependencyKind, allGates = true): CiGatePlan => createPlan({
+  allGates,
+  appTestSuites: APP_TEST_SUITES,
+  browser: true,
+  dependencyKind,
+  electronE2e: true,
+  protocolContracts: true,
+  runtimeMac: true,
+  rustFast: true,
+  rustMigration: true,
+  staticGroups: STATIC_GROUPS,
+  stress: true,
+});
+
+const githubActionPlan = (paths: readonly string[]): CiGatePlan => {
+  if (paths.some((path) => path.startsWith(".github/workflows/"))) {
+    return allGatesPlan("github-actions");
+  }
+  if (paths.every((path) => path === ".github/actions/run-stress-tests/action.yml")) {
+    return createPlan({
+      dependencyKind: "github-actions",
+      staticGroups: ["ci-contracts"],
+      stress: true,
+    });
+  }
+  if (paths.every((path) => path === ".github/actions/setup-playwright/action.yml")) {
+    return createPlan({
+      browser: true,
+      dependencyKind: "github-actions",
+      electronE2e: true,
+      staticGroups: ["ci-contracts"],
+      stress: true,
+    });
+  }
+  if (paths.every((path) => path === ".github/actions/setup-rust-ci/action.yml")) {
+    return createPlan({
+      appTestSuites: APP_TEST_SUITES,
+      dependencyKind: "github-actions",
+      electronE2e: true,
+      protocolContracts: true,
+      runtimeMac: true,
+      rustFast: true,
+      rustMigration: true,
+      staticGroups: ["ci-contracts", "repository-contracts"],
+      stress: true,
+    });
+  }
+  return allGatesPlan("github-actions");
+};
+
+const sourcePlan = (paths: readonly string[], dependencyKind: DependencyKind): CiGatePlan => {
+  const renderer = paths.some(isRendererPath);
+  const electronMain = paths.some(isElectronMainPath);
+  const rust = paths.some(isRustPath);
+  const migration = paths.some(isMigrationPath);
+  const protocol = paths.some(isProtocolPath);
+  const browser = paths.some(isBrowserPath);
+  const staticGroups = new Set<StaticGroup>(["types"]);
+  if (renderer) staticGroups.add("ui-contracts");
+  if (electronMain || rust || protocol) staticGroups.add("repository-contracts");
+  if (paths.some(isGeneratedResourcePath)) staticGroups.add("generated");
+  return createPlan({
+    appTestSuites: APP_TEST_SUITES,
+    browser,
+    dependencyKind,
+    electronE2e: electronMain || browser,
+    protocolContracts: protocol,
+    runtimeMac: paths.some(isRuntimePath),
+    rustFast: rust || protocol,
+    rustMigration: migration,
+    staticGroups: [...staticGroups],
+    stress: paths.some(isStressRelevantPath),
+  });
+};
+
 export function classifyChangedPaths(
   changedPaths: readonly string[],
   options: { readonly full?: boolean } = {},
-): ChangeClassification {
+): CiGatePlan {
   const paths = [...new Set(changedPaths.map(normalizePath))];
-  if (options.full || paths.length === 0) {
-    return {
-      app: true,
-      dependencyKind: "source",
-      browser: true,
-      docsOnly: false,
-      electronMain: true,
-      fullRequired: true,
-      landingOnly: false,
-      migration: true,
-      protocol: true,
-      releaseMetadata: false,
-      renderer: true,
-      rust: true,
-      runtime: true,
-      storage: true,
-      stressRelevant: true,
-    };
+  if (options.full || paths.length === 0) return allGatesPlan("source");
+
+  const releaseTransition = paths.length === RELEASE_PATHS.size
+    && [...RELEASE_PATHS].every((path) => paths.includes(path));
+  if (releaseTransition) return createPlan({ releaseTransition: true });
+
+  if (paths.every(isDocumentationPath)) return createPlan({ docsOnly: true });
+  const landingOnly = paths.some(isLandingPath)
+    && paths.every((path) => isLandingPath(path) || isDocumentationPath(path));
+  if (landingOnly) return createPlan({ landingOnly: true, staticGroups: ["landing"] });
+
+  const dependencyKind = dependencyKindFor(paths);
+  if (dependencyKind === "github-actions") return githubActionPlan(paths);
+  if (dependencyKind === "javascript" || dependencyKind === "editor") {
+    return allGatesPlan(dependencyKind, false);
+  }
+  if (dependencyKind === "rust") {
+    return createPlan({
+      appTestSuites: APP_TEST_SUITES,
+      dependencyKind,
+      electronE2e: true,
+      protocolContracts: true,
+      runtimeMac: true,
+      rustFast: true,
+      rustMigration: true,
+      staticGroups: ["repository-contracts", "generated"],
+      stress: true,
+    });
   }
 
-  const releaseMetadata = paths.length === RELEASE_PATHS.size
-    && [...RELEASE_PATHS].every((path) => paths.includes(path));
-  const docsOnly = !releaseMetadata && paths.every(isDocumentationPath);
-  const landingOnly = !releaseMetadata && paths.every(isLandingPath);
   const hasUnknownPath = paths.some((path) => (
     !isDocumentationPath(path)
     && !isLandingPath(path)
     && !isKnownAppPath(path)
     && !RELEASE_PATHS.has(path)
   ));
-  const fullRequired = !releaseMetadata
-    && (paths.some(isFullRequiredPath) || hasUnknownPath);
-  const dependencyKind = dependencyKindFor(paths);
-
-  return {
-    app: !releaseMetadata && !docsOnly && !landingOnly,
-    dependencyKind,
-    browser: paths.some(isBrowserPath),
-    docsOnly,
-    electronMain: paths.some(isElectronMainPath),
-    fullRequired,
-    landingOnly,
-    migration: paths.some(isMigrationPath),
-    protocol: paths.some(isProtocolPath),
-    releaseMetadata,
-    renderer: paths.some(isRendererPath),
-    rust: !releaseMetadata && paths.some(isRustPath),
-    runtime: !releaseMetadata && (hasUnknownPath || paths.some(isRuntimePath)),
-    storage: paths.some(isStoragePath),
-    stressRelevant: !releaseMetadata && paths.some(isStressRelevantPath),
-  };
+  if (hasUnknownPath || paths.some((path) => path.startsWith("scripts/ci/"))) {
+    return allGatesPlan(dependencyKind === "none" ? "source" : dependencyKind);
+  }
+  return sourcePlan(paths, dependencyKind);
 }
 
 const readOption = (args: readonly string[], name: string): string | undefined => {
@@ -269,9 +333,9 @@ const main = (): void => {
     stdio: ["ignore", "pipe", "pipe"],
   });
   const paths = output.split("\0").filter(Boolean);
-  const classification = classifyChangedPaths(paths, { full: args.includes("--full") });
+  const gatePlan = classifyChangedPaths(paths, { full: args.includes("--full") });
+  const serialized = `${JSON.stringify({ changedPaths: paths, plan: gatePlan }, null, 2)}\n`;
   const destination = readOption(args, "--output");
-  const serialized = `${JSON.stringify({ ...classification, changedPaths: paths }, null, 2)}\n`;
   if (!destination) {
     process.stdout.write(serialized);
     return;

--- a/scripts/ci/classify-change.ts
+++ b/scripts/ci/classify-change.ts
@@ -10,14 +10,14 @@ import {
   type CiGatePlan,
   type DependencyKind,
   type StaticGroup,
-} from "./ci-gate-plan";
+} from "./ci-gate-plan.ts";
 
 export type {
   AppTestSuite,
   CiGatePlan,
   DependencyKind,
   StaticGroup,
-} from "./ci-gate-plan";
+} from "./ci-gate-plan.ts";
 
 const RELEASE_PATHS = new Set(["Cargo.lock", "Cargo.toml", "CHANGELOG.md", "package.json"]);
 

--- a/scripts/ci/report-actions-timings.test.ts
+++ b/scripts/ci/report-actions-timings.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  fetchRuns,
   parseReportArguments,
   summarizeWorkflowRuns,
+  timingRecordForRun,
   type ActionsRunRecord,
 } from "./report-actions-timings";
 
@@ -87,6 +89,76 @@ describe("GitHub Actions timing reports", () => {
       { ...run({ id: 21, terminalAt: "2026-08-20T00:02:00.000Z" }), branch: "feature" },
     ], { branch: "main", event: "push" });
     expect(report.runs.map(({ id }) => id)).toEqual([20]);
+  });
+
+  test("filters runs at the API and flattens every paginated job page", () => {
+    const calls: string[][] = [];
+    const request = <T>(args: readonly string[]): T => {
+      calls.push([...args]);
+      if (args[2]?.includes("/actions/workflows/")) {
+        return {
+          workflow_runs: [{
+            conclusion: "success",
+            created_at: "2026-08-20T00:00:00.000Z",
+            event: "push",
+            head_branch: "main",
+            head_sha: "sha-30",
+            html_url: "https://example.test/runs/30",
+            id: 30,
+            run_attempt: 2,
+            run_started_at: "2026-08-20T00:00:05.000Z",
+            updated_at: "2026-08-20T00:03:00.000Z",
+          }],
+        } as T;
+      }
+      const ordinaryJobs = Array.from({ length: 100 }, (_, index) => ({
+        completed_at: "2026-08-20T00:01:00.000Z",
+        conclusion: "success",
+        name: `job-${index}`,
+        started_at: "2026-08-20T00:00:10.000Z",
+        status: "completed",
+      }));
+      return [
+        { jobs: ordinaryJobs },
+        { jobs: [{
+          completed_at: "2026-08-20T00:02:00.000Z",
+          conclusion: "success",
+          name: "required",
+          started_at: "2026-08-20T00:01:59.000Z",
+          status: "completed",
+        }] },
+      ] as T;
+    };
+
+    const [fetched] = fetchRuns(
+      "owner/repo",
+      7,
+      20,
+      { branch: "main", event: "push" },
+      request,
+    );
+    expect(calls[0]).toEqual([
+      "--method",
+      "GET",
+      "repos/owner/repo/actions/workflows/7/runs",
+      "-f",
+      "branch=main",
+      "-f",
+      "event=push",
+      "-f",
+      "per_page=20",
+    ]);
+    expect(calls[1]).toEqual([
+      "--method",
+      "GET",
+      "repos/owner/repo/actions/runs/30/attempts/2/jobs",
+      "-f",
+      "per_page=100",
+      "--paginate",
+      "--slurp",
+    ]);
+    expect(fetched?.jobs).toHaveLength(101);
+    expect(fetched && timingRecordForRun(fetched).wallMs).toBe(120_000);
   });
 
   test("requires an explicit workflow, sample limit, and output", () => {

--- a/scripts/ci/report-actions-timings.test.ts
+++ b/scripts/ci/report-actions-timings.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  parseReportArguments,
+  summarizeWorkflowRuns,
+  type ActionsRunRecord,
+} from "./report-actions-timings";
+
+const run = ({
+  attempt = 1,
+  conclusion = "success",
+  createdAt = "2026-08-20T00:00:00.000Z",
+  id,
+  startedAt = "2026-08-20T00:00:10.000Z",
+  terminalAt,
+}: {
+  readonly attempt?: number;
+  readonly conclusion?: string;
+  readonly createdAt?: string;
+  readonly id: number;
+  readonly startedAt?: string;
+  readonly terminalAt: string;
+}): ActionsRunRecord => ({
+  attempt,
+  branch: "main",
+  conclusion,
+  createdAt,
+  event: "push",
+  id,
+  jobs: [
+    {
+      completedAt: terminalAt,
+      conclusion,
+      name: "work",
+      startedAt,
+      status: "completed",
+    },
+    {
+      completedAt: terminalAt,
+      conclusion,
+      name: "main complete",
+      startedAt: terminalAt,
+      status: "completed",
+    },
+  ],
+  sha: `sha-${id}`,
+  startedAt,
+  updatedAt: terminalAt,
+  url: `https://example.test/runs/${id}`,
+});
+
+describe("GitHub Actions timing reports", () => {
+  test("calculates nearest-rank percentiles, queue time, and runner minutes", () => {
+    const report = summarizeWorkflowRuns([
+      run({ id: 1, terminalAt: "2026-08-20T00:01:00.000Z" }),
+      run({ id: 2, terminalAt: "2026-08-20T00:02:00.000Z" }),
+      run({ id: 3, terminalAt: "2026-08-20T00:03:00.000Z" }),
+      run({ id: 4, terminalAt: "2026-08-20T00:04:00.000Z" }),
+      run({ id: 5, terminalAt: "2026-08-20T00:10:00.000Z" }),
+    ]);
+    expect(report.summary).toMatchObject({
+      outcomes: { success: 5 },
+      queueMs: { p50: 10_000, p90: 10_000 },
+      sampleCount: 5,
+      wallMs: { p50: 180_000, p90: 600_000 },
+    });
+    expect(report.summary.runnerMinutes.p50).toBeCloseTo(2.8333, 3);
+  });
+
+  test("counts failures but excludes failures and reruns from latency samples", () => {
+    const report = summarizeWorkflowRuns([
+      run({ conclusion: "failure", id: 10, terminalAt: "2026-08-20T00:01:00.000Z" }),
+      run({ attempt: 1, id: 11, terminalAt: "2026-08-20T00:08:00.000Z" }),
+      run({ attempt: 2, id: 11, terminalAt: "2026-08-20T00:02:00.000Z" }),
+    ]);
+    expect(report.summary).toMatchObject({
+      outcomes: { failure: 1, success: 1 },
+      sampleCount: 0,
+      wallMs: { p50: null, p90: null },
+    });
+    expect(report.runs.find((candidate) => candidate.id === 11)?.attempt).toBe(2);
+  });
+
+  test("filters event and branch before summarizing", () => {
+    const report = summarizeWorkflowRuns([
+      run({ id: 20, terminalAt: "2026-08-20T00:01:00.000Z" }),
+      { ...run({ id: 21, terminalAt: "2026-08-20T00:02:00.000Z" }), branch: "feature" },
+    ], { branch: "main", event: "push" });
+    expect(report.runs.map(({ id }) => id)).toEqual([20]);
+  });
+
+  test("requires an explicit workflow, sample limit, and output", () => {
+    expect(parseReportArguments([
+      "--workflow", "CI", "--limit", "20", "--output", "report.json",
+    ])).toMatchObject({ limit: 20, output: "report.json", workflow: "CI" });
+    expect(() => parseReportArguments(["--workflow", "CI"])).toThrow("Usage:");
+  });
+});

--- a/scripts/ci/report-actions-timings.ts
+++ b/scripts/ci/report-actions-timings.ts
@@ -1,0 +1,338 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+interface GitHubWorkflowList {
+  readonly workflows: readonly {
+    readonly id: number;
+    readonly name: string;
+    readonly path: string;
+  }[];
+}
+
+interface GitHubWorkflowRunList {
+  readonly workflow_runs: readonly GitHubWorkflowRun[];
+}
+
+interface GitHubWorkflowRun {
+  readonly conclusion: string | null;
+  readonly created_at: string;
+  readonly event: string;
+  readonly head_branch: string | null;
+  readonly head_sha: string;
+  readonly html_url: string;
+  readonly id: number;
+  readonly run_attempt: number;
+  readonly run_started_at?: string;
+  readonly updated_at: string;
+}
+
+interface GitHubJobList {
+  readonly jobs: readonly GitHubWorkflowJob[];
+}
+
+interface GitHubWorkflowJob {
+  readonly completed_at: string | null;
+  readonly conclusion: string | null;
+  readonly name: string;
+  readonly started_at: string | null;
+  readonly status: string;
+}
+
+export interface ActionsJobRecord {
+  readonly completedAt: string | null;
+  readonly conclusion: string | null;
+  readonly name: string;
+  readonly startedAt: string | null;
+  readonly status: string;
+}
+
+export interface ActionsRunRecord {
+  readonly attempt: number;
+  readonly branch: string | null;
+  readonly conclusion: string | null;
+  readonly createdAt: string;
+  readonly event: string;
+  readonly id: number;
+  readonly jobs: readonly ActionsJobRecord[];
+  readonly sha: string;
+  readonly startedAt: string | null;
+  readonly updatedAt: string;
+  readonly url: string;
+}
+
+export interface RunTimingRecord {
+  readonly attempt: number;
+  readonly branch: string | null;
+  readonly conclusion: string | null;
+  readonly event: string;
+  readonly id: number;
+  readonly jobSeconds: number;
+  readonly queueMs: number;
+  readonly sha: string;
+  readonly url: string;
+  readonly wallMs: number;
+}
+
+interface DistributionSummary {
+  readonly p50: number | null;
+  readonly p90: number | null;
+}
+
+export interface WorkflowTimingSummary {
+  readonly outcomes: Readonly<Record<string, number>>;
+  readonly queueMs: DistributionSummary;
+  readonly runnerMinutes: DistributionSummary;
+  readonly sampleCount: number;
+  readonly wallMs: DistributionSummary;
+}
+
+interface TimingReportOptions {
+  readonly branch?: string;
+  readonly event?: string;
+}
+
+interface CliArguments extends TimingReportOptions {
+  readonly limit: number;
+  readonly output: string;
+  readonly repo?: string;
+  readonly workflow: string;
+}
+
+const parseTimestamp = (value: string, label: string): number => {
+  const parsed = Date.parse(value);
+  if (Number.isFinite(parsed)) return parsed;
+  throw new Error(`${label} is not an ISO timestamp: ${JSON.stringify(value)}.`);
+};
+
+const duration = (startedAt: string | null, completedAt: string | null): number => {
+  if (!startedAt || !completedAt) return 0;
+  return Math.max(0, parseTimestamp(completedAt, "completedAt") - parseTimestamp(startedAt, "startedAt"));
+};
+
+const nearestRank = (values: readonly number[], percentile: number): number | null => {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.max(0, Math.ceil(percentile * sorted.length) - 1);
+  return sorted[index] ?? null;
+};
+
+const distribution = (values: readonly number[]): DistributionSummary => ({
+  p50: nearestRank(values, 0.5),
+  p90: nearestRank(values, 0.9),
+});
+
+const terminalJobCompletion = (run: ActionsRunRecord): number => {
+  const terminalNames = new Set(["required", "main complete", "nightly complete", "performance complete"]);
+  const terminal = run.jobs.find((job) => terminalNames.has(job.name) && job.completedAt);
+  return terminal?.completedAt
+    ? parseTimestamp(terminal.completedAt, `${terminal.name}.completedAt`)
+    : parseTimestamp(run.updatedAt, "run.updatedAt");
+};
+
+export const timingRecordForRun = (run: ActionsRunRecord): RunTimingRecord => {
+  const createdAt = parseTimestamp(run.createdAt, "run.createdAt");
+  const firstStartedAt = run.jobs
+    .flatMap((job) => job.startedAt ? [parseTimestamp(job.startedAt, `${job.name}.startedAt`)] : [])
+    .sort((left, right) => left - right)[0]
+    ?? (run.startedAt ? parseTimestamp(run.startedAt, "run.startedAt") : createdAt);
+  const jobMs = run.jobs.reduce(
+    (total, job) => total + duration(job.startedAt, job.completedAt),
+    0,
+  );
+  return {
+    attempt: run.attempt,
+    branch: run.branch,
+    conclusion: run.conclusion,
+    event: run.event,
+    id: run.id,
+    jobSeconds: jobMs / 1_000,
+    queueMs: Math.max(0, firstStartedAt - createdAt),
+    sha: run.sha,
+    url: run.url,
+    wallMs: Math.max(0, terminalJobCompletion(run) - createdAt),
+  };
+};
+
+export const summarizeWorkflowRuns = (
+  inputRuns: readonly ActionsRunRecord[],
+  options: TimingReportOptions = {},
+): { readonly runs: readonly RunTimingRecord[]; readonly summary: WorkflowTimingSummary } => {
+  const latestAttempts = new Map<number, ActionsRunRecord>();
+  for (const run of inputRuns) {
+    const current = latestAttempts.get(run.id);
+    if (!current || run.attempt > current.attempt) latestAttempts.set(run.id, run);
+  }
+  const runs = [...latestAttempts.values()]
+    .filter((run) => !options.branch || run.branch === options.branch)
+    .filter((run) => !options.event || run.event === options.event)
+    .sort((left, right) => parseTimestamp(right.createdAt, "run.createdAt") - parseTimestamp(left.createdAt, "run.createdAt"))
+    .map(timingRecordForRun);
+  const outcomes: Record<string, number> = {};
+  for (const run of runs) {
+    const outcome = run.conclusion ?? "in_progress";
+    outcomes[outcome] = (outcomes[outcome] ?? 0) + 1;
+  }
+  const successfulFirstAttempts = runs.filter((run) => run.conclusion === "success" && run.attempt === 1);
+  return {
+    runs,
+    summary: {
+      outcomes,
+      queueMs: distribution(successfulFirstAttempts.map((run) => run.queueMs)),
+      runnerMinutes: distribution(successfulFirstAttempts.map((run) => run.jobSeconds / 60)),
+      sampleCount: successfulFirstAttempts.length,
+      wallMs: distribution(successfulFirstAttempts.map((run) => run.wallMs)),
+    },
+  };
+};
+
+const readOption = (args: readonly string[], name: string): string | undefined => {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}.`);
+  return value;
+};
+
+export const parseReportArguments = (args: readonly string[]): CliArguments => {
+  const workflow = readOption(args, "--workflow");
+  const output = readOption(args, "--output");
+  const limitValue = readOption(args, "--limit");
+  const limit = Number(limitValue);
+  if (!workflow || !output || !Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
+    throw new Error("Usage: report-actions-timings --workflow <name> --limit <1-100> --output <path> [--repo <owner/name>] [--event <event>] [--branch <branch>].");
+  }
+  return {
+    branch: readOption(args, "--branch"),
+    event: readOption(args, "--event"),
+    limit,
+    output,
+    repo: readOption(args, "--repo"),
+    workflow,
+  };
+};
+
+const ghJson = <T>(args: readonly string[]): T => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return JSON.parse(execFileSync(
+        "gh",
+        ["api", ...args],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      )) as T;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+};
+
+const resolveRepository = (explicit: string | undefined): string => {
+  if (explicit) return explicit;
+  if (process.env.GITHUB_REPOSITORY) return process.env.GITHUB_REPOSITORY;
+  const value = execFileSync(
+    "gh",
+    ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  ).trim();
+  if (value) return value;
+  throw new Error("Could not resolve a GitHub repository; pass --repo owner/name.");
+};
+
+const resolveWorkflowId = (repository: string, workflow: string): number => {
+  const response = ghJson<GitHubWorkflowList>([
+    `repos/${repository}/actions/workflows`,
+    "--paginate",
+    "--slurp",
+  ]);
+  const workflows = Array.isArray(response)
+    ? (response as unknown as readonly GitHubWorkflowList[]).flatMap((page) => page.workflows)
+    : response.workflows;
+  const matches = workflows.filter((candidate) => (
+    candidate.name === workflow
+    || candidate.path === workflow
+    || String(candidate.id) === workflow
+  ));
+  if (matches.length === 1) return matches[0]?.id ?? 0;
+  if (matches.length === 0) throw new Error(`Workflow ${JSON.stringify(workflow)} was not found.`);
+  throw new Error(`Workflow ${JSON.stringify(workflow)} is ambiguous.`);
+};
+
+const fetchRuns = (repository: string, workflowId: number, limit: number): readonly ActionsRunRecord[] => {
+  const response = ghJson<GitHubWorkflowRunList>([
+    "--method",
+    "GET",
+    `repos/${repository}/actions/workflows/${workflowId}/runs`,
+    "-f",
+    `per_page=${limit}`,
+  ]);
+  return response.workflow_runs.slice(0, limit).map((run) => {
+    const jobs = ghJson<GitHubJobList>([
+      "--method",
+      "GET",
+      `repos/${repository}/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`,
+      "-f",
+      "per_page=100",
+    ]).jobs;
+    return {
+      attempt: run.run_attempt,
+      branch: run.head_branch,
+      conclusion: run.conclusion,
+      createdAt: run.created_at,
+      event: run.event,
+      id: run.id,
+      jobs: jobs.map((job) => ({
+        completedAt: job.completed_at,
+        conclusion: job.conclusion,
+        name: job.name,
+        startedAt: job.started_at,
+        status: job.status,
+      })),
+      sha: run.head_sha,
+      startedAt: run.run_started_at ?? null,
+      updatedAt: run.updated_at,
+      url: run.html_url,
+    };
+  });
+};
+
+const displayDuration = (value: number | null, unit: "minutes" | "milliseconds"): string => {
+  if (value === null) return "n/a";
+  const minutes = unit === "milliseconds" ? value / 60_000 : value;
+  return `${minutes.toFixed(2)}m`;
+};
+
+export const formatTimingSummary = (workflow: string, summary: WorkflowTimingSummary): string => [
+  `# ${workflow} timing summary`,
+  "",
+  `Successful first-attempt samples: ${summary.sampleCount}`,
+  `Wall p50 / p90: ${displayDuration(summary.wallMs.p50, "milliseconds")} / ${displayDuration(summary.wallMs.p90, "milliseconds")}`,
+  `Queue p50 / p90: ${displayDuration(summary.queueMs.p50, "milliseconds")} / ${displayDuration(summary.queueMs.p90, "milliseconds")}`,
+  `Runner-minutes p50 / p90: ${displayDuration(summary.runnerMinutes.p50, "minutes")} / ${displayDuration(summary.runnerMinutes.p90, "minutes")}`,
+  `Outcomes: ${Object.entries(summary.outcomes).sort().map(([name, count]) => `${name}=${count}`).join(", ") || "none"}`,
+  "",
+].join("\n");
+
+const main = (): void => {
+  const options = parseReportArguments(process.argv.slice(2));
+  const repository = resolveRepository(options.repo);
+  const workflowId = resolveWorkflowId(repository, options.workflow);
+  const report = summarizeWorkflowRuns(
+    fetchRuns(repository, workflowId, options.limit),
+    { branch: options.branch, event: options.event },
+  );
+  const output = path.resolve(options.output);
+  mkdirSync(path.dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify({ repository, workflow: options.workflow, ...report }, null, 2)}\n`, "utf8");
+  process.stdout.write(formatTimingSummary(options.workflow, report.summary));
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/report-actions-timings.ts
+++ b/scripts/ci/report-actions-timings.ts
@@ -39,6 +39,8 @@ interface GitHubWorkflowJob {
   readonly status: string;
 }
 
+type GitHubJsonRequest = <T>(args: readonly string[]) => T;
+
 export interface ActionsJobRecord {
   readonly completedAt: string | null;
   readonly conclusion: string | null;
@@ -259,22 +261,36 @@ const resolveWorkflowId = (repository: string, workflow: string): number => {
   throw new Error(`Workflow ${JSON.stringify(workflow)} is ambiguous.`);
 };
 
-const fetchRuns = (repository: string, workflowId: number, limit: number): readonly ActionsRunRecord[] => {
-  const response = ghJson<GitHubWorkflowRunList>([
+export const fetchRuns = (
+  repository: string,
+  workflowId: number,
+  limit: number,
+  options: TimingReportOptions = {},
+  request: GitHubJsonRequest = ghJson,
+): readonly ActionsRunRecord[] => {
+  const runArguments = [
     "--method",
     "GET",
     `repos/${repository}/actions/workflows/${workflowId}/runs`,
-    "-f",
-    `per_page=${limit}`,
-  ]);
+  ];
+  if (options.branch) runArguments.push("-f", `branch=${options.branch}`);
+  if (options.event) runArguments.push("-f", `event=${options.event}`);
+  runArguments.push("-f", `per_page=${limit}`);
+  const response = request<GitHubWorkflowRunList>(runArguments);
   return response.workflow_runs.slice(0, limit).map((run) => {
-    const jobs = ghJson<GitHubJobList>([
+    const jobResponse = request<GitHubJobList | readonly GitHubJobList[]>([
       "--method",
       "GET",
       `repos/${repository}/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs`,
       "-f",
       "per_page=100",
-    ]).jobs;
+      "--paginate",
+      "--slurp",
+    ]);
+    const jobPages: readonly GitHubJobList[] = Array.isArray(jobResponse)
+      ? jobResponse
+      : [jobResponse as GitHubJobList];
+    const jobs = jobPages.flatMap((page) => page.jobs);
     return {
       attempt: run.run_attempt,
       branch: run.head_branch,
@@ -319,7 +335,7 @@ const main = (): void => {
   const repository = resolveRepository(options.repo);
   const workflowId = resolveWorkflowId(repository, options.workflow);
   const report = summarizeWorkflowRuns(
-    fetchRuns(repository, workflowId, options.limit),
+    fetchRuns(repository, workflowId, options.limit, options),
     { branch: options.branch, event: options.event },
   );
   const output = path.resolve(options.output);

--- a/scripts/ci/run-timed.test.ts
+++ b/scripts/ci/run-timed.test.ts
@@ -40,7 +40,13 @@ describe("CI timed command runner", () => {
       commandArguments: ["-e", "process.exit(0)"],
       timingDirectory: root,
       summaryPath,
-      env: { ...process.env, CI_TIMING_JOB: "test job" },
+      env: {
+        ...process.env,
+        CI_TIMING_JOB: "test job",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "12345",
+        GITHUB_SHA: "abc123",
+      },
     });
     const failure = await runTimedCommand({
       name: "failed step",
@@ -55,11 +61,23 @@ describe("CI timed command runner", () => {
     const records = (await readFile(path.join(root, "test-job.jsonl"), "utf8"))
       .trim()
       .split("\n")
-      .map((line) => JSON.parse(line) as { name: string; exitCode: number });
-    expect(records.map(({ name, exitCode }) => ({ name, exitCode }))).toEqual([
-      { name: "successful step", exitCode: 0 },
-      { name: "failed step", exitCode: 7 },
-    ]);
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records[0]).toMatchObject({
+      attempt: 2,
+      exitCode: 0,
+      job: "test job",
+      name: "successful step",
+      runId: "12345",
+      sha: "abc123",
+    });
+    expect(records[1]).toMatchObject({
+      attempt: null,
+      exitCode: 7,
+      job: "test job",
+      name: "failed step",
+      runId: null,
+      sha: null,
+    });
     const summary = await readFile(summaryPath, "utf8");
     expect(summary).toContain("| successful step |");
     expect(summary).toContain("| failed step |");

--- a/scripts/ci/run-timed.test.ts
+++ b/scripts/ci/run-timed.test.ts
@@ -34,6 +34,13 @@ describe("CI timed command runner", () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "nodex-ci-timed-"));
     temporaryRoots.push(root);
     const summaryPath = path.join(root, "summary.md");
+    const environmentWithoutGitHubRunIdentity = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => ![
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_RUN_ID",
+        "GITHUB_SHA",
+      ].includes(name)),
+    );
     const success = await runTimedCommand({
       name: "successful step",
       command: process.execPath,
@@ -54,7 +61,7 @@ describe("CI timed command runner", () => {
       commandArguments: ["-e", "process.exit(7)"],
       timingDirectory: root,
       summaryPath,
-      env: { ...process.env, CI_TIMING_JOB: "test job" },
+      env: { ...environmentWithoutGitHubRunIdentity, CI_TIMING_JOB: "test job" },
     });
     expect(success.exitCode).toBe(0);
     expect(failure.exitCode).toBe(7);

--- a/scripts/ci/run-timed.ts
+++ b/scripts/ci/run-timed.ts
@@ -10,7 +10,11 @@ export interface TimedCommandArguments {
 }
 
 export interface TimedCommandRecord {
+  readonly attempt: number | null;
+  readonly job: string | null;
   readonly name: string;
+  readonly runId: string | null;
+  readonly sha: string | null;
   readonly startedAt: string;
   readonly finishedAt: string;
   readonly durationMs: number;
@@ -72,6 +76,16 @@ const formatDuration = (durationMs: number): string => {
 
 const escapeSummaryCell = (value: string): string => value.replaceAll("|", "\\|");
 
+const optionalText = (value: string | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+};
+
+const optionalPositiveInteger = (value: string | undefined): number | null => {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
 const runChild = async (
   options: Pick<RunTimedOptions, "command" | "commandArguments" | "cwd" | "env">,
 ): Promise<number> => await new Promise((resolve) => {
@@ -118,8 +132,13 @@ export const runTimedCommand = async (
   const started = now();
   const exitCode = await runChild(options);
   const finished = now();
+  const environment = options.env ?? process.env;
   const record: TimedCommandRecord = {
+    attempt: optionalPositiveInteger(environment.GITHUB_RUN_ATTEMPT),
+    job: optionalText(environment.CI_TIMING_JOB ?? environment.GITHUB_JOB),
     name: options.name,
+    runId: optionalText(environment.GITHUB_RUN_ID),
+    sha: optionalText(environment.GITHUB_SHA),
     startedAt: started.toISOString(),
     finishedAt: finished.toISOString(),
     durationMs: Math.max(0, finished.getTime() - started.getTime()),
@@ -129,9 +148,8 @@ export const runTimedCommand = async (
     ?? path.resolve(process.cwd(), ".generated/ci-timings");
   await mkdir(timingDirectory, { recursive: true });
   const jobName = sanitizeJobName(
-    options.env?.CI_TIMING_JOB
-      ?? process.env.CI_TIMING_JOB
-      ?? process.env.GITHUB_JOB
+    environment.CI_TIMING_JOB
+      ?? environment.GITHUB_JOB
       ?? "local",
   );
   await appendFile(
@@ -139,7 +157,7 @@ export const runTimedCommand = async (
     `${JSON.stringify(record)}\n`,
     "utf8",
   );
-  await appendSummary(options.summaryPath ?? process.env.GITHUB_STEP_SUMMARY, record);
+  await appendSummary(options.summaryPath ?? environment.GITHUB_STEP_SUMMARY, record);
   return record;
 };
 

--- a/scripts/ci/verify-ci-matrix-contracts.test.ts
+++ b/scripts/ci/verify-ci-matrix-contracts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { APP_TEST_SUITES, STATIC_GROUPS } from "./ci-gate-plan";
+import {
+  verifyAppTestMatrixContracts,
+  verifyMainCiContracts,
+} from "./verify-ci-matrix-contracts";
+
+const mainWorkflow = ({
+  appTestSuites = APP_TEST_SUITES,
+  staticGroups = STATIC_GROUPS,
+}: {
+  readonly appTestSuites?: readonly string[];
+  readonly staticGroups?: readonly string[];
+} = {}): Record<string, unknown> => ({
+  jobs: {
+    "app-tests": { with: { suites_json: JSON.stringify(appTestSuites) } },
+    "static-contracts": { with: { groups_json: JSON.stringify(staticGroups) } },
+  },
+});
+
+describe("CI matrix contracts", () => {
+  test("accepts exhaustive canonical Main matrices", () => {
+    expect(() => verifyMainCiContracts(mainWorkflow())).not.toThrow();
+  });
+
+  test("rejects omitted, additional, and reordered Main matrix entries", () => {
+    expect(() => verifyMainCiContracts(mainWorkflow({ staticGroups: STATIC_GROUPS.slice(1) })))
+      .toThrow("Main CI static groups");
+    expect(() => verifyMainCiContracts(mainWorkflow({ appTestSuites: [...APP_TEST_SUITES, "new"] })))
+      .toThrow("Main CI app test suites");
+    expect(() => verifyMainCiContracts(mainWorkflow({ appTestSuites: [...APP_TEST_SUITES].reverse() })))
+      .toThrow("Main CI app test suites");
+  });
+
+  test("rejects Rust cache variables inherited by non-Rust matrix cells", () => {
+    expect(() => verifyAppTestMatrixContracts({ jobs: { test: { env: { CI_TIMING_JOB: "test" } } } }))
+      .not.toThrow();
+    expect(() => verifyAppTestMatrixContracts({
+      jobs: { test: { env: { RUSTC_WRAPPER: "sccache" } } },
+    })).toThrow("scope Rust cache variables to Rust-bearing steps");
+  });
+});

--- a/scripts/ci/verify-ci-matrix-contracts.ts
+++ b/scripts/ci/verify-ci-matrix-contracts.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+
+import { APP_TEST_SUITES, STATIC_GROUPS } from "./ci-gate-plan";
+import {
+  readWorkflow,
+  repositoryRoot,
+  requireRecord,
+  type UnknownRecord,
+} from "./github-workflow-files";
+
+const parseStringArray = (value: unknown, label: string): readonly string[] => {
+  if (typeof value !== "string") throw new Error(`${label} must be a JSON string.`);
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || !parsed.every((entry): entry is string => typeof entry === "string")) {
+    throw new Error(`${label} must contain a JSON string array.`);
+  }
+  return parsed;
+};
+
+const requireReusableInput = (
+  workflow: UnknownRecord,
+  jobName: string,
+  inputName: string,
+): readonly string[] => {
+  const jobs = requireRecord(workflow.jobs, "Main CI jobs");
+  const job = requireRecord(jobs[jobName], `Main CI ${jobName} job`);
+  const inputs = requireRecord(job.with, `Main CI ${jobName} inputs`);
+  return parseStringArray(inputs[inputName], `Main CI ${jobName}.${inputName}`);
+};
+
+const requireExactEntries = (
+  actual: readonly string[],
+  expected: readonly string[],
+  label: string,
+): void => {
+  if (actual.length === expected.length && actual.every((entry, index) => entry === expected[index])) {
+    return;
+  }
+  throw new Error(
+    `${label} must exactly match its canonical entries: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}.`,
+  );
+};
+
+export const verifyMainCiContracts = (workflow: UnknownRecord): void => {
+  requireExactEntries(
+    requireReusableInput(workflow, "static-contracts", "groups_json"),
+    STATIC_GROUPS,
+    "Main CI static groups",
+  );
+  requireExactEntries(
+    requireReusableInput(workflow, "app-tests", "suites_json"),
+    APP_TEST_SUITES,
+    "Main CI app test suites",
+  );
+};
+
+export const verifyAppTestMatrixContracts = (workflow: UnknownRecord): void => {
+  const jobs = requireRecord(workflow.jobs, "Application test workflow jobs");
+  const testJob = requireRecord(jobs.test, "Application test matrix job");
+  const environment = testJob.env === undefined
+    ? {}
+    : requireRecord(testJob.env, "Application test matrix job environment");
+  const unsafeGlobalVariables = ["RUSTC_WRAPPER", "SCCACHE_GHA_ENABLED"]
+    .filter((name) => Object.hasOwn(environment, name));
+  if (unsafeGlobalVariables.length === 0) return;
+  throw new Error(
+    `Application test matrix must scope Rust cache variables to Rust-bearing steps: ${unsafeGlobalVariables.join(", ")}.`,
+  );
+};
+
+const main = (): void => {
+  verifyMainCiContracts(readWorkflow(path.join(
+    repositoryRoot,
+    ".github/workflows/ci-main.yml",
+  )));
+  verifyAppTestMatrixContracts(readWorkflow(path.join(
+    repositoryRoot,
+    ".github/workflows/_app-tests.yml",
+  )));
+  process.stdout.write("Verified CI matrix coverage and prerequisite isolation.\n");
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/ci/verify-required-gates.test.ts
+++ b/scripts/ci/verify-required-gates.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+
+import { verifyRequiredGates } from "./verify-required-gates";
+
+describe("required CI gate verification", () => {
+  test("accepts successful selected gates and ignores unselected skipped jobs", () => {
+    expect(() => verifyRequiredGates({
+      classifierResult: "success",
+      results: {
+        "app-tests": "success",
+        "release-transition": "skipped",
+        "rust-pr": "skipped",
+      },
+      selectedGates: ["app-tests"],
+    })).not.toThrow();
+  });
+
+  test.each(["failure", "cancelled", "skipped"] as const)(
+    "rejects a selected gate with %s result",
+    (result) => {
+      expect(() => verifyRequiredGates({
+        classifierResult: "success",
+        results: { "app-tests": result },
+        selectedGates: ["app-tests"],
+      })).toThrow(`app-tests finished with ${result}`);
+    },
+  );
+
+  test("rejects classifier failure and missing selected results", () => {
+    expect(() => verifyRequiredGates({
+      classifierResult: "failure",
+      results: {},
+      selectedGates: [],
+    })).toThrow("classify finished with failure");
+    expect(() => verifyRequiredGates({
+      classifierResult: "success",
+      results: {},
+      selectedGates: ["release-transition"],
+    })).toThrow("release-transition has no GitHub job result");
+  });
+
+  test("supports the narrow release transition mode", () => {
+    expect(() => verifyRequiredGates({
+      classifierResult: "success",
+      results: { "release-transition": "success" },
+      selectedGates: ["release-transition"],
+    })).not.toThrow();
+  });
+});

--- a/scripts/ci/verify-required-gates.test.ts
+++ b/scripts/ci/verify-required-gates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
-import { verifyRequiredGates } from "./verify-required-gates";
+import { classifyChangedPaths } from "./classify-change";
+import { requiredGateNames, verifyRequiredGates } from "./verify-required-gates";
 
 describe("required CI gate verification", () => {
   test("accepts successful selected gates and ignores unselected skipped jobs", () => {
@@ -37,6 +38,33 @@ describe("required CI gate verification", () => {
       results: {},
       selectedGates: ["release-transition"],
     })).toThrow("release-transition has no GitHub job result");
+  });
+
+  test("rejects duplicate and empty selected gate names", () => {
+    expect(() => verifyRequiredGates({
+      classifierResult: "success",
+      results: { "app-tests": "success" },
+      selectedGates: ["app-tests", "app-tests"],
+    })).toThrow("must not contain duplicates");
+    expect(() => verifyRequiredGates({
+      classifierResult: "success",
+      results: { " ": "success" },
+      selectedGates: [" "],
+    })).toThrow("must not be empty");
+  });
+
+  test("derives PR gates only from the validated plan and Main gates from needs", () => {
+    expect(requiredGateNames(
+      ["stale-or-unselected"],
+      classifyChangedPaths(["src/renderer/app.tsx"]),
+    )).toEqual([
+      "static-contracts",
+      "app-tests",
+      "browser-tests",
+      "electron-e2e",
+    ]);
+    expect(requiredGateNames(["static-contracts", "rust-workspace"], undefined))
+      .toEqual(["static-contracts", "rust-workspace"]);
   });
 
   test("supports the narrow release transition mode", () => {

--- a/scripts/ci/verify-required-gates.ts
+++ b/scripts/ci/verify-required-gates.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 
+import { parseCiGatePlan, requiredJobIdsForGatePlan } from "./ci-gate-plan";
+
 export type GitHubJobResult = "cancelled" | "failure" | "skipped" | "success";
 
 export interface RequiredGateVerification {
@@ -74,18 +76,26 @@ const parseSelectedGates = (value: string): readonly string[] => {
 };
 
 const main = (): void => {
-  const selected = process.env.CI_SELECTED_GATES_JSON;
+  const planJson = process.env.CI_GATE_PLAN_JSON;
   const needsJson = process.env.CI_NEEDS_JSON;
-  if (!selected || !needsJson) {
-    throw new Error("CI_SELECTED_GATES_JSON and CI_NEEDS_JSON are required.");
-  }
+  if (!needsJson) throw new Error("CI_NEEDS_JSON is required.");
   const needs = parseNeeds(needsJson);
-  const classifierResult = needs.classify?.result;
-  if (!classifierResult) throw new Error("CI_NEEDS_JSON.classify.result is required.");
+  const classifierResult = process.env.CI_CLASSIFIER_RESULT
+    ? requireGitHubJobResult(process.env.CI_CLASSIFIER_RESULT, "CI_CLASSIFIER_RESULT")
+    : needs.classify?.result;
+  if (!classifierResult) throw new Error("A classifier result is required.");
+  if (classifierResult !== "success") {
+    verifyRequiredGates({ classifierResult, results: {}, selectedGates: [] });
+    return;
+  }
+  const selectedJson = process.env.CI_SELECTED_GATES_JSON;
+  const selectedGates = selectedJson
+    ? parseSelectedGates(selectedJson)
+    : requiredJobIdsForGatePlan(parseCiGatePlan(JSON.parse(planJson ?? "")));
   verifyRequiredGates({
     classifierResult,
     results: Object.fromEntries(Object.entries(needs).map(([name, job]) => [name, job.result])),
-    selectedGates: parseSelectedGates(selected),
+    selectedGates,
   });
   process.stdout.write("Every selected required gate succeeded.\n");
 };

--- a/scripts/ci/verify-required-gates.ts
+++ b/scripts/ci/verify-required-gates.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+
+export type GitHubJobResult = "cancelled" | "failure" | "skipped" | "success";
+
+export interface RequiredGateVerification {
+  readonly classifierResult: GitHubJobResult;
+  readonly results: Readonly<Record<string, GitHubJobResult>>;
+  readonly selectedGates: readonly string[];
+}
+
+const GITHUB_JOB_RESULTS = new Set<GitHubJobResult>([
+  "cancelled",
+  "failure",
+  "skipped",
+  "success",
+]);
+
+const requireGitHubJobResult = (value: unknown, label: string): GitHubJobResult => {
+  if (typeof value === "string" && GITHUB_JOB_RESULTS.has(value as GitHubJobResult)) {
+    return value as GitHubJobResult;
+  }
+  throw new Error(`${label} has unsupported GitHub job result ${JSON.stringify(value)}.`);
+};
+
+export const verifyRequiredGates = ({
+  classifierResult,
+  results,
+  selectedGates,
+}: RequiredGateVerification): void => {
+  if (classifierResult !== "success") {
+    throw new Error(`classify finished with ${classifierResult}; expected success.`);
+  }
+  const uniqueGates = new Set(selectedGates);
+  if (uniqueGates.size !== selectedGates.length) {
+    throw new Error("Selected required gates must not contain duplicates.");
+  }
+  for (const gate of selectedGates) {
+    if (!gate.trim()) throw new Error("Selected required gate names must not be empty.");
+    const result = results[gate];
+    if (!result) throw new Error(`${gate} has no GitHub job result.`);
+    if (result !== "success") {
+      throw new Error(`${gate} finished with ${result}; expected success.`);
+    }
+  }
+};
+
+interface GitHubNeedsJob {
+  readonly result: GitHubJobResult;
+}
+
+const parseNeeds = (value: string): Readonly<Record<string, GitHubNeedsJob>> => {
+  const parsed: unknown = JSON.parse(value);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("CI_NEEDS_JSON must be a JSON object.");
+  }
+  return Object.fromEntries(Object.entries(parsed).map(([name, candidate]) => {
+    if (typeof candidate !== "object" || candidate === null || Array.isArray(candidate)) {
+      throw new Error(`CI_NEEDS_JSON.${name} must be an object.`);
+    }
+    const result = requireGitHubJobResult(
+      (candidate as Readonly<Record<string, unknown>>).result,
+      `CI_NEEDS_JSON.${name}`,
+    );
+    return [name, { result }];
+  }));
+};
+
+const parseSelectedGates = (value: string): readonly string[] => {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || !parsed.every((gate) => typeof gate === "string")) {
+    throw new Error("CI_SELECTED_GATES_JSON must be a JSON string array.");
+  }
+  return parsed;
+};
+
+const main = (): void => {
+  const selected = process.env.CI_SELECTED_GATES_JSON;
+  const needsJson = process.env.CI_NEEDS_JSON;
+  if (!selected || !needsJson) {
+    throw new Error("CI_SELECTED_GATES_JSON and CI_NEEDS_JSON are required.");
+  }
+  const needs = parseNeeds(needsJson);
+  const classifierResult = needs.classify?.result;
+  if (!classifierResult) throw new Error("CI_NEEDS_JSON.classify.result is required.");
+  verifyRequiredGates({
+    classifierResult,
+    results: Object.fromEntries(Object.entries(needs).map(([name, job]) => [name, job.result])),
+    selectedGates: parseSelectedGates(selected),
+  });
+  process.stdout.write("Every selected required gate succeeded.\n");
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/verify-required-gates.ts
+++ b/scripts/ci/verify-required-gates.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { parseCiGatePlan, requiredJobIdsForGatePlan } from "./ci-gate-plan";
+import { parseCiGatePlan, requiredJobIdsForGatePlan } from "./ci-gate-plan.ts";
 
 export type GitHubJobResult = "cancelled" | "failure" | "skipped" | "success";
 

--- a/scripts/ci/verify-required-gates.ts
+++ b/scripts/ci/verify-required-gates.ts
@@ -50,6 +50,13 @@ interface GitHubNeedsJob {
   readonly result: GitHubJobResult;
 }
 
+export const requiredGateNames = (
+  availableGateNames: readonly string[],
+  rawPlan: unknown | undefined,
+): readonly string[] => rawPlan === undefined
+  ? availableGateNames
+  : requiredJobIdsForGatePlan(parseCiGatePlan(rawPlan));
+
 const parseNeeds = (value: string): Readonly<Record<string, GitHubNeedsJob>> => {
   const parsed: unknown = JSON.parse(value);
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -67,14 +74,6 @@ const parseNeeds = (value: string): Readonly<Record<string, GitHubNeedsJob>> => 
   }));
 };
 
-const parseSelectedGates = (value: string): readonly string[] => {
-  const parsed: unknown = JSON.parse(value);
-  if (!Array.isArray(parsed) || !parsed.every((gate) => typeof gate === "string")) {
-    throw new Error("CI_SELECTED_GATES_JSON must be a JSON string array.");
-  }
-  return parsed;
-};
-
 const main = (): void => {
   const planJson = process.env.CI_GATE_PLAN_JSON;
   const needsJson = process.env.CI_NEEDS_JSON;
@@ -88,10 +87,10 @@ const main = (): void => {
     verifyRequiredGates({ classifierResult, results: {}, selectedGates: [] });
     return;
   }
-  const selectedJson = process.env.CI_SELECTED_GATES_JSON;
-  const selectedGates = selectedJson
-    ? parseSelectedGates(selectedJson)
-    : requiredJobIdsForGatePlan(parseCiGatePlan(JSON.parse(planJson ?? "")));
+  const selectedGates = requiredGateNames(
+    Object.keys(needs),
+    planJson === undefined ? undefined : JSON.parse(planJson),
+  );
   verifyRequiredGates({
     classifierResult,
     results: Object.fromEntries(Object.entries(needs).map(([name, job]) => [name, job.result])),

--- a/scripts/ci/verify-static.test.ts
+++ b/scripts/ci/verify-static.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { STATIC_GROUPS } from "./ci-gate-plan";
+import {
+  parseStaticArguments,
+  runStaticChecks,
+  selectStaticChecks,
+  STATIC_CHECKS,
+} from "./verify-static";
+
+describe("static CI groups", () => {
+  test("partition every CI-selectable check exactly once", () => {
+    const selected = STATIC_GROUPS.flatMap((group) => selectStaticChecks(STATIC_CHECKS, [group]));
+    expect(selected.map(({ id }) => id)).toEqual(STATIC_CHECKS.map(({ id }) => id));
+    expect(new Set(selected.map(({ id }) => id)).size).toBe(STATIC_CHECKS.length);
+  });
+
+  test("parses explicit groups and rejects empty, unknown, or duplicate groups", () => {
+    expect(parseStaticArguments([])).toEqual({ groups: null });
+    expect(parseStaticArguments(["--group", "types", "--group", "generated"]))
+      .toEqual({ groups: ["types", "generated"] });
+    expect(() => selectStaticChecks(STATIC_CHECKS, [])).toThrow("At least one");
+    expect(() => parseStaticArguments(["--group", "surprise"])).toThrow("Unknown static group");
+    expect(() => parseStaticArguments(["--group", "types", "--group", "types"]))
+      .toThrow("must not be repeated");
+  });
+
+  test("stops after the first failing command", () => {
+    const execute = vi.fn((_executable: string, arguments_: readonly string[]) => {
+      if (arguments_.includes("lint")) throw new Error("lint failed");
+    });
+    expect(() => runStaticChecks([
+      { command: ["run", "typecheck"], name: "typecheck" },
+      { command: ["run", "lint"], name: "lint" },
+      { command: ["run", "build:landing"], name: "landing" },
+    ], execute)).toThrow("lint failed");
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/scripts/ci/verify-static.ts
+++ b/scripts/ci/verify-static.ts
@@ -1,28 +1,97 @@
 import { execFileSync } from "node:child_process";
+import path from "node:path";
 
-interface StaticCheck {
+import { STATIC_GROUPS, type StaticGroup } from "./ci-gate-plan";
+
+export interface StaticCheck {
   readonly command: readonly string[];
+  readonly group: StaticGroup;
+  readonly id: string;
   readonly name: string;
 }
 
 export const STATIC_CHECKS: readonly StaticCheck[] = [
-  { command: ["run", "typecheck"], name: "typecheck" },
-  { command: ["run", "lint"], name: "lint" },
-  { command: ["run", "semantic-theme:verify"], name: "semantic theme" },
-  { command: ["run", "verify:icons"], name: "icon boundaries" },
-  { command: ["run", "ci:workflow-contracts"], name: "workflow contracts" },
-  { command: ["run", "ci:stress-workflow-contracts"], name: "stress workflow ownership" },
-  { command: ["run", "ci:verify-ignored-rust-tests"], name: "ignored Rust test tiers" },
-  { command: ["run", "core:protocol:verify"], name: "protocol contracts" },
-  { command: ["run", "core:module-boundaries"], name: "module boundaries" },
-  { command: ["run", "version-surfaces:audit"], name: "version surfaces" },
-  { command: ["run", "build-resources:verify"], name: "generated build resources and notices/legal" },
-  { command: ["run", "build:landing"], name: "landing build" },
+  { command: ["run", "typecheck"], group: "types", id: "typecheck", name: "typecheck" },
+  { command: ["run", "lint"], group: "types", id: "lint", name: "lint" },
+  { command: ["run", "semantic-theme:verify"], group: "ui-contracts", id: "semantic-theme", name: "semantic theme" },
+  { command: ["run", "verify:icons"], group: "ui-contracts", id: "icon-boundaries", name: "icon boundaries" },
+  { command: ["run", "ci:workflow-contracts"], group: "ci-contracts", id: "workflow-contracts", name: "workflow contracts" },
+  { command: ["run", "ci:stress-workflow-contracts"], group: "ci-contracts", id: "stress-ownership", name: "stress workflow ownership" },
+  { command: ["run", "ci:verify-ignored-rust-tests"], group: "ci-contracts", id: "ignored-rust-tests", name: "ignored Rust test tiers" },
+  { command: ["run", "core:module-boundaries"], group: "repository-contracts", id: "module-boundaries", name: "module boundaries" },
+  { command: ["run", "version-surfaces:audit"], group: "repository-contracts", id: "version-surfaces", name: "version surfaces" },
+  { command: ["run", "build-resources:verify"], group: "generated", id: "generated-resources", name: "generated build resources and notices/legal" },
+  { command: ["run", "build:landing"], group: "landing", id: "landing-build", name: "landing build" },
 ];
 
-const pnpmExecutable = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+export const PROTOCOL_CHECK = {
+  command: ["run", "core:protocol:verify"],
+  id: "protocol-contracts",
+  name: "protocol contracts",
+} as const;
 
-for (const check of STATIC_CHECKS) {
-  process.stdout.write(`\n[static] ${check.name}\n`);
-  execFileSync(pnpmExecutable, check.command, { cwd: process.cwd(), stdio: "inherit" });
+interface StaticCliArguments {
+  readonly groups: readonly StaticGroup[] | null;
+}
+
+type StaticExecutor = (executable: string, arguments_: readonly string[]) => void;
+
+export const selectStaticChecks = (
+  checks: readonly StaticCheck[],
+  groups: readonly StaticGroup[],
+): readonly StaticCheck[] => {
+  if (groups.length === 0) throw new Error("At least one static group is required.");
+  const selected = new Set(groups);
+  return checks.filter((check) => selected.has(check.group));
+};
+
+export const parseStaticArguments = (args: readonly string[]): StaticCliArguments => {
+  if (args.length === 0) return { groups: null };
+  const groups: StaticGroup[] = [];
+  for (let index = 0; index < args.length; index += 2) {
+    if (args[index] !== "--group") throw new Error(`Unknown static argument: ${args[index]}.`);
+    const value = args[index + 1];
+    if (!value || !(STATIC_GROUPS as readonly string[]).includes(value)) {
+      throw new Error(`Unknown static group: ${JSON.stringify(value)}.`);
+    }
+    groups.push(value as StaticGroup);
+  }
+  if (new Set(groups).size !== groups.length) throw new Error("Static groups must not be repeated.");
+  return { groups };
+};
+
+export const runStaticChecks = (
+  checks: readonly Pick<StaticCheck, "command" | "name">[],
+  execute: StaticExecutor = (executable, arguments_) => {
+    execFileSync(executable, arguments_, { cwd: process.cwd(), stdio: "inherit" });
+  },
+): void => {
+  const pnpmExecutable = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  for (const check of checks) {
+    process.stdout.write(`\n[static] ${check.name}\n`);
+    execute(pnpmExecutable, check.command);
+  }
+};
+
+const main = (): void => {
+  const { groups } = parseStaticArguments(process.argv.slice(2));
+  if (groups) {
+    runStaticChecks(selectStaticChecks(STATIC_CHECKS, groups));
+    return;
+  }
+  const protocolIndex = STATIC_CHECKS.findIndex((check) => check.id === "module-boundaries");
+  runStaticChecks([
+    ...STATIC_CHECKS.slice(0, protocolIndex),
+    PROTOCOL_CHECK,
+    ...STATIC_CHECKS.slice(protocolIndex),
+  ]);
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/ci/write-github-outputs.test.ts
+++ b/scripts/ci/write-github-outputs.test.ts
@@ -27,8 +27,15 @@ describe("GitHub classification outputs", () => {
 
   test("rejects non-string paths before they can reach a summary", () => {
     expect(() => parseClassificationDocument({
-      changedPaths: ["safe", "unsafe\npath", 42],
+      changedPaths: ["safe", 42],
       plan: classifyChangedPaths(["README.md"]),
     })).toThrow("string array");
+  });
+
+  test("rejects newline-bearing paths independently", () => {
+    expect(() => parseClassificationDocument({
+      changedPaths: ["unsafe\npath"],
+      plan: classifyChangedPaths(["README.md"]),
+    })).toThrow("must not contain line breaks");
   });
 });

--- a/scripts/ci/write-github-outputs.test.ts
+++ b/scripts/ci/write-github-outputs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { classifyChangedPaths } from "./classify-change";
+import {
+  githubOutputForClassification,
+  parseClassificationDocument,
+} from "./write-github-outputs";
+
+describe("GitHub classification outputs", () => {
+  test("writes one compact, typed plan output", () => {
+    const document = parseClassificationDocument({
+      changedPaths: ["src/renderer/app.tsx"],
+      plan: classifyChangedPaths(["src/renderer/app.tsx"]),
+    });
+    const output = githubOutputForClassification(document);
+    expect(output.split("\n")).toHaveLength(2);
+    expect(JSON.parse(output.slice("plan=".length))).toMatchObject({ browser: true, rustFast: false });
+  });
+
+  test("rejects unknown document and plan fields", () => {
+    const plan = classifyChangedPaths(["src/renderer/app.tsx"]);
+    expect(() => parseClassificationDocument({ changedPaths: [], plan, surprise: true }))
+      .toThrow("unknown fields");
+    expect(() => parseClassificationDocument({ changedPaths: [], plan: { ...plan, surprise: true } }))
+      .toThrow("unknown fields");
+  });
+
+  test("rejects non-string paths before they can reach a summary", () => {
+    expect(() => parseClassificationDocument({
+      changedPaths: ["safe", "unsafe\npath", 42],
+      plan: classifyChangedPaths(["README.md"]),
+    })).toThrow("string array");
+  });
+});

--- a/scripts/ci/write-github-outputs.ts
+++ b/scripts/ci/write-github-outputs.ts
@@ -18,6 +18,9 @@ export const parseClassificationDocument = (value: unknown): ClassificationDocum
   if (!Array.isArray(value.changedPaths) || !value.changedPaths.every((entry) => typeof entry === "string")) {
     throw new Error("Classification changedPaths must be a string array.");
   }
+  if (value.changedPaths.some((entry) => /[\r\n]/u.test(entry))) {
+    throw new Error("Classification changedPaths must not contain line breaks.");
+  }
   return {
     changedPaths: value.changedPaths,
     plan: parseCiGatePlan(value.plan),

--- a/scripts/ci/write-github-outputs.ts
+++ b/scripts/ci/write-github-outputs.ts
@@ -1,7 +1,7 @@
 import { appendFileSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import { parseCiGatePlan, type CiGatePlan } from "./ci-gate-plan";
+import { parseCiGatePlan, type CiGatePlan } from "./ci-gate-plan.ts";
 
 interface ClassificationDocument {
   readonly changedPaths: readonly string[];

--- a/scripts/ci/write-github-outputs.ts
+++ b/scripts/ci/write-github-outputs.ts
@@ -1,0 +1,65 @@
+import { appendFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { parseCiGatePlan, type CiGatePlan } from "./ci-gate-plan";
+
+interface ClassificationDocument {
+  readonly changedPaths: readonly string[];
+  readonly plan: CiGatePlan;
+}
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const parseClassificationDocument = (value: unknown): ClassificationDocument => {
+  if (!isRecord(value)) throw new Error("Classification document must be an object.");
+  const unknown = Object.keys(value).filter((key) => key !== "changedPaths" && key !== "plan");
+  if (unknown.length > 0) throw new Error(`Classification document has unknown fields: ${unknown.join(", ")}.`);
+  if (!Array.isArray(value.changedPaths) || !value.changedPaths.every((entry) => typeof entry === "string")) {
+    throw new Error("Classification changedPaths must be a string array.");
+  }
+  return {
+    changedPaths: value.changedPaths,
+    plan: parseCiGatePlan(value.plan),
+  };
+};
+
+export const githubOutputForClassification = (document: ClassificationDocument): string => {
+  const serialized = JSON.stringify(document.plan);
+  if (serialized.includes("\n") || serialized.includes("\r")) {
+    throw new Error("Serialized CI gate plan must fit on one GitHub output line.");
+  }
+  return `plan=${serialized}\n`;
+};
+
+const readOption = (args: readonly string[], name: string): string | undefined => {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`Missing value for ${name}.`);
+  return value;
+};
+
+const main = (): void => {
+  const input = readOption(process.argv.slice(2), "--input");
+  const output = process.env.GITHUB_OUTPUT;
+  if (!input || !output) throw new Error("--input and GITHUB_OUTPUT are required.");
+  const document = parseClassificationDocument(JSON.parse(readFileSync(input, "utf8")));
+  appendFileSync(output, githubOutputForClassification(document), "utf8");
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (!summary) return;
+  appendFileSync(
+    summary,
+    `## Change classification\n\n${document.changedPaths.length} changed path(s).\n\n    ${JSON.stringify(document.plan)}\n`,
+    "utf8",
+  );
+};
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/renderer/components/board/editor/block-transfer-drop.jsdom.test.ts
+++ b/src/renderer/components/board/editor/block-transfer-drop.jsdom.test.ts
@@ -82,6 +82,45 @@ describe("Board Card Block transfer drop", () => {
     ).toEqual({ parentBlockId: "parent" });
   });
 
+  test("removes active drop feedback when the target is replaced", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const cleanup = setupBlockTransferDocumentDrop(
+      container,
+      { document: [] },
+      {
+        surfaceId: "surface-target",
+        projectId: "project-a",
+        documentId: "document-host",
+        storeEpoch: "epoch-a",
+        ancestorPageIds: [],
+        createOperationId: () => "operation-a",
+        transfer: async () => {
+          throw new Error("The test does not drop");
+        },
+        reportError: vi.fn(),
+      },
+    );
+    const registration = dropTargetHarness.registration as ElementDropTargetArgs;
+    const self = { element: container, data: {}, dropEffect: "move" as const };
+    registration.onDrag?.({
+      source: { data: dragData },
+      location: {
+        current: { input: input(false), dropTargets: [self] },
+      },
+      self,
+    } as unknown as Parameters<NonNullable<ElementDropTargetArgs["onDrag"]>>[0]);
+
+    expect(container.hasAttribute("data-block-transfer-drop-hover")).toBe(true);
+    expect(container.querySelectorAll("[data-block-transfer-drop-indicator]")).toHaveLength(1);
+
+    cleanup();
+
+    expect(container.hasAttribute("data-block-transfer-drop-hover")).toBe(false);
+    expect(container.querySelectorAll("[data-block-transfer-drop-indicator]")).toHaveLength(0);
+    container.remove();
+  });
+
   test.each([
     [false, "move"],
     [true, "copy"],

--- a/src/renderer/components/board/editor/block-transfer-drop.ts
+++ b/src/renderer/components/board/editor/block-transfer-drop.ts
@@ -555,6 +555,7 @@ export const setupBlockTransferDocumentDrop = (
   container.addEventListener("drop", onNativeDrop, true);
 
   return () => {
+    clear();
     pragmaticCleanup();
     container.removeEventListener("dragenter", onNativeDragOver, true);
     container.removeEventListener("dragover", onNativeDragOver, true);

--- a/tests/e2e/board-dense.spec.ts
+++ b/tests/e2e/board-dense.spec.ts
@@ -123,7 +123,7 @@ const chooseFilterPickerOption = async ({
   await expect(async () => {
     if ((await trigger.textContent())?.includes(expectedLabel)) return;
     await openFilterPicker({ trigger, search });
-    await option.evaluate((element) => (element as HTMLElement).click());
+    await option.click({ timeout: 2_000 });
     await expect(trigger).toContainText(expectedLabel, { timeout: 2_000 });
   }).toPass({ timeout: 30_000 });
 };

--- a/tests/e2e/board-dense.spec.ts
+++ b/tests/e2e/board-dense.spec.ts
@@ -95,6 +95,39 @@ const setBoardCardPriority = async ({
   await page.getByRole("option", { name: optionName, exact: true }).click();
 };
 
+const openFilterPicker = async ({
+  trigger,
+  search,
+}: {
+  readonly trigger: Locator;
+  readonly search: Locator;
+}): Promise<void> => {
+  await expect(async () => {
+    if (await search.isVisible()) return;
+    await trigger.click({ timeout: 2_000 });
+    await expect(search).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 10_000 });
+};
+
+const chooseFilterPickerOption = async ({
+  trigger,
+  search,
+  option,
+  expectedLabel,
+}: {
+  readonly trigger: Locator;
+  readonly search: Locator;
+  readonly option: Locator;
+  readonly expectedLabel: string;
+}): Promise<void> => {
+  await expect(async () => {
+    if ((await trigger.textContent())?.includes(expectedLabel)) return;
+    await openFilterPicker({ trigger, search });
+    await option.evaluate((element) => (element as HTMLElement).click());
+    await expect(trigger).toContainText(expectedLabel, { timeout: 2_000 });
+  }).toPass({ timeout: 30_000 });
+};
+
 const dragBoardCardWithMouse = async ({
   page,
   source,
@@ -389,14 +422,24 @@ test("keeps the canonical Board while grouping and dragging by Priority", async 
 
     await page.getByRole("button", { name: "Display options" }).click();
     const orderBy = page.getByRole("button", { name: "Order by", exact: true });
-    await orderBy.click();
-    await page.getByRole("option", { name: "Priority", exact: true }).click();
-    await expect(orderBy).toContainText("Priority");
+    const orderBySearch = page.getByRole("combobox", { name: "Search Order by" });
+    await chooseFilterPickerOption({
+      trigger: orderBy,
+      search: orderBySearch,
+      option: page.getByRole("option", { name: "Priority", exact: true }),
+      expectedLabel: "Priority",
+    });
+    await expect(orderBySearch).toBeHidden();
     const groupBy = page.getByRole("button", { name: "Group by", exact: true });
     await expect(groupBy).toHaveAttribute("aria-disabled", "false");
-    await groupBy.click();
-    await page.getByRole("option", { name: "Priority", exact: true }).click();
-    await expect(groupBy).toContainText("Priority");
+    const groupBySearch = page.getByRole("combobox", { name: "Search Group by" });
+    await chooseFilterPickerOption({
+      trigger: groupBy,
+      search: groupBySearch,
+      option: page.getByRole("option", { name: "Priority", exact: true }),
+      expectedLabel: "Priority",
+    });
+    await expect(groupBySearch).toBeHidden();
 
     const highColumn = page.locator(
       '[data-board-column-root][data-board-column-id="p1-high"]',

--- a/tests/e2e/board-dense.spec.ts
+++ b/tests/e2e/board-dense.spec.ts
@@ -78,6 +78,36 @@ const readOpaqueSurfaceStyle = async (surface: Locator) => {
   });
 };
 
+interface LocatorGeometry {
+  readonly height: number;
+  readonly width: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+const requireLocatorGeometry = async (
+  locator: Locator,
+  label: string,
+): Promise<LocatorGeometry> => {
+  let geometry: LocatorGeometry | null = null;
+  await expect(async () => {
+    geometry = await locator.boundingBox();
+    expect(geometry, `${label} geometry is unavailable`).not.toBeNull();
+  }).toPass({ timeout: 10_000 });
+  if (!geometry) throw new Error(`${label} geometry is unavailable`);
+  return geometry;
+};
+
+const revealWithHover = async (
+  target: Locator,
+  revealed: Locator,
+): Promise<void> => {
+  await expect(async () => {
+    await target.hover({ timeout: 2_000 });
+    await expect(revealed).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 15_000 });
+};
+
 const setBoardCardPriority = async ({
   page,
   pageId,
@@ -139,9 +169,8 @@ const dragBoardCardWithMouse = async ({
   readonly target: Locator;
   readonly expectPropertyChangeIndicator?: boolean;
 }): Promise<void> => {
-  const sourceBox = await source.boundingBox();
-  const targetBox = await target.boundingBox();
-  if (!sourceBox || !targetBox) throw new Error("Board drag geometry is unavailable");
+  const sourceBox = await requireLocatorGeometry(source, "Board drag source");
+  const targetBox = await requireLocatorGeometry(target, "Board drag target");
   const sourcePoint = {
     x: sourceBox.x + 3,
     y: sourceBox.y + sourceBox.height / 2,
@@ -272,11 +301,8 @@ const dragDatabasePageToEditorWithMouse = async ({
   await source.scrollIntoViewIfNeeded();
   const editorSurface = editor.locator('.ProseMirror[contenteditable="true"]').first();
   await editorSurface.scrollIntoViewIfNeeded();
-  const sourceBox = await source.boundingBox();
-  const editorBox = await editorSurface.boundingBox();
-  if (!sourceBox || !editorBox) {
-    throw new Error("Database Page to editor drag geometry is unavailable");
-  }
+  const sourceBox = await requireLocatorGeometry(source, "Database Page drag source");
+  const editorBox = await requireLocatorGeometry(editorSurface, "Database Page drag target");
   const sourcePoint = {
     x: sourceBox.x + Math.min(12, sourceBox.width / 2),
     y: sourceBox.y + sourceBox.height / 2,
@@ -601,15 +627,14 @@ test("materializes and opens the authoritative board/dense environment", async (
       name: "More options for Build",
     });
     await expect(moreOptions).toHaveCSS("opacity", "1");
-    const labelBox = await buildHeader.locator(
-      '[data-database-board-column-label="true"]',
-    ).boundingBox();
-    const countBox = await buildHeader.locator(
-      '[data-database-board-column-count="true"]',
-    ).boundingBox();
-    if (!labelBox || !countBox) {
-      throw new Error("Board Column label geometry is unavailable");
-    }
+    const labelBox = await requireLocatorGeometry(
+      buildHeader.locator('[data-database-board-column-label="true"]'),
+      "Board Column label",
+    );
+    const countBox = await requireLocatorGeometry(
+      buildHeader.locator('[data-database-board-column-count="true"]'),
+      "Board Column count",
+    );
     expect(countBox.x - (labelBox.x + labelBox.width)).toBeLessThanOrEqual(8);
     await moreOptions.click();
     await page.getByRole("button", { name: "Collapse", exact: true }).click();
@@ -630,24 +655,23 @@ test("materializes and opens the authoritative board/dense environment", async (
         .match(/[\d.]+/gu)?.map(Number) ?? [];
       return background.length < 4 || background[3] === 1;
     })).toBe(true);
-    const collapsedIconBox = await buildHeader.locator("svg").first().boundingBox();
-    const collapsedLabelBox = await buildHeader.locator(
-      '[data-database-board-collapsed-label="true"]',
-    ).boundingBox();
-    if (!collapsedIconBox || !collapsedLabelBox) {
-      throw new Error("Collapsed Board Column geometry is unavailable");
-    }
+    const collapsedIconBox = await requireLocatorGeometry(
+      buildHeader.locator("svg").first(),
+      "Collapsed Board Column icon",
+    );
+    const collapsedLabelBox = await requireLocatorGeometry(
+      buildHeader.locator('[data-database-board-collapsed-label="true"]'),
+      "Collapsed Board Column label",
+    );
     expect(collapsedLabelBox.y - (collapsedIconBox.y + collapsedIconBox.height))
       .toBeLessThanOrEqual(10);
     await buildColumn.getByRole("button", { name: "Expand Build" }).click();
     await expect(buildColumn).toHaveAttribute("data-board-column-collapsed", "false");
-    const headerBox = await buildHeader.boundingBox();
-    const buildBodyBox = await page.locator(
-      '[data-board-column-root][data-board-column-id="build"]',
-    ).boundingBox();
-    if (!headerBox || !buildBodyBox) {
-      throw new Error("Board Column geometry is unavailable");
-    }
+    const headerBox = await requireLocatorGeometry(buildHeader, "Board Column header");
+    const buildBodyBox = await requireLocatorGeometry(
+      page.locator('[data-board-column-root][data-board-column-id="build"]'),
+      "Board Column body",
+    );
     expect(Math.abs(headerBox.y + headerBox.height - buildBodyBox.y)).toBeLessThanOrEqual(1);
     const boardScreenshot = testInfo.outputPath("board-project-home.png");
     await page.screenshot({ path: boardScreenshot, fullPage: true });
@@ -793,9 +817,8 @@ test("materializes and opens the authoritative board/dense environment", async (
     expect(editorPageLinkStyle.paddingLeft).toBe("0px");
     expect(editorPageLinkStyle.paddingRight).toBe("0px");
     expect(editorPageLinkStyle.textDecorationLine).toBe("none");
-    await editorPageLink.hover();
     const linkToolbar = page.getByRole("toolbar", { name: "Link actions" });
-    await expect(linkToolbar).toBeVisible();
+    await revealWithHover(editorPageLink, linkToolbar);
     await expect(linkToolbar.getByRole("button", { name: "Edit" })).toBeVisible();
     await expect(linkToolbar.getByRole("button", { name: "Clear" })).toBeVisible();
     await expect(linkToolbar.getByRole("button", { name: "Copy" })).toBeVisible();
@@ -805,12 +828,8 @@ test("materializes and opens the authoritative board/dense environment", async (
     const compactToolbarSurface = await readOpaqueSurfaceStyle(linkToolbar);
     expect(compactToolbarSurface.backgroundImage).toBe("none");
     expect(compactToolbarSurface.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
-    const compactToolbarBox = await linkToolbar.boundingBox();
-    expect(compactToolbarBox).not.toBeNull();
-    if (!compactToolbarBox) throw new Error("Link toolbar geometry is unavailable");
-    const editorPageLinkBox = await editorPageLink.boundingBox();
-    expect(editorPageLinkBox).not.toBeNull();
-    if (!editorPageLinkBox) throw new Error("Editor link geometry is unavailable");
+    const compactToolbarBox = await requireLocatorGeometry(linkToolbar, "Link toolbar");
+    const editorPageLinkBox = await requireLocatorGeometry(editorPageLink, "Editor link");
     expect(compactToolbarBox.y).toBeGreaterThanOrEqual(editorPageLinkBox.y + editorPageLinkBox.height);
     await linkToolbar.getByRole("button", { name: "Edit" }).click();
     const editToolbar = page.getByRole("toolbar", { name: "Edit link" });
@@ -833,18 +852,16 @@ test("materializes and opens the authoritative board/dense environment", async (
     expect(applyButtonStyle.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(applyButtonStyle.borderRadius).not.toBe("0px");
     expect(applyButtonStyle.padding).toBe("0px");
-    const editApplyIconBox = await applyButton.locator("svg").boundingBox();
-    expect(editApplyIconBox).not.toBeNull();
-    if (!editApplyIconBox) throw new Error("Link apply icon geometry is unavailable");
+    const editApplyIconBox = await requireLocatorGeometry(
+      applyButton.locator("svg"),
+      "Link apply icon",
+    );
     expect(editApplyIconBox.width).toBeCloseTo(12, 0);
     expect(editApplyIconBox.height).toBeCloseTo(12, 0);
-    const editToolbarBox = await editToolbar.boundingBox();
-    expect(editToolbarBox).not.toBeNull();
-    if (!editToolbarBox) throw new Error("Link edit toolbar geometry is unavailable");
+    const editToolbarBox = await requireLocatorGeometry(editToolbar, "Link edit toolbar");
     expect(editToolbarBox.height).toBeCloseTo(compactToolbarBox.height, 0);
     await page.keyboard.press("Escape");
-    await editorPageLink.hover();
-    await expect(linkToolbar).toBeVisible();
+    await revealWithHover(editorPageLink, linkToolbar);
     const editorPageLinkHoverStyle = await editorPageLink.evaluate((element) => {
       const style = globalThis.getComputedStyle(element);
       return {
@@ -875,13 +892,8 @@ test("materializes and opens the authoritative board/dense environment", async (
     const pageSection = mentionMenu.getByText("Mention a page", { exact: true });
     await expect(dateSection).toBeVisible();
     await expect(pageSection).toBeVisible();
-    const dateSectionBox = await dateSection.boundingBox();
-    const pageSectionBox = await pageSection.boundingBox();
-    expect(dateSectionBox).not.toBeNull();
-    expect(pageSectionBox).not.toBeNull();
-    if (!dateSectionBox || !pageSectionBox) {
-      throw new Error("Mention section geometry is unavailable");
-    }
+    const dateSectionBox = await requireLocatorGeometry(dateSection, "Date mention section");
+    const pageSectionBox = await requireLocatorGeometry(pageSection, "Page mention section");
     expect(dateSectionBox.y).toBeLessThan(pageSectionBox.y);
     const pageRows = mentionMenu.locator('[role="option"][data-mention-kind="page"]');
     const pageMoreRow = mentionMenu.locator(
@@ -1036,13 +1048,11 @@ test("materializes and opens the authoritative board/dense environment", async (
     );
     await expect(mentionFocusAffordance).toBeVisible();
     await expect(mentionFocusAffordance).toHaveText("Open page↵");
-    const mentionBounds = await insertedMention.boundingBox();
-    const affordanceBounds = await mentionFocusAffordance.boundingBox();
-    expect(mentionBounds).not.toBeNull();
-    expect(affordanceBounds).not.toBeNull();
-    if (!mentionBounds || !affordanceBounds) {
-      throw new Error("Mention focus affordance geometry is unavailable");
-    }
+    const mentionBounds = await requireLocatorGeometry(insertedMention, "Page mention");
+    const affordanceBounds = await requireLocatorGeometry(
+      mentionFocusAffordance,
+      "Mention focus affordance",
+    );
     expect(affordanceBounds.y).toBeGreaterThanOrEqual(
       mentionBounds.y + mentionBounds.height - 1,
     );

--- a/tests/e2e/database-context-menu-performance.spec.ts
+++ b/tests/e2e/database-context-menu-performance.spec.ts
@@ -87,7 +87,7 @@ const measureCopySubmenuOpen = async (page: Page): Promise<number> =>
     return performance.now() - startedAt;
   });
 
-test("keeps production-scale Database context menus inside the interaction budget", async ({}, testInfo) => {
+test("keeps production-scale Database context menus inside the interaction budget @performance", async ({}, testInfo) => {
   test.setTimeout(300_000);
   await withElectronScenario({
     label: "database-context-menu-performance",

--- a/tests/e2e/electron-smoke.spec.ts
+++ b/tests/e2e/electron-smoke.spec.ts
@@ -1221,6 +1221,9 @@ async function sampleLargeContentScenario(input: {
   }
 }
 
+test.describe("parallel functional Electron smoke", () => {
+  test.describe.configure({ mode: process.env.CI ? "parallel" : "default" });
+
 test("provisions and persists the initial source-backed Project across a full Electron restart", async () => {
   test.setTimeout(120_000);
   const harness = await ElectronScenarioHarness.create({
@@ -1428,14 +1431,24 @@ test("New Chat reuses its default draft and opens a pre-thread Terminal", async 
     expect(repeatedSessions[0]?.id).toBe(firstSessionId);
     expect(repeatedSessions[0]?.thread).toBeNull();
 
-    await page.getByRole("button", { name: "Toggle bottom panel" }).click();
+    const bottomPanelToggle = page.getByRole("button", { name: "Toggle bottom panel" });
+    await bottomPanelToggle.click();
+    await expect(bottomPanelToggle).toHaveAttribute("aria-pressed", "true");
+    const terminalSurface = page.locator(".xterm-screen").last();
+    await expect(terminalSurface).toBeVisible();
+    const terminalRows = page.locator(".xterm-rows").last();
+    await expect.poll(
+      async () => (await terminalRows.textContent())?.trim() ?? "",
+      { timeout: 30_000 },
+    ).not.toBe("");
+    await terminalSurface.click();
     const terminalInput = page.getByRole("textbox", { name: "Terminal input" });
-    await expect(terminalInput).toBeVisible();
-    await terminalInput.pressSequentially("pwd");
-    await terminalInput.press("Enter");
+    await expect(terminalInput).toBeFocused();
+    await page.keyboard.type("pwd", { delay: 20 });
+    await page.keyboard.press("Enter");
     await expect.poll(async () => (
-      await page.locator(".xterm-rows").last().textContent()
-    ) ?? "").toContain(project.primaryWorkspaceRoot);
+      await terminalRows.textContent()
+    ) ?? "", { timeout: 30_000 }).toContain(project.primaryWorkspaceRoot);
   } finally {
     await harness.close();
   }
@@ -1849,13 +1862,18 @@ test("creates one stable Board Page and edits its grouping Property @create-moda
       `[data-list-row="true"][data-database-view-page-id="${createdPageId}"]`,
     );
     await expect(createdRow).toBeVisible();
-    await createdRow.click({ button: "right" });
     const priorityItem = page.getByRole("menuitem", { name: /Priority/ });
-    await expect(priorityItem).toBeVisible();
-    await priorityItem.click();
     const priorityOption = page.getByRole("option", { name: "P1 - High", exact: true });
-    await expect(priorityOption).toBeVisible();
-    await priorityOption.click();
+    await expect(async () => {
+      if (await priorityOption.isVisible()) return;
+      if (!(await priorityItem.isVisible())) {
+        await createdRow.click({ button: "right", timeout: 2_000 });
+        await expect(priorityItem).toBeVisible({ timeout: 2_000 });
+      }
+      await priorityItem.click({ timeout: 2_000 });
+      await expect(priorityOption).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000 });
+    await priorityOption.evaluate((option) => (option as HTMLElement).click());
 
     await expect.poll(async () => {
       const snapshot = requireIpcValue<Record<string, unknown>>(
@@ -2699,8 +2717,9 @@ test("opens and pointer-reorders a nested List subtree without changing its inte
     await harness.close();
   }
 });
+});
 
-test("keeps Page ready and idle CPU bounded with 14k LocalCommit history", async ({}, testInfo) => {
+test("keeps Page ready and idle CPU bounded with 14k LocalCommit history @performance", async ({}, testInfo) => {
   test.setTimeout(360_000);
   const harness = await ElectronScenarioHarness.create({ label: "page-ready-pressure" });
   const nodexHome = harness.profile.nodexHome;
@@ -3496,7 +3515,7 @@ test("converges a high-pressure Page promotion across tab groups and WebContents
   }
 });
 
-test("measures high-pressure nested Block transfer into a populated Board", async ({}, testInfo) => {
+test("measures high-pressure nested Block transfer into a populated Board @performance", async ({}, testInfo) => {
   test.setTimeout(HIGH_PRESSURE_TEST_TIMEOUT_MS);
   const keepFixture = process.env.NODEX_KEEP_BOARD_TRANSFER_FIXTURE === "1";
   const harness = await ElectronScenarioHarness.create({
@@ -3905,7 +3924,7 @@ test("measures high-pressure nested Block transfer into a populated Board", asyn
   }
 });
 
-test("keeps representative large-content surfaces bounded in a real Electron renderer", async ({}, testInfo) => {
+test("keeps representative large-content surfaces bounded in a real Electron renderer @performance", async ({}, testInfo) => {
   test.setTimeout(180_000);
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nodex-large-content-e2e-"));
   const builtFixtureDir = path.join(fixtureRoot, "renderer");

--- a/tests/e2e/electron-smoke.spec.ts
+++ b/tests/e2e/electron-smoke.spec.ts
@@ -1873,7 +1873,7 @@ test("creates one stable Board Page and edits its grouping Property @create-moda
       await priorityItem.click({ timeout: 2_000 });
       await expect(priorityOption).toBeVisible({ timeout: 2_000 });
     }).toPass({ timeout: 15_000 });
-    await priorityOption.evaluate((option) => (option as HTMLElement).click());
+    await priorityOption.click({ timeout: 2_000 });
 
     await expect.poll(async () => {
       const snapshot = requireIpcValue<Record<string, unknown>>(

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",
+    "rewriteRelativeImportExtensions": true,
     "strict": true,
     "noEmit": true,
     "incremental": true,

--- a/vitest.renderer.config.ts
+++ b/vitest.renderer.config.ts
@@ -5,6 +5,7 @@ import {
   rendererViteResolve,
 } from "./config/renderer-vite-shared";
 import { selectTieredTestFiles } from "./config/vitest-test-tier";
+import { rendererWorkerCount } from "./config/renderer-worker-count";
 
 const testFiles = selectTieredTestFiles({
   defaultExclude: [
@@ -32,7 +33,7 @@ export default defineConfig({
     exclude: testFiles.exclude,
     include: testFiles.include,
     pool: "forks",
-    maxWorkers: testFiles.isStress ? 1 : 2,
+    maxWorkers: rendererWorkerCount({ ci: process.env.CI === "true", stress: testFiles.isStress }),
     fileParallelism: !testFiles.isStress,
     passWithNoTests: testFiles.isStress,
     setupFiles: ["./src/renderer/test/setup.ts"],


### PR DESCRIPTION
Required CI feedback was dominated by serial application suites, serial static checks, exhaustive Rust work on ordinary PRs, Main workflow queueing, and Electron performance scenarios duplicated in the functional gate.

This change introduces a typed, fail-closed gate plan; reusable app/static matrices; parallel exhaustive Main Rust lanes; measurable p50/p90 and runner-minute reporting; four CI renderer workers; and explicit functional versus performance E2E ownership. Main CI remains the exhaustive upstream for production Release, while release execution stays serialized.

Validation:
- pnpm run typecheck
- pnpm run lint
- pnpm test
- pnpm run verify:static
- pnpm run core:fmt
- pnpm run core:clippy
- pnpm run core:test:workspace
- pnpm run core:test:migration
- 30 focused CI model tests
- workflow contracts across 18 workflows
- functional Electron E2E: 14/14 with 2 workers, no retry
- performance E2E selection: 4 exclusively owned scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Electron and board end-to-end test reliability with retries, readiness checks, and parallel execution.
  * Integration tests now prepare required development support before running.
* **New Features**
  * Added CI timing reports with queue, runtime, runner usage, and success statistics.
  * Added configurable renderer test workers for normal, local, and stress runs.
  * Performance end-to-end tests can now be run separately from standard validation.
* **Documentation**
  * Expanded CI and release documentation covering workflow selection, parallelism, concurrency, and timing reports.
* **Tests**
  * Added broad coverage for CI planning, validation, timing reports, worker selection, and test-suite execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->