### PR TITLE
fix(release): verify native signatures by their owner

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -341,6 +341,11 @@ Computer Use helper. Run deep strict `codesign` verification after restoring
 that closure and resealing Nodex, then require Gatekeeper assessment,
 notarization, stapling, and the architecture-specific runtime probe from the
 extracted final ZIP. Do not replace the vendor teams with the outer Nodex team.
+The Codex package executables, including `codex-path/rg`, are verified against
+the release lock's upstream team by the Codex runtime verifier. The native
+verifier's Nodex signature and entitlement inventory contains only the native
+runtime manifest binaries and Nodex clipboard bridge; it must remain disjoint
+from the signing hook's preserved vendor inventory.
 
 `vp run test:all` remains a compatibility alias for `verify:source`.
 

--- a/scripts/verify-native-runtime.test.ts
+++ b/scripts/verify-native-runtime.test.ts
@@ -12,8 +12,14 @@ import {
   isPackagedAppReady,
   parseMacCodeSigningEntitlements,
   removePrivateTemporaryDirectory,
+  resolveNodexNativeCodeObjects,
   selectPackagedSmokeProjectId,
 } from "./verify-native-runtime";
+import { NATIVE_RUNTIME_BINARY_PATHS, parseNativeRuntimeManifest } from "./native-runtime-manifest";
+import {
+  isPreservedBrowserRuntimeVendorCode,
+  isPreservedCodexRuntimeVendorCode,
+} from "./sign-macos-runtime.mjs";
 import {
   acquireIsolatedRunLease,
   markIsolatedRunClaimReady,
@@ -31,6 +37,37 @@ afterEach(() => {
 });
 
 describe("packaged native runtime verification", () => {
+  test("keeps Nodex signature and entitlement verification disjoint from preserved vendor code", () => {
+    const appPath = "/signed/Nodex.app";
+    const manifest = parseNativeRuntimeManifest({
+      schemaVersion: 4,
+      productVersion: "0.2.3",
+      minimumMacOS: "15.0",
+      targetArch: "arm64",
+      targetPlatform: "darwin",
+      rustTarget: "aarch64-apple-darwin",
+      binaries: Object.entries(NATIVE_RUNTIME_BINARY_PATHS).map(([name, bundlePath]) => ({
+        name,
+        bundlePath,
+        file: name,
+        sourceSize: 1,
+        sourceSha256: "a".repeat(64),
+      })),
+    });
+    const codeObjects = resolveNodexNativeCodeObjects(appPath, manifest);
+    expect(codeObjects).toHaveLength(manifest.binaries.length + 1);
+    expect(codeObjects).toContain(
+      path.join(appPath, "Contents/Resources/native/nodex-clipboard.node"),
+    );
+    for (const artifactPath of codeObjects) {
+      expect(isPreservedCodexRuntimeVendorCode(appPath, artifactPath)).toBe(false);
+      expect(isPreservedBrowserRuntimeVendorCode(appPath, artifactPath)).toBe(false);
+    }
+    const ripgrep = path.join(appPath, "Contents/Resources/codex-path/rg");
+    expect(isPreservedCodexRuntimeVendorCode(appPath, ripgrep)).toBe(true);
+    expect(codeObjects).not.toContain(ripgrep);
+  });
+
   test("parses boolean capabilities from codesign entitlement output", () => {
     expect(
       parseMacCodeSigningEntitlements(`

--- a/scripts/verify-native-runtime.ts
+++ b/scripts/verify-native-runtime.ts
@@ -30,6 +30,7 @@ import {
   readNativeRuntimeManifest,
   sha256File,
   type NativeRuntimeArchitecture,
+  type NativeRuntimeManifest,
 } from "./native-runtime-manifest";
 import {
   compareMacosVersions,
@@ -375,7 +376,10 @@ const verifySignatures = (
 ): void => {
   const helperApp = join(appPath, "Contents/Helpers/Nodex Service.app");
   const appSignature = signatureDetails(appPath);
-  const nestedSignatures = [...binaryPaths.map(signatureDetails), signatureDetails(helperApp)];
+  const nestedSignatures = [...binaryPaths, helperApp].map((artifactPath) => ({
+    artifactPath,
+    ...signatureDetails(artifactPath),
+  }));
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=2", appPath], "Verify app seal");
   if (!requireDeveloperId) return;
   if (appSignature.adhoc || !appSignature.teamIdentifier) {
@@ -383,7 +387,9 @@ const verifySignatures = (
   }
   for (const signature of nestedSignatures) {
     if (signature.adhoc || signature.teamIdentifier !== appSignature.teamIdentifier) {
-      throw new Error("Native runtime signature is inconsistent with the enclosing Nodex.app");
+      throw new Error(
+        `Native runtime signature for ${signature.artifactPath} has team ${signature.teamIdentifier ?? "<none>"}, expected enclosing Nodex.app team ${appSignature.teamIdentifier}`,
+      );
     }
   }
 };
@@ -1351,6 +1357,15 @@ const launchAppSmoke = async (appPath: string, expectedCoreSha256: string): Prom
   }
 };
 
+/** Vendor tools retain their upstream identity and are verified by verifyCodexRuntime. */
+export const resolveNodexNativeCodeObjects = (
+  appPath: string,
+  manifest: NativeRuntimeManifest,
+): readonly string[] => [
+  ...manifest.binaries.map(({ bundlePath }) => join(appPath, "Contents", bundlePath)),
+  join(appPath, "Contents/Resources/native/nodex-clipboard.node"),
+];
+
 export function verifyPackagedNativeRuntimeStructure(
   options: PackagedNativeRuntimeStructureOptions,
 ): PackagedNativeRuntimeIdentity {
@@ -1398,7 +1413,7 @@ export function verifyPackagedNativeRuntimeStructure(
       `Native runtime manifest is ${manifest.targetArch}, expected ${options.targetArch}`,
     );
   }
-  const nativeBinaryPaths = manifest.binaries.map((binary) => {
+  for (const binary of manifest.binaries) {
     const binaryPath = join(contentsPath, ...binary.bundlePath.split("/"));
     assertRegularExecutable(binaryPath);
     const metadata = statSync(binaryPath);
@@ -1406,16 +1421,14 @@ export function verifyPackagedNativeRuntimeStructure(
       throw new Error(`Native runtime manifest identity mismatch for ${binary.name}`);
     }
     assertMachO(binaryPath, options.targetArch, manifest.minimumMacOS);
-    return binaryPath;
-  });
+  }
   const cliRipgrep = join(contentsPath, "Resources/codex-path/rg");
   assertRegularExecutable(cliRipgrep);
   assertMachOArchitecture(cliRipgrep, options.targetArch);
-  nativeBinaryPaths.push(cliRipgrep);
   const clipboardBridge = join(contentsPath, "Resources/native/nodex-clipboard.node");
   assertRegularExecutable(clipboardBridge);
   assertMachO(clipboardBridge, options.targetArch, manifest.minimumMacOS);
-  nativeBinaryPaths.push(clipboardBridge);
+  const nativeBinaryPaths = resolveNodexNativeCodeObjects(appPath, manifest);
   const sparkleCodeObjects = verifySparkleRuntime(appPath, options);
   const computerUseInfo = join(
     contentsPath,


### PR DESCRIPTION
The signed Nightly failed after its packaged Browser runtime probe because native verification required Codex's preserved ripgrep signature to match Nodex's signing team. The Codex verifier had already validated that executable against the locked upstream identity.

Resolve Nodex's signature and entitlement inventory from its native manifest plus clipboard bridge. Keep vendor identity verification with the Codex verifier, retain ripgrep's structural and search checks, and report the artifact and team on signature failures. A cross-owner regression checks the verification inventory against the actual signing-preservation policy.

Validation:
- 25 focused native verification, signing policy and Codex verification tests passed.
- Full typecheck/lint and format checks passed.
- Standards review: no findings. Spec review: no findings.
- Actual Nightly 34324602491 passed every source gate and arm64 packaged Browser conformance before exposing this signature inventory defect. Protected-main publication will be rerun after merge.

The release runbook records the ownership boundary. No duplicate changelog entry: Nightly is already an Unreleased addition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified macOS release verification requirements for packaged executables and signing-team checks.
  * Documented the separate handling of native runtime artifacts and preserved vendor binaries.

* **Bug Fixes**
  * Improved packaged runtime validation to verify native components consistently.
  * Enhanced signing errors to identify the affected artifact and mismatched team, making release issues easier to diagnose.

* **Tests**
  * Added coverage confirming native runtime components remain distinct from preserved vendor binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->