### PR TITLE
fix(editor): keep Page Stage stable during Block transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed moving the final Block from Page Stage into Board or List crashing the source editor; remote structural deletions now restore a valid selection, and cross-surface transfers require prepared causal heads.
 - Fixed Core-backed views intermittently timing out during larger searches or maintenance; interactive work keeps reserved capacity, Full Page search avoids pathological SQLite query plans and preserves multi-term evidence, stale searches cancel silently end to end, and slow requests return typed Core outcomes instead of arbitrary transport failures.
 
 ## [0.2.2] - 2026-08-18

--- a/docs/adr/0040-local-commit-authority-and-causal-structural-mutations.md
+++ b/docs/adr/0040-local-commit-authority-and-causal-structural-mutations.md
@@ -163,13 +163,17 @@ fingerprints may share computed patch bytes, but never scope identity,
 revision, hash, or deduplication. Main maintains one multiplexed scoped-live
 broker and changes its active scope set make-before-break.
 
-Every mounted collaborative Document surface exposes a
-`BlockDocumentMutationBarrier`. It flushes local durable updates and returns a
-`DocumentHeadToken` containing Document identity, Store epoch, generation, and
-head sequence. Move-to and cross-surface Block DnD pass the tokens as causal
-dependencies. Core verifies them while preparing and revalidates them in the
-writer transaction against current SQLite Document rows. The dependency is excluded from the semantic
-intent hash so a retry after a fresh read remains the same idempotent command.
+Every mounted collaborative Document editor registers one structural-mutation
+participant over its `BlockDocumentMutationBarrier`. The participant first
+settles transient editor state, including IME, native Block drag ownership, and
+focus, then flushes local durable updates and returns a `DocumentHeadToken`
+containing Document identity, Store epoch, generation, and head sequence.
+Move-to and cross-surface Block DnD require the affected mounted participants
+and pass their tokens as causal dependencies; a participant that disappears
+causes the renderer command to fail closed. Core verifies the tokens while
+preparing and revalidates them in the writer transaction against current SQLite
+Document rows. The dependency is excluded from the semantic intent hash so a
+retry after a fresh read remains the same idempotent command.
 
 Document/Canvas live streams independently enforce per-surface head order. They
 buffer a bounded future-head gap and emit typed repair on overflow or epoch

--- a/docs/product-specs/board-drag-and-drop-behavior.md
+++ b/docs/product-specs/board-drag-and-drop-behavior.md
@@ -126,6 +126,10 @@ This post-removal contract must stay identical across:
 - Move submits one logical `BlockTransfer`: text-like roots promote to Cards in place, while non-convertible roots receive deterministic wrapper Cards. Copy recursively clones ownership with fresh IDs and leaves the source unchanged. Neither path serializes NFM nor mutates a Card description projection.
 - Multi-block order follows the selected top-level document order. Nested selected blocks are represented only once through their selected ancestor.
 - Board and List interpret pointer geometry into their own raw placement intent, while one shared renderer command owns session validation, source fencing, transfer, receipt feedback, and Undo registration. Core resolves the final placement and Property adoption atomically.
+- A mounted source editor must finish its native drag state and return a fresh
+  causal Document head before the command is submitted. If that exact source
+  participant has unmounted or changed, the drop fails and asks the user to
+  start the drag again; it never submits an unfenced transfer.
 - A direct Board placement freezes the complete effective presentation that
   authored the gesture. Core normalizes and validates grouping and writable
   sort values against that presentation, never against a different durable
@@ -141,6 +145,9 @@ This post-removal contract must stay identical across:
 ### NFM editor -> NFM editor
 - An explicit side-menu drag between different Card Documents carries stable root Block IDs and logical Document coordinates through the same window-local session. The destination renders the horizontal block insertion line and suppresses ProseMirror's vertical text caret.
 - The target does not insert a serialized ProseMirror/HTML slice, and the source does not later delete its selection. One `BlockTransfer` commits both Document updates and Block locations or leaves both unchanged.
+- Both mounted editors settle transient drag/focus state and supply causal
+  Document heads before the transfer. A missing source or target participant
+  fails closed.
 - Same mounted-surface reorder remains BlockNote-native because it is already one Yjs transaction in one Document. Two separately mounted surfaces over the same logical Document fail closed until a stable-ID single-Document move command is available.
 - In nested Card outliners, the closest `.nfm-editor` to the event target owns the drop. An outer editor capture listener must not steal a drop intended for an embedded Card body.
 

--- a/docs/reliability/document-sync-history-and-retention.md
+++ b/docs/reliability/document-sync-history-and-retention.md
@@ -40,10 +40,21 @@ compact retry delta and stops automatic retry until new local work or an
 explicit lifecycle checkpoint arrives.
 
 Structural operations that consume mounted Document shape first flush pending
-updates and carry a typed causal head token. Core rechecks the token with every
-owner, membership, and authorization fact in the committing transaction.
+updates and carry a typed causal head token. The mounted editor participant
+finishes transient native drag/focus/IME state before that flush; losing any
+required participant fails the command instead of silently omitting its causal
+head. Core rechecks the token with every owner, membership, and authorization fact in the committing transaction.
 Response-loss retry retains the original logical intent; the transient head
 proof is not part of idempotent identity.
+
+Yjs invokes editor observers synchronously while applying remote updates. An
+observer may fail after the Y.Doc has already integrated the update, leaving
+the editor projection and provider head behind the CRDT state. This boundary is
+`recovery_required`: the surface discards that replica and synchronizes a fresh
+one. It must not retry on the same Y.Doc or misclassify a local editor
+projection failure as malformed Core content. Collaborative selection restore
+falls back to a nearby valid selection when a remotely removed Node selection
+no longer has a selectable node at its relative anchor.
 
 Cross-Document transfer and copy prepare against isolated clones, then recheck
 all captured heads and ownership facts under the writer. Each affected Document

--- a/patches/y-prosemirror@1.3.7.patch
+++ b/patches/y-prosemirror@1.3.7.patch
@@ -1,0 +1,19 @@
+diff --git a/src/plugins/sync-plugin.js b/src/plugins/sync-plugin.js
+index dccfb76..09dd1e1 100644
+--- a/src/plugins/sync-plugin.js
++++ b/src/plugins/sync-plugin.js
+@@ -7 +7 @@ import * as PModel from 'prosemirror-model'
+-import { AllSelection, Plugin, TextSelection, NodeSelection } from "prosemirror-state"; // eslint-disable-line
++import { AllSelection, Plugin, Selection, TextSelection, NodeSelection } from "prosemirror-state"; // eslint-disable-line
+@@ -260 +260,10 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
+-      tr.setSelection(NodeSelection.create(tr.doc, anchor))
++      if (anchor !== null) {
++        const safeAnchor = Math.max(0, Math.min(anchor, tr.doc.content.size))
++        const $anchor = tr.doc.resolve(safeAnchor)
++        const node = $anchor.nodeAfter
++        tr.setSelection(
++          node !== null && NodeSelection.isSelectable(node)
++            ? NodeSelection.create(tr.doc, safeAnchor)
++            : Selection.near($anchor)
++        )
++      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ overrides:
   tmp: 0.2.7
   yaml: 2.9.0
 
+patchedDependencies:
+  y-prosemirror@1.3.7: 1455252e42a8d5765c73ee98bfda5934fb8398a5a8f15cc58a44c1d8439ef375
+
 importers:
 
   .:
@@ -551,7 +554,7 @@ importers:
         version: 1.41.9
       y-prosemirror:
         specifier: ^1.3.7
-        version: 1.3.7(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.9)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+        version: 1.3.7(patch_hash=1455252e42a8d5765c73ee98bfda5934fb8398a5a8f15cc58a44c1d8439ef375)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.9)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
       y-protocols:
         specifier: ^1.0.6
         version: 1.0.7(yjs@13.6.31)
@@ -15586,7 +15589,7 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  y-prosemirror@1.3.7(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.9)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31):
+  y-prosemirror@1.3.7(patch_hash=1455252e42a8d5765c73ee98bfda5934fb8398a5a8f15cc58a44c1d8439ef375)(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.9)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31):
     dependencies:
       lib0: 0.2.117
       prosemirror-model: 1.25.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ packages:
   - "packages/*"
   - "third_party/blocknote/packages/*"
 
+patchedDependencies:
+  y-prosemirror@1.3.7: patches/y-prosemirror@1.3.7.patch
+
 supportedArchitectures:
   os:
     - current

--- a/src/renderer/components/board/editor/block-transfer-drop.browser.test.ts
+++ b/src/renderer/components/board/editor/block-transfer-drop.browser.test.ts
@@ -5,6 +5,21 @@ import {
 } from "../../workbench/block-transfer/cross-surface-drag";
 import { setupBlockTransferDocumentDrop } from "./block-transfer-drop";
 
+const structuralPreparation = {
+  prepareAndFence: async () => ({
+    documentId: "document-target",
+    storeEpoch: "epoch-a",
+    generation: 1,
+    expectedHeadSeq: 0,
+  }),
+  prepareSourceAndFence: async () => ({
+    documentId: "document-source",
+    storeEpoch: "epoch-a",
+    generation: 1,
+    expectedHeadSeq: 0,
+  }),
+};
+
 describe("nested Block transfer targets in Chromium", () => {
   test("hands indicator ownership from the parent editor to the sub-editor", () => {
     const outer = document.createElement("div");
@@ -21,6 +36,7 @@ describe("nested Block transfer targets in Chromium", () => {
       outer,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-outer",
         projectId: "project-a",
         documentId: "document-outer",
@@ -37,6 +53,7 @@ describe("nested Block transfer targets in Chromium", () => {
       inner,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-inner",
         projectId: "project-a",
         documentId: "document-inner",

--- a/src/renderer/components/board/editor/block-transfer-drop.jsdom.test.ts
+++ b/src/renderer/components/board/editor/block-transfer-drop.jsdom.test.ts
@@ -57,6 +57,21 @@ const input = (altKey: boolean) => ({
   shiftKey: false,
 });
 
+const structuralPreparation = {
+  prepareAndFence: async () => ({
+    documentId: "document-target",
+    storeEpoch: "epoch-a",
+    generation: 1,
+    expectedHeadSeq: 0,
+  }),
+  prepareSourceAndFence: async () => ({
+    documentId: "document-source",
+    storeEpoch: "epoch-a",
+    generation: 1,
+    expectedHeadSeq: 0,
+  }),
+};
+
 describe("Board Card Block transfer drop", () => {
   test("resolves before/after against the target Block hierarchy", () => {
     const editor: BlockTransferDropEditor = {
@@ -89,6 +104,7 @@ describe("Board Card Block transfer drop", () => {
       container,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-target",
         projectId: "project-a",
         documentId: "document-host",
@@ -166,6 +182,7 @@ describe("Board Card Block transfer drop", () => {
         container,
         { document: [] },
         {
+          ...structuralPreparation,
           surfaceId: "surface-target",
           projectId: "project-a",
           documentId: "document-host",
@@ -243,13 +260,13 @@ describe("Board Card Block transfer drop", () => {
         },
       };
     });
-    const flushAndFence = vi.fn(async () => ({
+    const prepareAndFence = vi.fn(async () => ({
       documentId: "document-target",
       storeEpoch: "epoch-a",
       generation: 1,
       expectedHeadSeq: 0,
     }));
-    const flushSourceAndFence = vi.fn(async () => ({
+    const prepareSourceAndFence = vi.fn(async () => ({
       documentId: "document-source",
       storeEpoch: "epoch-a",
       generation: 1,
@@ -264,8 +281,8 @@ describe("Board Card Block transfer drop", () => {
         documentId: "document-target",
         storeEpoch: "epoch-a",
         ancestorPageIds: [],
-        flushAndFence,
-        flushSourceAndFence,
+        prepareAndFence,
+        prepareSourceAndFence,
         createOperationId: () => "operation-editor",
         transfer,
         reportError: vi.fn(),
@@ -312,8 +329,8 @@ describe("Board Card Block transfer drop", () => {
         source: { kind: "document", documentId: "document-source" },
         target: { kind: "document", documentId: "document-target" },
       });
-      expect(flushAndFence).toHaveBeenCalledOnce();
-      expect(flushSourceAndFence).toHaveBeenCalledWith("surface-source");
+      expect(prepareAndFence).toHaveBeenCalledOnce();
+      expect(prepareSourceAndFence).toHaveBeenCalledWith("surface-source");
     } finally {
       cleanup();
       endLocalBlockDragSession();
@@ -330,6 +347,7 @@ describe("Board Card Block transfer drop", () => {
       container,
       { document: [{ id: "canvas-1" }, { id: "paragraph-1" }] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-page",
         projectId: "project-a",
         documentId: "document-page",
@@ -424,6 +442,7 @@ describe("Board Card Block transfer drop", () => {
         getExtension: () => ({ clearDropCursor: clearOuterDropCursor }),
       },
       {
+        ...structuralPreparation,
         surfaceId: "surface-outer",
         projectId: "project-a",
         documentId: "document-outer",
@@ -438,6 +457,7 @@ describe("Board Card Block transfer drop", () => {
       inner,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-inner",
         projectId: "project-a",
         documentId: "document-inner",
@@ -541,6 +561,7 @@ describe("Board Card Block transfer drop", () => {
       outer,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-outer-pragmatic",
         projectId: "project-a",
         documentId: "document-outer",
@@ -555,6 +576,7 @@ describe("Board Card Block transfer drop", () => {
       inner,
       { document: [] },
       {
+        ...structuralPreparation,
         surfaceId: "surface-inner-pragmatic",
         projectId: "project-a",
         documentId: "document-inner",

--- a/src/renderer/components/board/editor/block-transfer-drop.ts
+++ b/src/renderer/components/board/editor/block-transfer-drop.ts
@@ -47,12 +47,12 @@ export interface BlockTransferDropBoundary {
   readonly storeEpoch: string;
   readonly hostPageId?: string;
   readonly ancestorPageIds: readonly string[];
-  /** Flushes unsent edits in the destination document before Core plans. */
-  readonly flushAndFence?: () => Promise<DocumentHeadFence>;
-  /** Flushes the actual drag source session when it is mounted locally. */
-  readonly flushSourceAndFence?: (
+  /** Settles the destination editor and flushes its durable causal head. */
+  readonly prepareAndFence: () => Promise<DocumentHeadFence>;
+  /** Settles and flushes the actual drag source mounted in this renderer. */
+  readonly prepareSourceAndFence: (
     sourceSurfaceId: string,
-  ) => Promise<DocumentHeadFence | undefined>;
+  ) => Promise<DocumentHeadFence>;
   readonly transfer: (
     intent: PublicBlockTransferIntent,
   ) => Promise<BlockTransferCommandResult>;
@@ -249,10 +249,10 @@ export const setupBlockTransferDocumentDrop = (
     sourceSurfaceId?: string,
   ): Promise<readonly DocumentHeadFence[]> => {
     const tokens = await Promise.all([
-      boundary.flushAndFence?.(),
-      sourceSurfaceId === undefined
+      boundary.prepareAndFence(),
+      sourceSurfaceId === undefined || sourceSurfaceId === boundary.surfaceId
         ? undefined
-        : boundary.flushSourceAndFence?.(sourceSurfaceId),
+        : boundary.prepareSourceAndFence(sourceSurfaceId),
     ]);
     return tokens.filter(
       (token): token is DocumentHeadFence => token !== undefined,

--- a/src/renderer/components/board/editor/nfm-editor-relocation.test.tsx
+++ b/src/renderer/components/board/editor/nfm-editor-relocation.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { render } from "@/test/dom";
 import {
   prepareNfmEditorForMutation,
+  prepareNfmEditorStructuralMutation,
   type NfmEditorMutationRuntime,
 } from "./nfm-editor-relocation";
 
@@ -38,5 +39,49 @@ describe("NfmEditor mutation preparation", () => {
     await prepareNfmEditorForMutation(runtime, container);
     expect(other.ownerDocument.activeElement === other).toBe(true);
     expect(blurCalls).toBe(1);
+  });
+
+  test("finishes native drag state before flushing the structural head", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const order: string[] = [];
+    const editor = {
+      prosemirrorView: {
+        dragging: { slice: "dragged" },
+        root: document,
+      },
+      getExtension: () => ({
+        blockDragEnd: () => {
+          order.push("drag-end");
+        },
+      }),
+      blur: () => {
+        order.push("blur");
+      },
+      isFocused: () => true,
+    };
+    const flushAndFence = vi.fn(async () => {
+      order.push("flush");
+      return {
+        documentId: "document-1",
+        storeEpoch: "epoch-1",
+        generation: 1,
+        expectedHeadSeq: 4,
+      };
+    });
+
+    try {
+      const fence = await prepareNfmEditorStructuralMutation(
+        editor,
+        container,
+        { flushAndFence },
+      );
+
+      expect(editor.prosemirrorView.dragging).toBeNull();
+      expect(order).toEqual(["drag-end", "blur", "flush"]);
+      expect(fence.expectedHeadSeq).toBe(4);
+    } finally {
+      container.remove();
+    }
   });
 });

--- a/src/renderer/components/board/editor/nfm-editor-relocation.ts
+++ b/src/renderer/components/board/editor/nfm-editor-relocation.ts
@@ -1,8 +1,20 @@
+import type {
+  BlockDocumentMutationBarrier,
+  DocumentHeadFence,
+} from "@/lib/block-document-surface-runtime";
+import {
+  finalizeSideMenuBlockDrag,
+  type SideMenuDragCleanupEditor,
+} from "./side-menu-drag-lifecycle";
+
 export interface NfmEditorMutationRuntime {
   readonly isFocused?: () => boolean;
   readonly isWithinEditor?: (element: Element) => boolean;
   readonly blur?: () => void;
 }
+
+export type NfmEditorStructuralMutationRuntime =
+  NfmEditorMutationRuntime & SideMenuDragCleanupEditor;
 
 export const prepareNfmEditorForMutation = async (
   editor: NfmEditorMutationRuntime,
@@ -16,4 +28,15 @@ export const prepareNfmEditorForMutation = async (
   if (ownsFocus && activeElement instanceof HTMLElement) activeElement.blur();
   if (ownsFocus || editor.isFocused?.()) editor.blur?.();
   await Promise.resolve();
+};
+
+/** Settles editor-only drag/focus state before Core observes a causal head. */
+export const prepareNfmEditorStructuralMutation = async (
+  editor: NfmEditorStructuralMutationRuntime,
+  container: HTMLElement,
+  barrier: BlockDocumentMutationBarrier,
+): Promise<DocumentHeadFence> => {
+  finalizeSideMenuBlockDrag(editor);
+  await prepareNfmEditorForMutation(editor, container);
+  return await barrier.flushAndFence();
 };

--- a/src/renderer/components/board/editor/nfm-editor-undo.browser.test.tsx
+++ b/src/renderer/components/board/editor/nfm-editor-undo.browser.test.tsx
@@ -1,7 +1,7 @@
 import {
   BlockNoteEditor,
 } from "@blocknote/core";
-import { TextSelection } from "@tiptap/pm/state";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
 import { BlockNoteViewRaw, useCreateBlockNote } from "@blocknote/react";
 import { act, render } from "@testing-library/react";
 import { StrictMode } from "react";
@@ -30,6 +30,96 @@ function ExternalEditorHookOwner({
 }
 
 describe("collaborative NFM undo in Chromium", () => {
+  test("keeps a valid selection when a remote structural update removes the selected Block", async () => {
+    let nextBlockId = 0;
+    const genesis = createPageDocumentGenesis({
+      documentId: "document:remote-selected-block-deletion",
+      title: "Remote selected Block deletion",
+      nfm: "Before\n\nMiddle\n\nDragged last Block",
+      allocateBlockId: () => `block-${++nextBlockId}`,
+    });
+    const localDocument = genesis.document;
+    const remoteDocument = new Y.Doc({ guid: localDocument.guid });
+    Y.applyUpdate(remoteDocument, Y.encodeStateAsUpdate(localDocument));
+    const remoteBaseVector = Y.encodeStateVector(remoteDocument);
+    const createEditor = (
+      document: Y.Doc,
+      clientSessionId: string,
+      name: string,
+    ) => BlockNoteEditor.create(createNfmEditorModeOptions({
+      kind: "collaborative-document",
+      documentId: document.guid,
+      storeEpoch: "epoch:remote-selected-block-deletion",
+      generation: 1,
+      clientSessionId,
+      fragment: document.getXmlFragment("body"),
+      user: { name, color: name === "Local" ? "#2563eb" : "#16a34a" },
+    }));
+    const localEditor = createEditor(localDocument, "surface:local", "Local");
+    const remoteEditor = createEditor(remoteDocument, "surface:remote", "Remote");
+    const localHost = globalThis.document.createElement("div");
+    const remoteHost = globalThis.document.createElement("div");
+    globalThis.document.body.append(localHost, remoteHost);
+    localEditor.mount(localHost);
+    remoteEditor.mount(remoteHost);
+
+    try {
+      await act(settleEditor);
+      const draggedBlockId = localEditor.document.at(-1)?.id;
+      if (!draggedBlockId) {
+        throw new Error("Expected a final Block to drag");
+      }
+      let draggedBlockPosition: number | null = null;
+      localEditor.prosemirrorState.doc.descendants((node, position) => {
+        if (node.type.name !== "blockContainer") return true;
+        if (node.attrs.id !== draggedBlockId) return false;
+        draggedBlockPosition = position;
+        return false;
+      });
+      if (draggedBlockPosition === null) {
+        throw new Error("Expected the dragged Block in ProseMirror");
+      }
+      localEditor.prosemirrorView.dispatch(
+        localEditor.prosemirrorState.tr.setSelection(
+          NodeSelection.create(
+            localEditor.prosemirrorState.doc,
+            draggedBlockPosition,
+          ),
+        ),
+      );
+
+      remoteEditor.removeBlocks([draggedBlockId]);
+      const remoteUpdate = Y.encodeStateAsUpdate(
+        remoteDocument,
+        remoteBaseVector,
+      );
+
+      Y.applyUpdate(localDocument, remoteUpdate);
+      expect(localEditor.getBlock(draggedBlockId)).toBeUndefined();
+      expect(localEditor.prosemirrorState.selection).not.toBeInstanceOf(
+        NodeSelection,
+      );
+      expect(localEditor.prosemirrorState.selection.$head.parent).toBeDefined();
+      const survivingBlock = localEditor.document.at(-1);
+      if (!survivingBlock) {
+        throw new Error("Expected a surviving Block after the remote deletion");
+      }
+      localEditor.updateBlock(survivingBlock, { content: "Still editable" });
+      expect(localEditor.getBlock(survivingBlock.id)?.content).not.toEqual(
+        survivingBlock.content,
+      );
+    } finally {
+      localEditor.unmount();
+      remoteEditor.unmount();
+      localHost.remove();
+      remoteHost.remove();
+      localEditor._tiptapEditor.destroy();
+      remoteEditor._tiptapEditor.destroy();
+      localDocument.destroy();
+      remoteDocument.destroy();
+    }
+  });
+
   test("leaves an externally owned editor alive after its React owner unmounts", async () => {
     const editor = BlockNoteEditor.create();
     const destroy = vi.spyOn(editor._tiptapEditor, "destroy");

--- a/src/renderer/components/board/editor/nfm-editor-undo.browser.test.tsx
+++ b/src/renderer/components/board/editor/nfm-editor-undo.browser.test.tsx
@@ -79,22 +79,37 @@ describe("collaborative NFM undo in Chromium", () => {
       if (draggedBlockPosition === null) {
         throw new Error("Expected the dragged Block in ProseMirror");
       }
-      localEditor.prosemirrorView.dispatch(
-        localEditor.prosemirrorState.tr.setSelection(
-          NodeSelection.create(
-            localEditor.prosemirrorState.doc,
-            draggedBlockPosition,
+      const selectedBlockPosition = draggedBlockPosition;
+      await act(async () => {
+        localEditor.prosemirrorView.dispatch(
+          localEditor.prosemirrorState.tr.setSelection(
+            NodeSelection.create(
+              localEditor.prosemirrorState.doc,
+              selectedBlockPosition,
+            ),
           ),
-        ),
-      );
+        );
+        await settleEditor();
+      });
 
-      remoteEditor.removeBlocks([draggedBlockId]);
-      const remoteUpdate = Y.encodeStateAsUpdate(
-        remoteDocument,
-        remoteBaseVector,
-      );
+      let remoteUpdate: Uint8Array | undefined;
+      await act(async () => {
+        remoteEditor.removeBlocks([draggedBlockId]);
+        remoteUpdate = Y.encodeStateAsUpdate(
+          remoteDocument,
+          remoteBaseVector,
+        );
+        await settleEditor();
+      });
+      if (!remoteUpdate) {
+        throw new Error("Expected the remote structural update");
+      }
+      const appliedRemoteUpdate = remoteUpdate;
 
-      Y.applyUpdate(localDocument, remoteUpdate);
+      await act(async () => {
+        Y.applyUpdate(localDocument, appliedRemoteUpdate);
+        await settleEditor();
+      });
       expect(localEditor.getBlock(draggedBlockId)).toBeUndefined();
       expect(localEditor.prosemirrorState.selection).not.toBeInstanceOf(
         NodeSelection,
@@ -104,7 +119,10 @@ describe("collaborative NFM undo in Chromium", () => {
       if (!survivingBlock) {
         throw new Error("Expected a surviving Block after the remote deletion");
       }
-      localEditor.updateBlock(survivingBlock, { content: "Still editable" });
+      await act(async () => {
+        localEditor.updateBlock(survivingBlock, { content: "Still editable" });
+        await settleEditor();
+      });
       expect(localEditor.getBlock(survivingBlock.id)?.content).not.toEqual(
         survivingBlock.content,
       );

--- a/src/renderer/components/board/editor/nfm-editor.tsx
+++ b/src/renderer/components/board/editor/nfm-editor.tsx
@@ -182,8 +182,8 @@ import { cn } from "@/lib/utils";
 import { useCommandPaletteThreadItems } from "@/lib/command-palette-chat-search";
 import type { BlockDocumentMutationBarrier } from "@/lib/block-document-surface-runtime";
 import {
-  registerBlockDocumentMutationBarrier,
-  resolveBlockDocumentMutationBarrier,
+  registerBlockDocumentStructuralMutationParticipant,
+  resolveBlockDocumentStructuralMutationParticipant,
 } from "@/lib/block-document-mutation-registry";
 import {
   createCanvasInHostPage,
@@ -213,8 +213,8 @@ import {
   type NfmEditorSource,
 } from "./nfm-editor-source";
 import {
-  prepareNfmEditorForMutation,
-  type NfmEditorMutationRuntime,
+  prepareNfmEditorStructuralMutation,
+  type NfmEditorStructuralMutationRuntime,
 } from "./nfm-editor-relocation";
 import { moveNfmBlocks } from "@/lib/nfm-block-move-runtime";
 import { commitPageLifecycleIntent } from "@/lib/page-lifecycle-runtime";
@@ -1476,13 +1476,32 @@ function NfmEditorInstance({
   }, [editor, syncSearchStats]);
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const structuralMutationParticipant = useMemo(() => {
+    if (!surfaceMutationBarrier) return undefined;
+    return {
+      prepareAndFence: async () => {
+        const container = containerRef.current;
+        if (!container) {
+          throw new Error(
+            "The Page editor is not ready for a structural mutation.",
+          );
+        }
+        return await prepareNfmEditorStructuralMutation(
+          editor as unknown as NfmEditorStructuralMutationRuntime,
+          container,
+          surfaceMutationBarrier,
+        );
+      },
+    };
+  }, [editor, surfaceMutationBarrier]);
+
   useEffect(() => {
-    if (!surfaceMutationBarrier) return;
-    return registerBlockDocumentMutationBarrier(
+    if (!structuralMutationParticipant) return;
+    return registerBlockDocumentStructuralMutationParticipant(
       source.clientSessionId,
-      surfaceMutationBarrier,
+      structuralMutationParticipant,
     );
-  }, [source.clientSessionId, surfaceMutationBarrier]);
+  }, [source.clientSessionId, structuralMutationParticipant]);
 
   useEffect(() => {
     if (
@@ -1830,20 +1849,12 @@ function NfmEditorInstance({
       if (executionProjectId === null) {
         throw new Error("Moving Blocks requires a Project.");
       }
-      if (!surfaceMutationBarrier) {
+      if (!structuralMutationParticipant) {
         throw new Error(
           "The collaborative Page surface changed; reopen it before moving Blocks.",
         );
       }
-      const container = containerRef.current;
-      if (!container) {
-        throw new Error("The Page editor is not ready for a Block move.");
-      }
-      await prepareNfmEditorForMutation(
-        editor as unknown as NfmEditorMutationRuntime,
-        container,
-      );
-      const sourceHead = await surfaceMutationBarrier.flushAndFence();
+      const sourceHead = await structuralMutationParticipant.prepareAndFence();
 
       await moveNfmBlocks({
         projectId: executionProjectId,
@@ -1857,11 +1868,10 @@ function NfmEditorInstance({
       });
     },
     [
-      editor,
       executionProjectId,
       source,
       sourcePageContext,
-      surfaceMutationBarrier,
+      structuralMutationParticipant,
     ],
   );
 
@@ -2060,7 +2070,9 @@ function NfmEditorInstance({
   );
 
   const crossSurfaceDrag = useMemo(() => {
-    if (executionProjectId === null) return undefined;
+    if (executionProjectId === null || !structuralMutationParticipant) {
+      return undefined;
+    }
     return {
       surfaceId: source.clientSessionId,
       projectId: executionProjectId,
@@ -2075,13 +2087,16 @@ function NfmEditorInstance({
           ? { hostPageId: sourcePageContext.pageId }
           : {}),
         ancestorPageIds: parentBlockReferenceRuntime?.ancestorPageIds ?? [],
-        ...(surfaceMutationBarrier
-          ? { flushAndFence: surfaceMutationBarrier.flushAndFence }
-          : {}),
-        flushSourceAndFence: async (sourceSurfaceId: string) => {
-          if (sourceSurfaceId === source.clientSessionId) return;
-          return await resolveBlockDocumentMutationBarrier(sourceSurfaceId)
-            ?.flushAndFence();
+        prepareAndFence: structuralMutationParticipant.prepareAndFence,
+        prepareSourceAndFence: async (sourceSurfaceId: string) => {
+          const participant =
+            resolveBlockDocumentStructuralMutationParticipant(sourceSurfaceId);
+          if (!participant) {
+            throw new Error(
+              "The dragged Page editor changed; start the drag again.",
+            );
+          }
+          return await participant.prepareAndFence();
         },
         createOperationId: () => crypto.randomUUID(),
         transfer: (intent: Parameters<typeof transferBlocks>[1]) =>
@@ -2128,7 +2143,7 @@ function NfmEditorInstance({
                   targetPageId,
                   insertion,
                   sourceRuntime,
-                    targetRuntime: surfaceMutationBarrier,
+                  targetRuntime: surfaceMutationBarrier,
                 });
               },
             }
@@ -2144,6 +2159,7 @@ function NfmEditorInstance({
     source.clientSessionId,
     source.storeEpoch,
     sourcePageContext,
+    structuralMutationParticipant,
     surfaceMutationBarrier,
   ]);
 
@@ -2334,18 +2350,10 @@ function NfmEditorInstance({
       if (!sourcePageContext) {
         throw new Error("A Subpage can only be created inside a Page.");
       }
-      if (!surfaceMutationBarrier) {
+      if (!structuralMutationParticipant) {
         throw new Error("The Page Document is not ready to create a Subpage.");
       }
-      const container = containerRef.current;
-      if (!container) {
-        throw new Error("The Page editor is not ready to create a Subpage.");
-      }
-      await prepareNfmEditorForMutation(
-        editor as unknown as NfmEditorMutationRuntime,
-        container,
-      );
-      const hostHead = await surfaceMutationBarrier.flushAndFence();
+      const hostHead = await structuralMutationParticipant.prepareAndFence();
       if (
         hostHead.storeEpoch !== source.storeEpoch
         || hostHead.documentId !== source.documentId
@@ -2384,12 +2392,11 @@ function NfmEditorInstance({
     },
     [
       contentAccessContext,
-      editor,
       source.documentId,
       source.generation,
       source.storeEpoch,
       sourcePageContext,
-      surfaceMutationBarrier,
+      structuralMutationParticipant,
     ],
   );
 
@@ -2453,20 +2460,12 @@ function NfmEditorInstance({
       if (!sourcePageContext || executionProjectId === null) {
         throw new Error("A nested Page can only be deleted inside a Page.");
       }
-      if (!surfaceMutationBarrier) {
+      if (!structuralMutationParticipant) {
         throw new Error(
           "The host Page Document is not ready for a Page deletion.",
         );
       }
-      const container = containerRef.current;
-      if (!container) {
-        throw new Error("The host Page editor is not ready for a Page deletion.");
-      }
-      await prepareNfmEditorForMutation(
-        editor as unknown as NfmEditorMutationRuntime,
-        container,
-      );
-      const hostHead = await surfaceMutationBarrier.flushAndFence();
+      const hostHead = await structuralMutationParticipant.prepareAndFence();
       if (
         hostHead.storeEpoch !== source.storeEpoch
         || hostHead.documentId !== source.documentId
@@ -2493,11 +2492,10 @@ function NfmEditorInstance({
       }
     },
     [
-      editor,
       executionProjectId,
       source,
       sourcePageContext,
-      surfaceMutationBarrier,
+      structuralMutationParticipant,
     ],
   );
 

--- a/src/renderer/components/board/editor/side-menu-drag-lifecycle.ts
+++ b/src/renderer/components/board/editor/side-menu-drag-lifecycle.ts
@@ -4,7 +4,7 @@ interface SideMenuDragLifecycle {
   blockDragEnd: () => void;
 }
 
-interface SideMenuDragCleanupEditor {
+export interface SideMenuDragCleanupEditor {
   prosemirrorView?: {
     dragging?: unknown;
     root?: Document | ShadowRoot;

--- a/src/renderer/components/board/editor/use-editor-drag-behaviors.test.tsx
+++ b/src/renderer/components/board/editor/use-editor-drag-behaviors.test.tsx
@@ -77,6 +77,18 @@ function DragBehaviorHarness({
               storeEpoch: "epoch-a",
               hostPageId: "card-host",
               ancestorPageIds: [],
+              prepareAndFence: async () => ({
+                documentId: "document-a",
+                storeEpoch: "epoch-a",
+                generation: 1,
+                expectedHeadSeq: 0,
+              }),
+              prepareSourceAndFence: async () => ({
+                documentId: "document-source",
+                storeEpoch: "epoch-a",
+                generation: 1,
+                expectedHeadSeq: 0,
+              }),
               createOperationId: () => "operation-a",
               transfer: async () => ({
                 ok: false,

--- a/src/renderer/components/workbench/database-view-block-drop-command.jsdom.test.ts
+++ b/src/renderer/components/workbench/database-view-block-drop-command.jsdom.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createDatabaseViewMutationHistory } from "./database-view-mutation-history";
+import { commitDatabaseViewBlockDrop } from "./database-view-block-drop-command";
+import type { LocalBlockDragSession } from "./block-transfer/cross-surface-drag";
+
+const mocks = vi.hoisted(() => ({
+  transferBlocks: vi.fn(),
+  toastDanger: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  transferBlocks: mocks.transferBlocks,
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: {
+    danger: mocks.toastDanger,
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const session: LocalBlockDragSession = {
+  sessionId: "drag-session-missing-participant",
+  sourceSurfaceId: "surface-missing-participant",
+  payload: {
+    version: 2,
+    kind: "block_transfer",
+    sessionId: "drag-session-missing-participant",
+    sourceSurfaceId: "surface-missing-participant",
+    projectId: "project-1",
+    storeEpoch: "epoch-1",
+    source: { kind: "page", pageId: "page-source" },
+    rootBlockIds: ["block-source"],
+    displayHints: ["paragraph"],
+  },
+};
+
+describe("Database View Block drop command", () => {
+  beforeEach(() => {
+    mocks.transferBlocks.mockReset();
+    mocks.toastDanger.mockReset();
+  });
+
+  test("fails closed when the mounted source editor cannot prepare a causal head", async () => {
+    const committed = await commitDatabaseViewBlockDrop({
+      session,
+      projectId: "project-1",
+      storeEpoch: "epoch-1",
+      dataSourceId: "data-source-1",
+      placement: {
+        kind: "direct",
+        viewId: "view-1",
+        presentationOverride: { layout: "board" },
+        groupKey: null,
+      },
+      altKey: false,
+      shiftKey: false,
+      mutationHistory: createDatabaseViewMutationHistory("view-1"),
+    });
+
+    expect(committed).toBe(false);
+    expect(mocks.transferBlocks).not.toHaveBeenCalled();
+    expect(mocks.toastDanger).toHaveBeenCalledWith(
+      "The dragged Page editor changed; start the drag again.",
+    );
+  });
+});

--- a/src/renderer/components/workbench/database-view-block-drop-command.ts
+++ b/src/renderer/components/workbench/database-view-block-drop-command.ts
@@ -1,6 +1,7 @@
 import { toast } from "@/components/ui/toast";
 import { transferBlocks } from "@/lib/api";
-import { resolveBlockDocumentMutationBarrier } from "@/lib/block-document-mutation-registry";
+import { resolveBlockDocumentStructuralMutationParticipant } from "@/lib/block-document-mutation-registry";
+import type { DocumentHeadFence } from "@/lib/block-document-surface-runtime";
 import { readTaskShorthandPagePromotionEnabled } from "@/lib/page-promotion-preference";
 import type { BlockTransferDataSourcePlacement } from "../../../shared/block-transfer";
 import {
@@ -60,9 +61,24 @@ export const commitDatabaseViewBlockDrop = async (
     toast.info("Database blocks can only move through a typed Database action.");
     return false;
   }
-  const sourceBarrier = resolveBlockDocumentMutationBarrier(payload.sourceSurfaceId);
-  const sourceHead = await sourceBarrier?.flushAndFence();
-  if (sourceHead && sourceHead.storeEpoch !== input.storeEpoch) {
+  const sourceParticipant =
+    resolveBlockDocumentStructuralMutationParticipant(payload.sourceSurfaceId);
+  if (!sourceParticipant) {
+    toast.danger("The dragged Page editor changed; start the drag again.");
+    return false;
+  }
+  let sourceHead: DocumentHeadFence;
+  try {
+    sourceHead = await sourceParticipant.prepareAndFence();
+  } catch (error) {
+    toast.danger(
+      error instanceof Error
+        ? error.message
+        : "The dragged Page could not prepare for transfer.",
+    );
+    return false;
+  }
+  if (sourceHead.storeEpoch !== input.storeEpoch) {
     toast.danger("The dragged Document belongs to another store generation.");
     return false;
   }
@@ -80,15 +96,11 @@ export const commitDatabaseViewBlockDrop = async (
         preferenceEnabled: readTaskShorthandPagePromotionEnabled(),
         shiftKey: input.shiftKey,
       }),
-      ...(sourceHead
-        ? {
-            causalDependencies: [{
-              documentId: sourceHead.documentId,
-              generation: sourceHead.generation,
-              expectedHeadSeq: sourceHead.expectedHeadSeq,
-            }],
-          }
-        : {}),
+      causalDependencies: [{
+        documentId: sourceHead.documentId,
+        generation: sourceHead.generation,
+        expectedHeadSeq: sourceHead.expectedHeadSeq,
+      }],
     }),
   );
   if (!result.ok) {

--- a/src/renderer/lib/block-document-mutation-registry.node.test.ts
+++ b/src/renderer/lib/block-document-mutation-registry.node.test.ts
@@ -1,20 +1,32 @@
 import { describe, expect, test } from "vitest";
 import {
-  registerBlockDocumentMutationBarrier,
-  resolveBlockDocumentMutationBarrier,
+  registerBlockDocumentStructuralMutationParticipant,
+  resolveBlockDocumentStructuralMutationParticipant,
 } from "./block-document-mutation-registry";
 
-describe("Block Document mutation barrier registry", () => {
+describe("Block Document structural mutation participant registry", () => {
   test("does not let an older surface disposer remove the current runtime", () => {
-    const first = { flushAndFence: async () => undefined } as never;
-    const second = { flushAndFence: async () => undefined } as never;
-    const unregisterFirst = registerBlockDocumentMutationBarrier("surface-1", first);
-    const unregisterSecond = registerBlockDocumentMutationBarrier("surface-1", second);
+    const first = { prepareAndFence: async () => undefined } as never;
+    const second = { prepareAndFence: async () => undefined } as never;
+    const unregisterFirst = registerBlockDocumentStructuralMutationParticipant(
+      "surface-1",
+      first,
+    );
+    const unregisterSecond = registerBlockDocumentStructuralMutationParticipant(
+      "surface-1",
+      second,
+    );
 
-    expect(resolveBlockDocumentMutationBarrier("surface-1")).toBe(second);
+    expect(
+      resolveBlockDocumentStructuralMutationParticipant("surface-1"),
+    ).toBe(second);
     unregisterFirst();
-    expect(resolveBlockDocumentMutationBarrier("surface-1")).toBe(second);
+    expect(
+      resolveBlockDocumentStructuralMutationParticipant("surface-1"),
+    ).toBe(second);
     unregisterSecond();
-    expect(resolveBlockDocumentMutationBarrier("surface-1")).toBeNull();
+    expect(
+      resolveBlockDocumentStructuralMutationParticipant("surface-1"),
+    ).toBeNull();
   });
 });

--- a/src/renderer/lib/block-document-mutation-registry.ts
+++ b/src/renderer/lib/block-document-mutation-registry.ts
@@ -1,36 +1,45 @@
-import type { BlockDocumentMutationBarrier } from "./block-document-surface-runtime";
+import type { DocumentHeadFence } from "./block-document-surface-runtime";
 
 /**
- * Resolves the live mutation barrier for a mounted document surface. Drag
- * payloads carry this renderer-local identity so a target surface can flush
- * the actual source session before Core captures its structural fence.
+ * One mounted editor's complete preparation boundary for a structural command.
+ * The participant settles transient editor state before returning the durable
+ * Document head that Core must recheck.
  */
-const barriers = new Map<
+export interface BlockDocumentStructuralMutationParticipant {
+  readonly prepareAndFence: () => Promise<DocumentHeadFence>;
+}
+
+/**
+ * Resolves the live structural participant for a mounted document surface.
+ * Drag payloads carry this renderer-local identity so a target can prepare the
+ * actual source editor before Core captures its structural fence.
+ */
+const participants = new Map<
   string,
-  Map<number, BlockDocumentMutationBarrier>
+  Map<number, BlockDocumentStructuralMutationParticipant>
 >();
 let nextRegistrationId = 1;
 
-export const registerBlockDocumentMutationBarrier = (
+export const registerBlockDocumentStructuralMutationParticipant = (
   surfaceId: string,
-  barrier: BlockDocumentMutationBarrier,
+  participant: BlockDocumentStructuralMutationParticipant,
 ): (() => void) => {
   const registrationId = nextRegistrationId;
   nextRegistrationId += 1;
-  const registrations = barriers.get(surfaceId) ?? new Map();
-  registrations.set(registrationId, barrier);
-  barriers.set(surfaceId, registrations);
+  const registrations = participants.get(surfaceId) ?? new Map();
+  registrations.set(registrationId, participant);
+  participants.set(surfaceId, registrations);
   return () => {
-    const current = barriers.get(surfaceId);
+    const current = participants.get(surfaceId);
     if (!current || !current.delete(registrationId)) return;
-    if (current.size === 0) barriers.delete(surfaceId);
+    if (current.size === 0) participants.delete(surfaceId);
   };
 };
 
-export const resolveBlockDocumentMutationBarrier = (
+export const resolveBlockDocumentStructuralMutationParticipant = (
   surfaceId: string,
-): BlockDocumentMutationBarrier | null => {
-  const registrations = barriers.get(surfaceId);
+): BlockDocumentStructuralMutationParticipant | null => {
+  const registrations = participants.get(surfaceId);
   if (!registrations || registrations.size === 0) return null;
   return [...registrations.values()].at(-1) ?? null;
 };

--- a/src/renderer/lib/nodex-y-provider.node.test.ts
+++ b/src/renderer/lib/nodex-y-provider.node.test.ts
@@ -1219,6 +1219,59 @@ describe("NodexYProvider", () => {
     }
   });
 
+  test("requires a fresh replica when a realtime editor observer rejects an applied update", async () => {
+    const adapter = new MemoryDocumentSyncAdapter();
+    const document = new Y.Doc({ guid: "document-1" });
+    const provider = new NodexYProvider({
+      documentId: "document-1",
+      document,
+      adapter,
+      clientSessionId: "window-observer-failure",
+      autoConnect: false,
+    });
+    const title = document.getText("title");
+    const rejectProjection = () => {
+      throw new Error("editor projection failed");
+    };
+    try {
+      await provider.connect();
+      title.observe(rejectProjection);
+      const update = adapter.commitExternal((serverTitle) => {
+        serverTitle.insert(0, "Committed remotely");
+      });
+
+      adapter.emit({
+        kind: "document-update",
+        documentId: "document-1",
+        storeEpoch: adapter.storeEpoch,
+        generation: adapter.generation,
+        headSeq: adapter.headSeq,
+        updateId: "rust:observer-failure",
+        clientSessionId: "rust:test",
+        update,
+      });
+
+      expect(provider.getStatus()).toMatchObject({
+        phase: "reset-required",
+        headSeq: 0,
+        error: {
+          code: "recovery_required",
+          resetRequired: true,
+          retryable: false,
+        },
+      });
+      expect(provider.getStatus().error?.message).toContain(
+        "local editor could not integrate the realtime document update",
+      );
+      expect(title.toString()).toBe("Committed remotely");
+    } finally {
+      title.unobserve(rejectProjection);
+      provider.destroy();
+      document.destroy();
+      adapter.destroy();
+    }
+  });
+
   test("drops old-epoch outbox and checkpoint state on an explicit store reset", async () => {
     const adapter = new MemoryDocumentSyncAdapter();
     const checkpoints = new MemoryDocumentLocalCheckpointStore();

--- a/src/renderer/lib/nodex-y-provider.ts
+++ b/src/renderer/lib/nodex-y-provider.ts
@@ -228,6 +228,18 @@ const invalidResponseError = (message: string): DocumentSyncCommandError => ({
   resetRequired: false,
 });
 
+const documentIntegrationError = (
+  updateKind: "document sync" | "realtime document",
+  error: unknown,
+): DocumentSyncCommandError => ({
+  code: "recovery_required",
+  message: `The local editor could not integrate the ${updateKind} update: ${
+    error instanceof Error ? error.message : String(error)
+  }`,
+  retryable: false,
+  resetRequired: true,
+});
+
 const resetBoundaryError = (message: string): DocumentSyncCommandError => ({
   code: "store_epoch_mismatch",
   message,
@@ -762,11 +774,10 @@ export class NodexYProvider {
         REMOTE_DOCUMENT_ORIGIN,
       );
     } catch (error) {
-      this.enterFatal(
-        invalidResponseError(
-          `Invalid document sync update: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
+      // Yjs observers run synchronously during apply and may throw after the
+      // CRDT update has already mutated this Y.Doc. Never retry or classify
+      // that ambiguous local replica as a malformed Core response.
+      this.enterReset(documentIntegrationError("document sync", error));
       return;
     }
 
@@ -900,11 +911,7 @@ export class NodexYProvider {
         REMOTE_DOCUMENT_ORIGIN,
       );
     } catch (error) {
-      this.enterFatal(
-        invalidResponseError(
-          `Invalid realtime document update: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
+      this.enterReset(documentIntegrationError("realtime document", error));
       return;
     }
     this.headSeq = event.headSeq;

--- a/tests/e2e/electron-smoke.spec.ts
+++ b/tests/e2e/electron-smoke.spec.ts
@@ -2275,7 +2275,6 @@ test("moves a Block into Board and List views with native DnD @dnd-smoke", async
         "\tDnD smoke first child",
         "\tDnD smoke middle child",
         "\tDnD smoke last child",
-        "After smoke sibling",
       ].join("\n"),
     );
 
@@ -2390,9 +2389,8 @@ test("moves a Block into Board and List views with native DnD @dnd-smoke", async
     await expect(sourceSurface.locator(".bn-block[data-id]").filter({
       hasText: "Before smoke sibling",
     })).toHaveCount(1);
-    await expect(sourceSurface.locator(".bn-block[data-id]").filter({
-      hasText: "After smoke sibling",
-    })).toHaveCount(1);
+    await expect(sourcePanel.getByRole("button", { name: "Reload" })).toHaveCount(0);
+    await expect(sourceSurface).toHaveAttribute("contenteditable", "true");
 
     const promotedPageId = requireString(
       await promotedCards.getAttribute("data-board-uuid-v7"),
@@ -2489,6 +2487,8 @@ test("moves a Block into Board and List views with native DnD @dnd-smoke", async
     ).filter({ hasText: "DnD smoke title" });
     await expect(promotedListRows).toHaveCount(1, { timeout: 15_000 });
     await expect(sourceBlock).toHaveCount(0, { timeout: 15_000 });
+    await expect(sourcePanel.getByRole("button", { name: "Reload" })).toHaveCount(0);
+    await expect(sourceSurface).toHaveAttribute("contenteditable", "true");
     const promotedListPageId = requireString(
       await promotedListRows.getAttribute("data-database-view-page-id"),
       "Native List DnD promoted Page id",


### PR DESCRIPTION
## Summary

Dragging the final or only Block from a mounted Page Stage into Board or List could crash the source editor after Core committed a valid structural update. BlockNote left a node selection on the dragged Block, and y-prosemirror tried to restore that selection at the new document boundary where no selectable node remained.

This change:

- restores deleted node selections to a nearby valid position instead of constructing an invalid `NodeSelection`
- gives every mounted editor one structural-mutation participant that settles native drag, focus, and IME state before returning a durable causal head
- fails cross-surface transfers closed when the exact source or target participant disappears
- treats synchronous editor-observer failures as recovery-required replica failures instead of malformed Core content
- strengthens native Board/List DnD and collaborative editor regressions around the final-Block boundary

## Validation

- `pnpm run verify:static`
- focused provider and mutation-registry tests: 26 passed
- focused renderer structural-transfer tests: 11 passed
- focused collaborative browser tests: 6 passed
- `pnpm test`
- `pnpm run build`
- native Electron DnD smoke repeated 10 times: 10/10 passed
- frozen offline dependency-patch install

## Investigation

The installed profile was inspected read-only. Its failing sequence was a valid `rust:block-transfer` source update from head 1154 to 1155, and the dragged root was the final root in the Page. The durable Core state remained valid; the failure occurred synchronously in the mounted y-prosemirror projection while restoring the stale node selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block drag-and-drop reliability by requiring valid document state before transfers.
  * Prevented transfers when a source editor is unavailable or cannot provide current state.
  * Improved selection recovery when a remotely deleted block was selected.
  * Added safer recovery handling when collaborative updates cannot be integrated.
  * Preserved editor usability after drag-and-drop operations.

* **Documentation**
  * Updated specifications and reliability guidance for collaborative structural changes and drag-and-drop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->