### PR TITLE
fix(release): restore reliable Nightly publication on clean hosts

### DIFF
--- a/.github/actions/finalize-sparkle/action.yml
+++ b/.github/actions/finalize-sparkle/action.yml
@@ -33,7 +33,6 @@ runs:
         path: ${{ runner.temp }}/architecture
 
     - name: Fetch verified compatible update history
-      id: history
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_ARCH: ${{ inputs.architecture }}
@@ -42,18 +41,17 @@ runs:
       run: |
         set -euo pipefail
         build_version="$(node -p "require('${RUNNER_TEMP}/architecture/architecture-build.json').releaseIdentity.buildVersion")"
-        history_dirs="$(vp run release:fetch:sparkle-history -- \
+        vp run release:fetch:sparkle-history -- \
           --arch "${RELEASE_ARCH}" \
           --channel "${{ inputs.channel }}" \
           --build-version "${build_version}" \
           --version "${RELEASE_VERSION}" \
           --repo "${GITHUB_REPOSITORY}" \
-          --output "${RUNNER_TEMP}/sparkle-history")"
-        echo "directories=${history_dirs}" >> "${GITHUB_OUTPUT}"
+          --output "${RUNNER_TEMP}/sparkle-history" \
+          --manifest "${RUNNER_TEMP}/sparkle-history.json"
 
     - name: Finalize signed appcast and deltas
       env:
-        HISTORY_DIRS: ${{ steps.history.outputs.directories }}
         RELEASE_ARCH: ${{ inputs.architecture }}
         RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
         RELEASE_VERSION: ${{ inputs.version }}
@@ -78,10 +76,8 @@ runs:
           --source-sha "${RELEASE_SOURCE_SHA}"
           --version "${RELEASE_VERSION}"
           --output "${SPARKLE_OUTPUT}"
+          --history-manifest "${RUNNER_TEMP}/sparkle-history.json"
         )
-        if [[ -n "${HISTORY_DIRS}" ]]; then
-          sparkle_args+=(--history-dirs "${HISTORY_DIRS}")
-        fi
         vp run release:finalize:sparkle -- "${sparkle_args[@]}"
 
     - name: Summarize signed update set

--- a/.github/actions/run-stress-tests/action.yml
+++ b/.github/actions/run-stress-tests/action.yml
@@ -12,7 +12,7 @@ runs:
       env:
         NODEX_TEST_TIMINGS: .generated/ci-timings
       shell: bash
-      run: vp exec tsx scripts/ci/run-timed.ts --name stress-tests -- xvfb-run --auto-servernum vp run test:stress
+      run: vp exec tsx scripts/ci/run-timed.ts --name stress-tests -- vp run test:stress
     - name: Show Rust compiler cache statistics
       if: always()
       shell: bash

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -6,41 +6,10 @@ runs:
     - name: Cache Playwright browsers
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ~/.cache/ms-playwright
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
         key: playwright-${{ runner.os }}-${{ hashFiles('package.json', 'pnpm-lock.yaml') }}
         restore-keys: |
           playwright-${{ runner.os }}-
     - name: Install Chromium and system dependencies
       shell: bash
-      run: |
-        set -euo pipefail
-        install_marker="${RUNNER_TEMP}/nodex-playwright-install-complete"
-        rm -f "$install_marker"
-        install_status=0
-        timeout --signal=TERM --kill-after=30s 8m \
-          bash -c '
-            vp exec playwright install --with-deps chromium
-            status=$?
-            printf "%s\\n" "$status" > "$1"
-            exit "$status"
-          ' _ "$install_marker" || install_status=$?
-
-        if [[ -f "$install_marker" ]]; then
-          completed_status="$(<"$install_marker")"
-          rm -f "$install_marker"
-          if [[ "$completed_status" == 0 ]]; then
-            exit 0
-          fi
-
-          echo "::error::Playwright dependency installation failed with status $completed_status"
-          exit "$completed_status"
-        fi
-
-        if [[ "$install_status" != 124 && "$install_status" != 137 ]]; then
-          echo "::error::Playwright dependency installation failed with status $install_status"
-          exit "$install_status"
-        fi
-
-        echo "::warning::Playwright dependency installation timed out; retrying browser-only installation"
-        timeout --signal=TERM --kill-after=30s 8m \
-          vp exec playwright install chromium
+      run: vp exec tsx scripts/ci/install-playwright.ts

--- a/.github/workflows/_certify-release-source.yml
+++ b/.github/workflows/_certify-release-source.yml
@@ -62,7 +62,7 @@ jobs:
   stress:
     name: certify stress contracts
     needs: guard
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -41,7 +41,7 @@ jobs:
 
   stress:
     name: nightly stress suite
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     env:
       CI_TIMING_JOB: nightly-stress
       RUSTC_WRAPPER: sccache

--- a/config/test-suites.ts
+++ b/config/test-suites.ts
@@ -14,6 +14,8 @@ export type SuiteId = (typeof APP_TEST_SUITES)[number];
 export type TestRuntime = "host-node" | "electron-node" | "jsdom" | "chromium";
 export type NativeArtifactId = "core-server" | "yjs-yrs-bridge" | "cli";
 export const NODEX_CLI_BOOTSTRAP_TEST = "src/main/platform/node/NodexCliBootstrap.node.test.ts";
+export const CODEX_SCALE_TEST =
+  "src/main/core-client/CodexSubagentParityPerformance.stress.test.ts";
 export const YJS_YRS_TEST = "src/shared/block-documents/yjs-yrs-conformance.test.ts";
 
 const blocknoteTests = [
@@ -191,3 +193,12 @@ export function nativeRequirements(
 }
 
 export const maintainedThirdPartyTests: readonly string[] = blocknoteTests;
+
+/** The real-history pressure gate uses the same locked macOS package as Nodex. */
+export function requiresAgentRuntime(
+  suite: SuiteId,
+  tier: VitestTestTier,
+  files?: readonly string[],
+): boolean {
+  return suite === "main" && tier === "stress" && (!files || files.includes(CODEX_SCALE_TEST));
+}

--- a/crates/nodex-core/src/infrastructure/store_validation.rs
+++ b/crates/nodex-core/src/infrastructure/store_validation.rs
@@ -739,8 +739,8 @@ fn validate_subagent_projection(connection: &Connection) -> Result<(), StoreErro
            UNION
            SELECT child.host_id, child.source_epoch, child.generation,
              child.root_thread_id, child.thread_id
-           FROM workspace_subagent_descendants child
-           JOIN reachable parent
+           FROM reachable parent
+           CROSS JOIN workspace_subagent_descendants child
              ON child.host_id = parent.host_id
             AND child.source_epoch = parent.source_epoch
             AND child.generation = parent.generation

--- a/crates/nodex-core/src/workspace/subagent_projection.rs
+++ b/crates/nodex-core/src/workspace/subagent_projection.rs
@@ -1,3 +1,6 @@
+// Recursive closures keep the current parent outside the child lookup with CROSS JOIN.
+// Otherwise SQLite may scan the entire universe per parent despite the parent index,
+// making overview, completeness, and lifecycle queries quadratic on fresh Profiles.
 use std::collections::BTreeSet;
 
 use nodex_core_contracts::BoundModuleContext;
@@ -718,8 +721,8 @@ pub(super) fn begin_lifecycle(
            SELECT ?5
            UNION
            SELECT child.thread_id
-           FROM workspace_subagent_descendants child
-           JOIN reachable parent ON child.parent_thread_id = parent.thread_id
+           FROM reachable parent
+           CROSS JOIN workspace_subagent_descendants child ON child.parent_thread_id = parent.thread_id
            WHERE child.host_id = ?1 AND child.source_epoch = ?2
              AND child.generation = ?3 AND child.root_thread_id = ?4
          ), expected(thread_id) AS (
@@ -1170,8 +1173,8 @@ fn read_overview_lane(
              AND descendant.parent_thread_id = ?4
            UNION
            SELECT child.thread_id
-           FROM workspace_subagent_descendants child
-           JOIN reachable parent ON child.parent_thread_id = parent.thread_id
+           FROM reachable parent
+           CROSS JOIN workspace_subagent_descendants child ON child.parent_thread_id = parent.thread_id
            WHERE child.host_id = ?1 AND child.source_epoch = ?2
              AND child.generation = ?3 AND child.root_thread_id = ?4
          )
@@ -1264,8 +1267,8 @@ fn overview_counts(
              AND descendant.parent_thread_id = ?4
            UNION
            SELECT child.thread_id
-           FROM workspace_subagent_descendants child
-           JOIN reachable parent ON child.parent_thread_id = parent.thread_id
+           FROM reachable parent
+           CROSS JOIN workspace_subagent_descendants child ON child.parent_thread_id = parent.thread_id
            WHERE child.host_id = ?1 AND child.source_epoch = ?2
              AND child.generation = ?3 AND child.root_thread_id = ?4
          )
@@ -1626,8 +1629,8 @@ fn require_complete_reachable_closure(
              AND descendant.parent_thread_id = ?4
            UNION
            SELECT child.thread_id
-           FROM workspace_subagent_descendants child
-           JOIN reachable parent ON child.parent_thread_id = parent.thread_id
+           FROM reachable parent
+           CROSS JOIN workspace_subagent_descendants child ON child.parent_thread_id = parent.thread_id
            WHERE child.host_id = ?1 AND child.source_epoch = ?2
              AND child.generation = ?3 AND child.root_thread_id = ?4
          )
@@ -2048,6 +2051,80 @@ mod tests {
         assert_eq!(snapshot.known_done_count, 0);
         assert!(!snapshot.discovery_complete);
         assert_eq!(snapshot.discovery_continuation, None);
+    }
+
+    #[test]
+    fn overview_query_work_grows_with_descendants_instead_of_all_parent_child_pairs() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let mut measurements = Vec::new();
+        for size in [100, 1_000] {
+            let workspace = seeded_workspace();
+            seed_root(&workspace.module);
+            for page in 0..size / 100 {
+                let observations = (page * 100..(page + 1) * 100)
+                    .map(|index| {
+                        observation(
+                            index,
+                            "thread:root",
+                            if index % 2 == 0 {
+                                CodexThreadStatusType::Active
+                            } else {
+                                CodexThreadStatusType::Idle
+                            },
+                        )
+                    })
+                    .collect();
+                observe_page(
+                    &workspace.module,
+                    page,
+                    observations,
+                    page + 1 == size / 100,
+                );
+            }
+            let steps = workspace
+                .kernel
+                .writer()
+                .call(move |connection| {
+                    let ticks = Arc::new(AtomicUsize::new(0));
+                    let observed = Arc::clone(&ticks);
+                    connection.progress_handler(
+                        100,
+                        Some(move || {
+                            observed.fetch_add(1, Ordering::Relaxed);
+                            false
+                        }),
+                    )?;
+                    let result = super::read_overview(
+                        connection,
+                        "library-1",
+                        0,
+                        &universe(),
+                        &CollectionWindowRequest {
+                            after: None,
+                            first: Some(4),
+                        },
+                        &CollectionWindowRequest {
+                            after: None,
+                            first: Some(10),
+                        },
+                    );
+                    connection.progress_handler(0, None::<fn() -> bool>)?;
+                    let snapshot = result?;
+                    assert_eq!(snapshot.known_active_count as usize, size / 2);
+                    assert_eq!(snapshot.known_done_count as usize, size / 2);
+                    assert_eq!(snapshot.active.items.len(), 4);
+                    assert_eq!(snapshot.done.items.len(), 10);
+                    Ok(ticks.load(Ordering::Relaxed) * 100)
+                })
+                .expect("measured production overview");
+            measurements.push(steps);
+        }
+        assert!(
+            measurements[1] < measurements[0] * 20,
+            "10x descendants must not cause quadratic query work: {measurements:?}"
+        );
     }
 
     #[test]

--- a/docs/development.md
+++ b/docs/development.md
@@ -321,6 +321,8 @@ isolation stays enabled, and suites do not compete through aggregate parallelism
 Before execution, the aggregate prepares its union of required Cargo targets
 once. Standalone native suites prepare themselves. Cargo checks freshness and
 returns the executable paths, including when `CARGO_TARGET_DIR` is customized.
+Ordinary suites use development builds; stress suites use optimized release
+builds so performance evidence measures the shipped native execution profile.
 Bridge tests run the prepared executable directly; test bodies never invoke
 Cargo. Reuse binaries, but always create fresh writable Profiles and stores.
 Cancellation terminates only this command's descendants, including detached Core

--- a/docs/development.md
+++ b/docs/development.md
@@ -323,6 +323,9 @@ once. Standalone native suites prepare themselves. Cargo checks freshness and
 returns the executable paths, including when `CARGO_TARGET_DIR` is customized.
 Ordinary suites use development builds; stress suites use optimized release
 builds so performance evidence measures the shipped native execution profile.
+The real-history stress gate also stages the locked Agent runtime before tests
+start. The complete stress tier runs on macOS, matching that runtime package;
+Nightly and release certification use the same macOS runner and test launcher.
 Bridge tests run the prepared executable directly; test bodies never invoke
 Cargo. Reuse binaries, but always create fresh writable Profiles and stores.
 Cancellation terminates only this command's descendants, including detached Core

--- a/docs/product-specs/codex-subagent-behavior.md
+++ b/docs/product-specs/codex-subagent-behavior.md
@@ -172,6 +172,9 @@ of hiding an unresolved subtree.
 
 ## Performance and failure behavior
 
+Graph traversal uses indexed parent-to-child lookups so larger descendant sets
+do not multiply every parent by the entire root graph, including on fresh Profiles.
+
 Normal overview and notification handling may read child metadata, graph, and
 status only. It does not call child resume, item-page, or transcript-bearing
 Thread reads, and it does not register child conversation subscriptions. The

--- a/docs/product-specs/desktop-control-surfaces.md
+++ b/docs/product-specs/desktop-control-surfaces.md
@@ -6,7 +6,7 @@ Nodex presents Browser Use, control of supported browser profiles, and Computer 
 
 The built-in Browser is available when its verified runtime is ready. Control of an existing browser profile additionally requires a supported browser family, the installed native host, and a connected allowed extension instance. Browser Settings reports the live provider state as checking, unavailable, needs repair, waiting for extension, or ready. Agents can select the existing-browser backend only in the ready state.
 
-Computer Use is available only when its verified helper and operating-system requirements are ready. A failure in one control backend does not weaken or implicitly enable another. ACP tasks and remote Codex executions do not acquire local desktop-control surfaces.
+Computer Use is available only when its verified helper and operating-system requirements are ready. Its service uses the bundled Agent runtime and the owning Profile without requiring a separately installed Codex app or sharing another Profile’s configuration. A failure in one control backend does not weaken or implicitly enable another. ACP tasks and remote Codex executions do not acquire local desktop-control surfaces.
 
 ## Website tools
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -66,6 +66,10 @@ the materialized plugin, private host-services socket, `sky.node`, and canonical
 helper app. The primary app-server is the digest-pinned, unmodified package from
 the locked official Codex release; Nodex neither rebuilds it nor publishes a
 second copy.
+The managed Computer Use service starts with the verified bundled Codex CLI and
+its owning Profile in an explicit process environment. Its short-lived native
+launcher preserves the vendor spawn behavior and gives disclaimed descendants
+non-pipe stdio; it never depends on another installed app or a PATH lookup.
 The probe runner uses a temporary LaunchServices background app so helper stdio
 matches an ordinary desktop launch instead of inheriting CI pipe fd guards.
 The x64 probe must prove Computer Use is absent while Browser Use remains

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -241,6 +241,11 @@ release, it proves the protected private key matches the reviewed public key
 and that the extracted App plist/runtime carry that key; both architectures
 must also use the pinned Developer ID Team ID `8HGUT3HC4Z`.
 
+Compatible history moves between fetch and finalization as a JSON manifest of
+absolute directory paths. Task-runner stdout is diagnostic output, never the
+machine-readable directory list. Empty history is an empty array; paths do not
+depend on shell delimiters or GitHub step-output parsing.
+
 `Nightly Retention` keeps the newest 20 published Nightly releases and every
 release younger than 14 days. It also protects every tag referenced by either
 live Nightly appcast and deletes only immutable releases whose downloaded

--- a/scripts/ci/install-playwright.test.ts
+++ b/scripts/ci/install-playwright.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "vite-plus/test";
+import { installPlaywrightChromium } from "./install-playwright";
+
+const result = (exitCode: number) => ({ exitCode, signal: null, durationMs: 1 });
+
+test("installs the browser on macOS without Linux package dependencies", async () => {
+  const observed: string[][] = [];
+  const exit = await installPlaywrightChromium({
+    platform: "darwin",
+    signal: new AbortController().signal,
+    execute: async (command) => {
+      observed.push([...command.args]);
+      return result(0);
+    },
+  });
+  expect(exit).toBe(0);
+  expect(observed).toEqual([["exec", "playwright", "install", "chromium"]]);
+});
+
+test("preserves installation failures instead of masking them with a retry", async () => {
+  let calls = 0;
+  expect(
+    await installPlaywrightChromium({
+      platform: "linux",
+      signal: new AbortController().signal,
+      execute: async () => {
+        calls++;
+        return result(127);
+      },
+    }),
+  ).toBe(127);
+  expect(calls).toBe(1);
+});
+
+test("retries browser-only after a system dependency timeout", async () => {
+  const attempts: boolean[] = [];
+  const exit = await installPlaywrightChromium({
+    platform: "linux",
+    signal: new AbortController().signal,
+    timeoutMs: 1,
+    execute: async (command) => {
+      const withDependencies = command.args.includes("--with-deps");
+      attempts.push(withDependencies);
+      if (!withDependencies) return result(0);
+      await new Promise<void>((resolve) =>
+        command.signal!.addEventListener("abort", () => resolve(), { once: true }),
+      );
+      return result(130);
+    },
+  });
+  expect(exit).toBe(0);
+  expect(attempts).toEqual([true, false]);
+});
+
+test("user cancellation prevents fallback installation", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  expect(
+    await installPlaywrightChromium({
+      platform: "linux",
+      signal: controller.signal,
+      execute: async () => {
+        calls++;
+        controller.abort();
+        return result(130);
+      },
+    }),
+  ).toBe(130);
+  expect(calls).toBe(1);
+});

--- a/scripts/ci/install-playwright.ts
+++ b/scripts/ci/install-playwright.ts
@@ -1,0 +1,45 @@
+import path from "node:path";
+import { runCommand, withCommandSignal } from "../tooling/process.ts";
+
+/** System packages are Linux-only; every host installs the locked browser. */
+export async function installPlaywrightChromium(options: {
+  readonly platform: NodeJS.Platform;
+  readonly signal: AbortSignal;
+  readonly execute?: typeof runCommand;
+  readonly timeoutMs?: number;
+}): Promise<number> {
+  const attempts = options.platform === "linux" ? [true, false] : [false];
+  for (const withDependencies of attempts) {
+    if (options.signal.aborted) return 130;
+    const deadline = new AbortController();
+    const timer = setTimeout(() => deadline.abort(), options.timeoutMs ?? 8 * 60_000);
+    try {
+      const result = await (options.execute ?? runCommand)({
+        command: "vp",
+        args: [
+          "exec",
+          "playwright",
+          "install",
+          ...(withDependencies ? ["--with-deps"] : []),
+          "chromium",
+        ],
+        signal: AbortSignal.any([options.signal, deadline.signal]),
+      });
+      if (options.signal.aborted) return 130;
+      if (!deadline.signal.aborted) return result.exitCode;
+      if (!withDependencies) return 124;
+      process.stderr.write(
+        "Playwright system dependency installation timed out; retrying browser installation.\n",
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return 124;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  void withCommandSignal((signal) =>
+    installPlaywrightChromium({ platform: process.platform, signal }),
+  );
+}

--- a/scripts/probe-browser-runtime.ts
+++ b/scripts/probe-browser-runtime.ts
@@ -546,6 +546,35 @@ async function probeBrowserRuntimePromise(
         },
       ),
     );
+  } catch (error) {
+    // Native helper failures are otherwise reduced to a tool error after its process exits.
+    // Limit diagnostics to this disposable Profile, never an installed application's logs.
+    process.stderr.write(
+      `Browser runtime managed service: ${JSON.stringify(computerUseRuntime.managedServiceSnapshot())}\n`,
+    );
+    try {
+      const diagnostics = execFileSync(
+        "/usr/bin/log",
+        [
+          "show",
+          "--style",
+          "compact",
+          "--last",
+          "2m",
+          "--info",
+          "--debug",
+          "--predicate",
+          `processImagePath BEGINSWITH ${JSON.stringify(stateHome + path.sep)}`,
+        ],
+        { encoding: "utf8", timeout: 10_000, maxBuffer: 256 * 1024 },
+      );
+      process.stderr.write(
+        `Browser runtime native diagnostics:\n${diagnostics.slice(-64 * 1024)}\n`,
+      );
+    } catch (diagnosticError) {
+      process.stderr.write(`Browser runtime diagnostics unavailable: ${String(diagnosticError)}\n`);
+    }
+    throw error;
   } finally {
     await cleanupBrowserRuntime({
       closeNativePipeServer: () => callbacks.runPromise(Scope.close(nativePipeScope, Exit.void)),

--- a/scripts/probe-browser-runtime.ts
+++ b/scripts/probe-browser-runtime.ts
@@ -370,6 +370,11 @@ async function probeBrowserRuntimePromise(
     {
       macOSRelease,
       platform: process.platform,
+      serviceLaunchContext: {
+        nodePath: bundle.paths.node,
+        codexCliPath: bundle.paths.codexCli,
+        runtimeStateHome: stateHome,
+      },
       verifiedSkyNativeAddonPath: bundle.paths.skyNativeAddon,
       verifiedSkyNativeExports: bundle.manifest.capabilities.nativePip.exports.expectedExports,
     },

--- a/scripts/release/sparkle.test.ts
+++ b/scripts/release/sparkle.test.ts
@@ -1,6 +1,109 @@
 import { expect, test } from "vite-plus/test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { load as parse } from "js-yaml";
 
-import { isEligibleSparkleHistoryRelease, selectLatestSparkleHistoryAppcast } from "./sparkle";
+import {
+  isEligibleSparkleHistoryRelease,
+  selectLatestSparkleHistoryAppcast,
+  readSparkleHistoryManifest,
+  writeSparkleHistoryManifest,
+} from "./sparkle";
+
+test("round-trips empty and delimiter-containing history paths through a manifest", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "sparkle-history-manifest-"));
+  try {
+    const manifest = path.join(root, "history.json");
+    for (const directories of [
+      [],
+      [path.join(root, "first release"), path.join(root, "second:release\nwith newline")],
+    ]) {
+      writeSparkleHistoryManifest(manifest, directories);
+      expect(readSparkleHistoryManifest(manifest)).toEqual(directories);
+    }
+    for (const invalid of [
+      "task log\n[]",
+      JSON.stringify(["relative/path"]),
+      JSON.stringify([42]),
+      "{}",
+    ]) {
+      writeFileSync(manifest, invalid);
+      expect(() => readSparkleHistoryManifest(manifest)).toThrow();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Sparkle action carries history independently of task-runner stdout", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "sparkle-action-"));
+  try {
+    const bin = path.join(root, "bin");
+    mkdirSync(bin);
+    mkdirSync(path.join(root, "architecture"));
+    writeFileSync(
+      path.join(root, "architecture", "architecture-build.json"),
+      JSON.stringify({
+        releaseIdentity: { buildVersion: "1.0.1" },
+      }),
+    );
+    const directories = [path.join(root, "first release"), path.join(root, "second:release")];
+    writeFileSync(path.join(root, "expected.json"), JSON.stringify(directories));
+    writeFileSync(
+      path.join(bin, "vp"),
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const flag = (name) => args[args.indexOf(name) + 1];
+if (args.includes("release:fetch:sparkle-history")) {
+  fs.copyFileSync(process.env.EXPECTED_HISTORY, flag("--manifest"));
+  console.log("Task preparation log\\nTask timing summary");
+} else if (args.includes("release:finalize:sparkle")) {
+  fs.copyFileSync(flag("--history-manifest"), process.env.OBSERVED_HISTORY);
+} else {
+  throw new Error("Unexpected task: " + args.join(" "));
+}
+`,
+      { mode: 0o755 },
+    );
+    const action = parse(
+      readFileSync(
+        path.resolve(import.meta.dirname, "../../.github/actions/finalize-sparkle/action.yml"),
+        "utf8",
+      ),
+    ) as {
+      runs: { steps: Array<{ name?: string; run?: string }> };
+    };
+    const env = {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+      RUNNER_TEMP: root,
+      GITHUB_REPOSITORY: "fixture/repository",
+      RELEASE_ARCH: "arm64",
+      RELEASE_VERSION: "0.2.3-nightly.20260909.100",
+      RELEASE_SOURCE_SHA: "HEAD",
+      SPARKLE_ED25519_PRIVATE_KEY: "fixture-key",
+      SPARKLE_OUTPUT: path.join(root, "output"),
+      EXPECTED_HISTORY: path.join(root, "expected.json"),
+      OBSERVED_HISTORY: path.join(root, "observed.json"),
+    };
+    for (const name of [
+      "Fetch verified compatible update history",
+      "Finalize signed appcast and deltas",
+    ]) {
+      const script = action.runs.steps.find((step) => step.name === name)?.run;
+      if (!script) throw new Error(`Missing Sparkle step: ${name}`);
+      execFileSync("bash", ["-e", "-c", script.replaceAll("${{ inputs.channel }}", "nightly")], {
+        env,
+      });
+    }
+    expect(readSparkleHistoryManifest(env.OBSERVED_HISTORY)).toEqual(directories);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("selects Sparkle history by semantic version rather than filename order", () => {
   expect(

--- a/scripts/release/sparkle.ts
+++ b/scripts/release/sparkle.ts
@@ -557,13 +557,24 @@ export async function finalizeSparkleArchitectureUpdate(
   }
 }
 
-const splitHistoryDirectories = (value: string | undefined): readonly string[] =>
-  value
-    ? value
-        .split(path.delimiter)
-        .filter(Boolean)
-        .map((entry) => path.resolve(entry))
-    : [];
+/** Machine output is a file contract; task-runner logs never become paths. */
+export function writeSparkleHistoryManifest(
+  filePath: string,
+  directories: readonly string[],
+): void {
+  writeFileSync(filePath, `${JSON.stringify(directories, null, 2)}\n`, "utf8");
+}
+
+export function readSparkleHistoryManifest(filePath: string): readonly string[] {
+  const value: unknown = JSON.parse(readFileSync(filePath, "utf8"));
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => typeof entry === "string" && path.isAbsolute(entry))
+  ) {
+    throw new Error("Sparkle history manifest must contain an array of absolute directory paths.");
+  }
+  return value;
+}
 
 export async function runSparkleFinalizeCli(args: ReadonlyMap<string, string>): Promise<void> {
   const architecture = args.get("arch");
@@ -584,7 +595,9 @@ export async function runSparkleFinalizeCli(args: ReadonlyMap<string, string>): 
       return channel;
     })(),
     architectureDirectory: required("architecture-dir"),
-    historyDirectories: splitHistoryDirectories(args.get("history-dirs")),
+    historyDirectories: args.has("history-manifest")
+      ? readSparkleHistoryManifest(required("history-manifest"))
+      : [],
     outputDirectory: required("output"),
     privateKey: process.env.SPARKLE_ED25519_PRIVATE_KEY ?? "",
     publishedAt: required("published-at"),
@@ -809,5 +822,5 @@ export function runSparkleHistoryCli(args: ReadonlyMap<string, string>): void {
     outputDirectory: required("output"),
     repository: required("repo"),
   });
-  process.stdout.write(`${directories.join(path.delimiter)}\n`);
+  writeSparkleHistoryManifest(required("manifest"), directories);
 }

--- a/scripts/testing/native-artifacts.test.ts
+++ b/scripts/testing/native-artifacts.test.ts
@@ -46,6 +46,19 @@ describe("native test preparation", () => {
       executable,
     );
   });
+  test("prepares optimized native executables for performance measurements", async () => {
+    const releaseExecutable = path.resolve("/tmp/custom target/release/nodex-core");
+    const prepared = await prepareNativeArtifacts(["core-server"], {
+      repositoryRoot: root,
+      profile: "release",
+      execute: async (command) => {
+        expect(command.args).toContain("--release");
+        command.onStdout?.(JSON.stringify({ ...artifact, executable: releaseExecutable }) + "\n");
+        return { exitCode: 0, signal: null, durationMs: 1 };
+      },
+    });
+    expect(prepared.executables["core-server"]).toBe(releaseExecutable);
+  });
   test("rejects missing, ambiguous and unrelated artifacts", () => {
     expect(() => readCargoExecutables("", ["core-server"], root)).toThrow("exactly one");
     expect(() =>

--- a/scripts/testing/native-artifacts.ts
+++ b/scripts/testing/native-artifacts.ts
@@ -32,11 +32,17 @@ export interface PreparedNativeArtifacts {
   readonly executables: Readonly<Partial<Record<NativeArtifactId, string>>>;
 }
 
-export function cargoBuildArguments(artifacts: readonly NativeArtifactId[]): readonly string[] {
+export type NativeBuildProfile = "dev" | "release";
+
+export function cargoBuildArguments(
+  artifacts: readonly NativeArtifactId[],
+  profile: NativeBuildProfile = "dev",
+): readonly string[] {
   const selected = [...new Set(artifacts)].map((id) => targets[id]);
   if (selected.length === 0) return [];
   return [
     "build",
+    ...(profile === "release" ? ["--release"] : []),
     ...[...new Set(selected.map((target) => target.package))].flatMap((name) => ["-p", name]),
     ...selected.flatMap((target) => ["--" + target.kind, target.name]),
     "--message-format=json-render-diagnostics",
@@ -89,12 +95,13 @@ export async function prepareNativeArtifacts(
   artifacts: readonly NativeArtifactId[],
   context: {
     readonly repositoryRoot: string;
+    readonly profile?: NativeBuildProfile;
     readonly env?: NodeJS.ProcessEnv;
     readonly signal?: AbortSignal;
     readonly execute?: typeof runCommand;
   },
 ): Promise<PreparedNativeArtifacts> {
-  const args = cargoBuildArguments(artifacts);
+  const args = cargoBuildArguments(artifacts, context.profile);
   if (args.length === 0) return { executables: {} };
   let output = "";
   process.stdout.write(

--- a/scripts/testing/run-tests.test.ts
+++ b/scripts/testing/run-tests.test.ts
@@ -122,8 +122,9 @@ test("a full Core stress tier does not prepare the default-only bridge", async (
       expect(context.env?.NODEX_TEST_TIER).toBe("stress");
       return ["src/main/core-client/database-context-menu-scenario.stress.node.test.ts"];
     },
-    prepare: async (artifacts) => {
+    prepare: async (artifacts, context) => {
       expect(artifacts).toEqual(["core-server"]);
+      expect(context.profile).toBe("release");
       return { executables: { "core-server": "/tmp/core" } };
     },
     execute: async () => result(),

--- a/scripts/testing/run-tests.test.ts
+++ b/scripts/testing/run-tests.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { describe, expect, test } from "vite-plus/test";
 import { parseTestSelection, runTests } from "./run-tests";
-import { YJS_YRS_TEST } from "../../config/test-suites";
+import { CODEX_SCALE_TEST, YJS_YRS_TEST } from "../../config/test-suites";
 
 const result = (exitCode = 0) => ({ exitCode, signal: null, durationMs: 1 });
 const root = path.resolve(".");
@@ -129,4 +129,24 @@ test("a full Core stress tier does not prepare the default-only bridge", async (
     },
     execute: async () => result(),
   });
+});
+
+test("stages the locked Agent runtime before a discovered real-history pressure gate", async () => {
+  const events: string[] = [];
+  const exit = await runTests(parseTestSelection(["main", CODEX_SCALE_TEST], "stress"), {
+    repositoryRoot: root,
+    env: {},
+    signal: new AbortController().signal,
+    discover: async () => [CODEX_SCALE_TEST],
+    prepare: async () => {
+      events.push("native");
+      return { executables: {} };
+    },
+    execute: async (command) => {
+      events.push(command.args.includes("stage:codex-runtime:mac:cached") ? "agent" : "test");
+      return result();
+    },
+  });
+  expect(exit).toBe(0);
+  expect(events).toEqual(["agent", "native", "test"]);
 });

--- a/scripts/testing/run-tests.ts
+++ b/scripts/testing/run-tests.ts
@@ -4,6 +4,7 @@ import {
   STANDARD_TEST_SUITES,
   STRESS_TEST_SUITES,
   nativeRequirements,
+  requiresAgentRuntime,
   parseTestSuite,
   type SuiteId,
   type NativeArtifactId,
@@ -68,6 +69,7 @@ export async function runTests(
     signal: context.signal,
   };
   const requirements: NativeArtifactId[] = [];
+  let stageAgentRuntime = false;
   for (const suite of selection.suites) {
     if (context.signal.aborted) return 130;
     const needsSelection =
@@ -82,6 +84,15 @@ export async function runTests(
         )
       : undefined;
     requirements.push(...nativeRequirements(suite, files));
+    stageAgentRuntime ||= requiresAgentRuntime(suite, selection.tier, files);
+  }
+  if (stageAgentRuntime) {
+    const staged = await (context.execute ?? runCommand)({
+      ...commandContext,
+      command: "vp",
+      args: ["run", "stage:codex-runtime:mac:cached"],
+    });
+    if (staged.exitCode !== 0) return staged.exitCode;
   }
   const prepared = await (context.prepare ?? prepareNativeArtifacts)([...new Set(requirements)], {
     repositoryRoot: context.repositoryRoot,

--- a/scripts/testing/run-tests.ts
+++ b/scripts/testing/run-tests.ts
@@ -85,6 +85,7 @@ export async function runTests(
   }
   const prepared = await (context.prepare ?? prepareNativeArtifacts)([...new Set(requirements)], {
     repositoryRoot: context.repositoryRoot,
+    profile: selection.tier === "stress" ? "release" : "dev",
     env: environment,
     signal: context.signal,
   });

--- a/src/main/codex-application/CodexHistoryIndependentCreationPerformance.stress.test.ts
+++ b/src/main/codex-application/CodexHistoryIndependentCreationPerformance.stress.test.ts
@@ -11,6 +11,7 @@ import type {
   CodexConversationSnapshot,
 } from "../../shared/types";
 import type { ProjectWorkspaceReadSnapshot } from "../core-client/types";
+import { createCodexCanonicalConversationState } from "../../shared/codex-conversation-state/codex-conversation-state";
 import {
   CodexAppServerCapabilities,
   createCodexAppServerCapabilitySnapshot,
@@ -34,7 +35,7 @@ import { CodexRendererConversationCoordinator } from "./CodexRendererConversatio
 import { make as makeSideChatCommands } from "./CodexSideChatCommands";
 import { SIDE_CHAT_BOUNDARY_TEXT } from "./CodexSideChatPolicy";
 import { CodexThreadCatalog } from "./CodexThreadCatalog";
-import { CodexThreadDirectory } from "./CodexThreadDirectory";
+import { CodexThreadDirectory, type CodexThreadDirectoryEntry } from "./CodexThreadDirectory";
 import { CodexThreadTitlePersistence } from "./CodexThreadTitlePersistence";
 import { CodexTurnCommands, type CodexTurnCommandsService } from "./CodexTurnCommands";
 import { ConversationEntityMap } from "./internal/ConversationEntityMap";
@@ -171,7 +172,10 @@ const forkResponse = (threadId: string, ephemeral: boolean): ThreadForkResponse 
     multiAgentMode: "explicitRequestOnly",
   }) as unknown as ThreadForkResponse;
 
-const sourceEntry = (logicalTurnCount: number, includeMetadataOnlyCanonical = false) => {
+const sourceEntry = (
+  logicalTurnCount: number,
+  includeMetadataOnlyCanonical = false,
+): CodexThreadDirectoryEntry => {
   const summary = conversationSnapshot(SOURCE_THREAD_ID, logicalTurnCount);
   return {
     fidelity: "durable",
@@ -179,16 +183,41 @@ const sourceEntry = (logicalTurnCount: number, includeMetadataOnlyCanonical = fa
     durable: {
       threadId: SOURCE_THREAD_ID,
       projectId: "project-performance",
+      sessionId: null,
+      forkedFromId: null,
+      parentThreadId: null,
+      threadSource: "user",
+      serviceName: null,
+      agentNickname: null,
+      agentRole: null,
+      agentPath: null,
+      threadName: summary.threadName,
+      threadPreview: summary.threadPreview,
+      backendBinding: { kind: "codex" },
       executionHostId: HOST_ID,
       cwd: "/workspace",
       executionProfile: summary.executionProfile,
+      managedWorktreePath: null,
+      projectlessOutputDirectory: null,
+      projectlessWorkspaceBrowserRoot: null,
+      statusType: "notLoaded",
+      statusActiveFlags: [],
+      archived: false,
+      pinnedOrder: null,
+      hasUnreadTurn: false,
+      createdAt: 100,
+      updatedAt: 100,
+      recencyAt: 100,
+      linkedAt: "2026-09-09T00:00:00.000Z",
     },
     summary,
     canonical: includeMetadataOnlyCanonical
-      ? ({ turns: [] } as unknown as CodexCanonicalConversationState)
+      ? createCodexCanonicalConversationState(protocolThread(SOURCE_THREAD_ID), {
+          turnParamsById: {},
+        })
       : null,
     snapshot: null,
-  } as never;
+  };
 };
 
 const capabilitySnapshot = createCodexAppServerCapabilitySnapshot({

--- a/src/main/core-client/CodexSubagentParityPerformance.stress.test.ts
+++ b/src/main/core-client/CodexSubagentParityPerformance.stress.test.ts
@@ -13,7 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
-import type { Thread } from "@nodex/codex-app-server-protocol/v2";
+import type { Thread, ThreadListParams } from "@nodex/codex-app-server-protocol/v2";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -26,6 +26,7 @@ import {
 } from "../app/ScopedCallbackRuntime";
 import { resolveCodexRuntime } from "../codex/codex-runtime";
 import { openCodexProbeSession } from "../../../scripts/codex-probe-session";
+import { requiredNativeExecutable } from "../../../scripts/testing/native-artifacts";
 import type {
   CodexSelectedSubagentHydrateResult,
   CodexSubagentOverviewWindow,
@@ -53,6 +54,16 @@ const DESCENDANT_COUNTS = [10, 100, 1_000] as const;
 const REAL_HISTORY_ITEM_COUNTS = [0, 100, 10_000] as const;
 const REAL_HISTORY_ITEM_TEXT_BYTES = 4_096;
 const REAL_HISTORY_INJECTION_BATCH_SIZE = 500;
+const REAL_HISTORY_SOURCE = "appServer";
+const REAL_HISTORY_LIST_PARAMS = {
+  archived: false,
+  limit: 10,
+  modelProviders: [],
+  sortDirection: "desc",
+  sortKey: "created_at",
+  sourceKinds: [REAL_HISTORY_SOURCE],
+  useStateDbOnly: true,
+} satisfies ThreadListParams;
 const SAMPLE_COUNT = 15;
 const WARMUP_COUNT = 3;
 const STATUS_SAMPLE_COUNT = 15;
@@ -60,7 +71,7 @@ const HOT_OVERVIEW_P95_GATE_MS = 250;
 const REAL_HISTORY_LIST_P95_GATE_MS = 250;
 const REAL_HISTORY_RSS_NOISE_FLOOR_BYTES = 4 * 1024 * 1024;
 const PINNED_THREAD_SECTION_ID = "01984de2-8f74-7c91-a3b2-5c5e937cf318";
-const CORE_EXECUTABLE = path.resolve("target/release/nodex-core");
+const CORE_EXECUTABLE = requiredNativeExecutable("core-server");
 const EVIDENCE_PATH = path.resolve(
   "notes.local/artifacts/subagent-parity/subagent-performance-scale.json",
 );
@@ -646,7 +657,7 @@ const measureRealPersistedHistory = async (input: {
       const started = await writer.request("thread/start", {
         ephemeral: false,
         historyMode: "paginated",
-        threadSource: "appServer",
+        threadSource: REAL_HISTORY_SOURCE,
         cwd,
         approvalPolicy: "never",
         sandbox: "danger-full-access",
@@ -750,15 +761,7 @@ const measureRealPersistedHistory = async (input: {
         threadId,
         name: `Indexed real history ${input.historyItemCount}`,
       });
-      const response = await indexer.request("thread/list", {
-        archived: false,
-        limit: 10,
-        modelProviders: [],
-        sortDirection: "desc",
-        sortKey: "created_at",
-        sourceKinds: ["vscode"],
-        useStateDbOnly: true,
-      });
+      const response = await indexer.request("thread/list", REAL_HISTORY_LIST_PARAMS);
       const data = isRecord(response) && Array.isArray(response.data) ? response.data : null;
       if (!data?.some((candidate) => isRecord(candidate) && candidate.id === threadId)) {
         throw new Error("Real-history metadata resume did not index its Thread");
@@ -778,15 +781,7 @@ const measureRealPersistedHistory = async (input: {
       let metadataListBytes = 0;
       for (let sampleIndex = 0; sampleIndex < WARMUP_COUNT + SAMPLE_COUNT; sampleIndex += 1) {
         const startedAt = performance.now();
-        const response = await reader.request("thread/list", {
-          archived: false,
-          limit: 10,
-          modelProviders: [],
-          sortDirection: "desc",
-          sortKey: "created_at",
-          sourceKinds: ["vscode"],
-          useStateDbOnly: true,
-        });
+        const response = await reader.request("thread/list", REAL_HISTORY_LIST_PARAMS);
         const elapsedMs = performance.now() - startedAt;
         const data = isRecord(response) && Array.isArray(response.data) ? response.data : null;
         if (!data) throw new Error("Real-history probe received an invalid thread/list response");
@@ -962,7 +957,13 @@ it.live(
           assert.strictEqual(harness.measurement.gateway.transcriptResponseBytes, 0);
           assert.strictEqual(harness.measurement.gateway.requestCount, 0);
           assert.strictEqual(harness.measurement.childSubscriptionDependencyReads, 0);
-          assert.deepEqual(harness.measurement.conversationsReadThreadIds, []);
+          // Reading the resident root prevents starting a second live owner. Only child
+          // Conversation reads would hydrate descendant history through this boundary.
+          const childConversationReads = harness.measurement.conversationsReadThreadIds.filter(
+            (threadId) => threadId !== fixture.rootThreadId,
+          );
+          assert.deepEqual(childConversationReads, []);
+          assert.isAtMost(harness.measurement.conversationsReadThreadIds.length, SAMPLE_COUNT);
 
           const latency = summarize(latencySamples);
           assert.isAtMost(latency.p95Ms, HOT_OVERVIEW_P95_GATE_MS);
@@ -970,7 +971,8 @@ it.live(
             descendantCount,
             latency,
             steadyOverview: {
-              childConversationReads: harness.measurement.conversationsReadThreadIds.length,
+              childConversationReads: childConversationReads.length,
+              rootConversationReads: harness.measurement.conversationsReadThreadIds.length,
               childSubscriptionDependencyReads:
                 harness.measurement.childSubscriptionDependencyReads,
               childTranscriptBytes: 0,

--- a/src/main/host-runtime/ComputerUseRuntime.node.test.ts
+++ b/src/main/host-runtime/ComputerUseRuntime.node.test.ts
@@ -363,3 +363,40 @@ it.effect("keeps runtime availability best-effort when config publication fails"
     yield* Scope.close(scope, Exit.void);
   }),
 );
+
+it.effect(
+  "releases a late launched helper when its request is interrupted during Profile close",
+  () =>
+    Effect.gen(function* () {
+      const fixture = makeRuntimeFixture();
+      const launchStarted = yield* Deferred.make<void>();
+      const finishLaunch = yield* Deferred.make<void>();
+      const harness = makeHost({
+        spawnService: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(launchStarted, undefined);
+            yield* Deferred.await(finishLaunch);
+            return 8123;
+          }),
+      });
+      const { runtime, scope } = yield* buildRuntime({
+        ...fixture,
+        host: harness.host,
+        terminateManagedServiceOnDispose: true,
+      });
+      yield* runtime.ensureReady;
+      const request = yield* Effect.forkChild(
+        harness.request()("ensureService", { service: "computer-use" }),
+      );
+      yield* Deferred.await(launchStarted);
+      const interrupting = yield* Effect.forkChild(Fiber.interrupt(request));
+      const closing = yield* Effect.forkChild(Scope.close(scope, Exit.void));
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(finishLaunch, undefined);
+      yield* Fiber.join(interrupting);
+      yield* Fiber.join(closing);
+      assert.isTrue(Exit.isFailure(yield* Fiber.await(request)));
+      assert.deepEqual(harness.terminate.mock.calls, [[8123]]);
+      assert.strictEqual(runtime.managedServiceSnapshot().status, "closed");
+    }),
+);

--- a/src/main/host-runtime/ComputerUseRuntime.ts
+++ b/src/main/host-runtime/ComputerUseRuntime.ts
@@ -223,6 +223,8 @@ const make = (options: ComputerUseRuntimeLayerOptions) =>
       ),
     );
 
+    // Once native launch starts, retain the gate until its PID is adopted or
+    // terminated. The platform launch and process validation are both bounded.
     const ensureServiceUnlocked = Effect.fn("ComputerUseRuntime.ensureServiceUnlocked")(function* (
       addon: ComputerUseServiceAddon,
       executablePath: string,
@@ -279,7 +281,7 @@ const make = (options: ComputerUseRuntimeLayerOptions) =>
         "service.validate",
         new Error("Computer Use service did not become a valid managed process"),
       );
-    });
+    }, Effect.uninterruptible);
 
     const ensureService = (
       addon: ComputerUseServiceAddon,

--- a/src/main/host-runtime/ComputerUseRuntime.ts
+++ b/src/main/host-runtime/ComputerUseRuntime.ts
@@ -587,6 +587,14 @@ export const live = (
           {
             macOSRelease: options.macOSRelease,
             platform: options.platform,
+            serviceLaunchContext:
+              options.browserRuntime.status === "available"
+                ? {
+                    nodePath: options.browserRuntime.bundle.paths.node,
+                    codexCliPath: options.browserRuntime.bundle.paths.codexCli,
+                    runtimeStateHome: options.runtimeStateHome,
+                  }
+                : undefined,
             verifiedSkyNativeAddonPath:
               options.browserRuntime.status === "available"
                 ? options.browserRuntime.bundle.paths.skyNativeAddon

--- a/src/main/platform/electron/ComputerUseHostPlatform.test.ts
+++ b/src/main/platform/electron/ComputerUseHostPlatform.test.ts
@@ -169,6 +169,7 @@ it.effect("restores the prior canonical helper when post-swap verification fails
   }),
 );
 
+/* oxlint-disable effecttsgo/async-function, effecttsgo/process-env -- This boundary test launches real child processes and verifies ambient environment isolation. */
 test("launches native helpers with isolated Profile and locked runtime environments", async () => {
   const root = makeTemporaryRoot();
   const addonPath = path.join(root, "addon.cjs");
@@ -211,3 +212,5 @@ module.exports.spawnComputerUseService = async (executable) => {
   assert.strictEqual(process.env.CODEX_HOME, inheritedHome);
   assert.strictEqual(process.env.CODEX_CLI_PATH, inheritedCli);
 });
+
+/* oxlint-enable effecttsgo/async-function, effecttsgo/process-env */

--- a/src/main/platform/electron/ComputerUseHostPlatform.test.ts
+++ b/src/main/platform/electron/ComputerUseHostPlatform.test.ts
@@ -3,11 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import * as Effect from "effect/Effect";
 import { assert, it } from "@effect/vitest";
-import { afterEach, vi } from "vite-plus/test";
+import { afterEach, test, vi } from "vite-plus/test";
 import {
   ComputerUseAppMaterializer,
   ComputerUseHostPlatformError,
   makeComputerUseHostPlatform,
+  spawnComputerUseServiceInContext,
 } from "./ComputerUseHostPlatform";
 import type { ScopedCallbackRuntime } from "../../app/ScopedCallbackRuntime";
 
@@ -167,3 +168,46 @@ it.effect("restores the prior canonical helper when post-swap verification fails
     assert.strictEqual(fs.readFileSync(canonical.serviceExecutablePath, "utf8"), "old-helper");
   }),
 );
+
+test("launches native helpers with isolated Profile and locked runtime environments", async () => {
+  const root = makeTemporaryRoot();
+  const addonPath = path.join(root, "addon.cjs");
+  fs.writeFileSync(
+    addonPath,
+    `
+const fs = require("node:fs");
+const path = require("node:path");
+module.exports.spawnComputerUseService = async (executable) => {
+  fs.writeFileSync(path.join(process.env.CODEX_HOME, "observed.json"), JSON.stringify({
+    home: process.env.CODEX_HOME, codex: process.env.CODEX_CLI_PATH, executable,
+  }));
+  return 8123;
+};
+`,
+  );
+  const inheritedHome = process.env.CODEX_HOME;
+  const inheritedCli = process.env.CODEX_CLI_PATH;
+  await Promise.all(
+    ["first", "second"].map(async (name) => {
+      const home = path.join(root, name);
+      fs.mkdirSync(home);
+      const context = {
+        runtimeStateHome: home,
+        codexCliPath: path.join(home, "locked-codex"),
+        nodePath: process.execPath,
+      };
+      assert.strictEqual(
+        await spawnComputerUseServiceInContext(addonPath, "/canonical/helper", context),
+        8123,
+      );
+      assert.deepEqual(JSON.parse(fs.readFileSync(path.join(home, "observed.json"), "utf8")), {
+        home,
+        codex: context.codexCliPath,
+        executable: "/canonical/helper",
+      });
+      assert.deepEqual(fs.readdirSync(home), ["observed.json"]);
+    }),
+  );
+  assert.strictEqual(process.env.CODEX_HOME, inheritedHome);
+  assert.strictEqual(process.env.CODEX_CLI_PATH, inheritedCli);
+});

--- a/src/main/platform/electron/ComputerUseHostPlatform.ts
+++ b/src/main/platform/electron/ComputerUseHostPlatform.ts
@@ -337,6 +337,7 @@ addon.spawnComputerUseService(process.argv[2]).then((pid) => {
 }).catch(() => { process.exitCode = 1; });
 `;
 
+// oxlint-disable-next-line effecttsgo/async-function -- Native process and receipt-file acquisition is a Node platform boundary.
 export async function spawnComputerUseServiceInContext(
   addonPath: string,
   executablePath: string,

--- a/src/main/platform/electron/ComputerUseHostPlatform.ts
+++ b/src/main/platform/electron/ComputerUseHostPlatform.ts
@@ -321,7 +321,63 @@ function isLiveProcess(pid: number): boolean {
   return !processState.stdout.trimStart().startsWith("Z");
 }
 
+export interface ComputerUseServiceLaunchContext {
+  readonly nodePath: string;
+  readonly codexCliPath: string;
+  readonly runtimeStateHome: string;
+}
+
+// The native spawn API inherits its process environment. A short-lived launcher
+// gives each Profile an explicit environment without mutating Electron's globals.
+const SERVICE_LAUNCHER_SOURCE = `
+const fs = require("node:fs");
+const addon = require(process.argv[1]);
+addon.spawnComputerUseService(process.argv[2]).then((pid) => {
+  fs.writeFileSync(process.argv[3], JSON.stringify(pid));
+}).catch(() => { process.exitCode = 1; });
+`;
+
+export async function spawnComputerUseServiceInContext(
+  addonPath: string,
+  executablePath: string,
+  context: ComputerUseServiceLaunchContext,
+): Promise<number | null> {
+  const receiptDirectory = await fs.mkdtemp(path.join(context.runtimeStateHome, "service-launch-"));
+  const receiptPath = path.join(receiptDirectory, "pid.json");
+  try {
+    // Disclaimed native descendants must not inherit guarded CI stdio pipes.
+    await execFileAsync(
+      "/bin/sh",
+      [
+        "-c",
+        'exec "$@" </dev/null >/dev/null 2>&1',
+        "nodex-service-launch",
+        context.nodePath,
+        "-e",
+        SERVICE_LAUNCHER_SOURCE,
+        addonPath,
+        executablePath,
+        receiptPath,
+      ],
+      {
+        env: {
+          ...process.env,
+          CODEX_CLI_PATH: context.codexCliPath,
+          CODEX_HOME: context.runtimeStateHome,
+        },
+        timeout: 10_000,
+      },
+    );
+    const pid: unknown = JSON.parse(await fs.readFile(receiptPath, "utf8"));
+    if (typeof pid !== "number" || !Number.isSafeInteger(pid) || pid <= 0) return null;
+    return pid;
+  } finally {
+    await fs.rm(receiptDirectory, { force: true, recursive: true });
+  }
+}
+
 export interface ComputerUseHostPlatformOptions {
+  readonly serviceLaunchContext?: ComputerUseServiceLaunchContext;
   readonly loadAddon?: (
     verifiedAddonPath: string,
     verifiedExports: readonly string[],
@@ -365,9 +421,18 @@ export function makeComputerUseHostPlatform(
         return false;
       }
     },
-    spawnService: (addon, executablePath) =>
+    spawnService: (_addon, executablePath) =>
       Effect.tryPromise({
-        try: () => addon.spawnComputerUseService(executablePath),
+        try: () => {
+          if (!options.serviceLaunchContext || !options.verifiedSkyNativeAddonPath) {
+            throw new Error("Computer Use requires a verified Profile launch context");
+          }
+          return spawnComputerUseServiceInContext(
+            options.verifiedSkyNativeAddonPath,
+            executablePath,
+            options.serviceLaunchContext,
+          );
+        },
         catch: (cause) => platformError("service.spawn", cause),
       }),
     terminateProcess: (pid) =>


### PR DESCRIPTION
Nightly builds stopped before publication because release history parsing consumed task logs, stress validation omitted runtime dependencies, Computer Use inherited an incomplete launch environment, and descendant queries exceeded the overview latency budget.

Sparkle history now travels through a validated JSON manifest. The test runner prepares optimized native artifacts and the locked Agent runtime for real-history pressure tests, with complete stress validation on macOS. Computer Use launches with the verified bundled CLI and owning Profile, preserving native spawn behavior without depending on another installed app or changing global environment variables. Service acquisition retains ownership through Profile shutdown, and Chromium installation uses the same bounded process runner on macOS and Linux.

Core descendant traversal now uses indexed parent-to-child lookups, preserving reachability and universe isolation while removing quadratic SQL work. A production-query work regression covers fresh Profiles; the full local stress run measures 1,000 descendants at 4.68 ms P95 against the unchanged 250 ms gate.

Validation:
- `vp run check` and final `vp run typecheck`: passed with no warnings.
- `vp run build`: passed.
- Focused release, probe, native preparation and test-runner tests: passed.
- Complete local stress tier: passed; no performance limits relaxed.
- Explicit service environment, concurrent Profile isolation and interrupted acquisition/cleanup tests: passed.
- Cross-platform Chromium installation, timeout and cancellation tests: passed.
- Workflow secret, source-trust, matrix, Vite+ and stress contracts: passed.
- `cargo clippy -p nodex-core --all-targets --all-features -- -D warnings`: passed.
- Core Subagent projection and store-validation tests: passed; the query-work regression fails before the fix and passes after it.
- Real local Browser and Computer Use conformance: passed.
- Hosted macOS runtime conformance: passed after the service environment repair.
- [Full Nightly Reliability CI](https://github.com/junyudev/nodex/actions/runs/34322815773): passed all gates on `b72ced27a`, including the complete stress tier, native macOS runtime and browser suite. Protected-main publication validation follows merge.

The development, release and desktop-control specifications describe the resulting contracts. Nightly already has an Unreleased Added entry, so no duplicate changelog entry was added.
