### PR TITLE
fix(release): keep dictation verification on the production protocol

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -346,6 +346,10 @@ the release lock's upstream team by the Codex runtime verifier. The native
 verifier's Nodex signature and entitlement inventory contains only the native
 runtime manifest binaries and Nodex clipboard bridge; it must remain disjoint
 from the signing hook's preserved vendor inventory.
+The dictation helper build stamp and packaged handshake check use the production
+client's protocol version. Packaged conformance checks empty binding replacement,
+permission capability reads without prompting, and clean helper exit; an
+incompatible ready handshake fails immediately with the observed version.
 
 `vp run test:all` remains a compatibility alias for `verify:source`.
 

--- a/scripts/build-macos-dictation-helper.ts
+++ b/scripts/build-macos-dictation-helper.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { MAC_DICTATION_HELPER_PROTOCOL_VERSION } from "../src/main/dictation/mac-dictation-native-helper-client";
 import {
   swiftTargetForNativeRuntime,
   type NativeRuntimeArchitecture,
@@ -19,7 +20,7 @@ import {
 interface BuildStamp {
   readonly architecture: NativeRuntimeArchitecture;
   readonly minimumMacOS: "15.0";
-  readonly protocolVersion: 3;
+  readonly protocolVersion: typeof MAC_DICTATION_HELPER_PROTOCOL_VERSION;
   readonly sourceSha256: string;
 }
 
@@ -57,7 +58,7 @@ const main = (): void => {
   const stamp: BuildStamp = {
     architecture: resolveArchitecture(),
     minimumMacOS: "15.0",
-    protocolVersion: 3,
+    protocolVersion: MAC_DICTATION_HELPER_PROTOCOL_VERSION,
     sourceSha256: createHash("sha256").update(readFileSync(sourcePath)).digest("hex"),
   };
   const stampPath = `${outputPath}.build.json`;

--- a/scripts/verify-native-runtime.test.ts
+++ b/scripts/verify-native-runtime.test.ts
@@ -14,6 +14,7 @@ import {
   removePrivateTemporaryDirectory,
   resolveNodexNativeCodeObjects,
   selectPackagedSmokeProjectId,
+  smokeDictationHelper,
 } from "./verify-native-runtime";
 import { NATIVE_RUNTIME_BINARY_PATHS, parseNativeRuntimeManifest } from "./native-runtime-manifest";
 import {
@@ -37,6 +38,43 @@ afterEach(() => {
 });
 
 describe("packaged native runtime verification", () => {
+  const createDictationHelperApp = (protocolVersion: number): string => {
+    const appPath = fs.mkdtempSync(path.join(os.tmpdir(), "nodex-dictation-smoke-"));
+    temporaryDirectories.push(appPath);
+    const bin = path.join(appPath, "Contents/Resources/bin");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(
+      path.join(bin, "nodex-dictation-helper"),
+      `#!/usr/bin/env node
+const readline = require("node:readline");
+let requests = 0;
+process.stdout.write(JSON.stringify({ type: "ready", protocolVersion: ${protocolVersion} }) + "\\n");
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const request = JSON.parse(line);
+  const expected = requests++ === 0 ? "replaceBindings" : "capabilities";
+  if (request.type !== expected) process.exit(2);
+  if (request.type === "replaceBindings" && request.bindings.length !== 0) process.exit(3);
+  const value = request.type === "replaceBindings"
+    ? { applied: true, generation: request.generation }
+    : { inputMonitoring: false, accessibility: false };
+  process.stdout.write(JSON.stringify({ type: "response", id: request.id, ok: true, value }) + "\\n");
+}).on("close", () => process.exit(requests === 2 ? 0 : 4));
+`,
+      { mode: 0o755 },
+    );
+    return appPath;
+  };
+
+  test("smokes the current dictation handshake, empty bindings, capabilities and clean exit", async () => {
+    await expect(smokeDictationHelper(createDictationHelperApp(3))).resolves.toBeUndefined();
+  });
+
+  test("rejects an incompatible dictation handshake with its version instead of timing out", async () => {
+    await expect(smokeDictationHelper(createDictationHelperApp(2))).rejects.toThrow(
+      "protocol is 2, expected 3",
+    );
+  });
+
   test("keeps Nodex signature and entitlement verification disjoint from preserved vendor code", () => {
     const appPath = "/signed/Nodex.app";
     const manifest = parseNativeRuntimeManifest({

--- a/scripts/verify-native-runtime.ts
+++ b/scripts/verify-native-runtime.ts
@@ -60,6 +60,7 @@ import {
   ProjectWorkspace,
 } from "../src/main/project-application/ProjectWorkspace";
 import { decodeXmlCharacterReferences } from "../src/shared/xml-character-references";
+import { MAC_DICTATION_HELPER_PROTOCOL_VERSION } from "../src/main/dictation/mac-dictation-native-helper-client";
 
 export class PackagedNativeRuntimeVerificationError extends Schema.TaggedError<PackagedNativeRuntimeVerificationError>()(
   "PackagedNativeRuntimeVerificationError",
@@ -1061,7 +1062,7 @@ const smokeBrowserProfileHelper = (appPath: string): void => {
   }
 };
 
-const smokeDictationHelper = async (appPath: string): Promise<void> => {
+export const smokeDictationHelper = async (appPath: string): Promise<void> => {
   const helper = join(appPath, "Contents/Resources/bin/nodex-dictation-helper");
   const child = spawn(helper, [], { stdio: ["pipe", "pipe", "pipe"] });
   child.stdout.setEncoding("utf8");
@@ -1094,7 +1095,15 @@ const smokeDictationHelper = async (appPath: string): Promise<void> => {
           fail(new Error("Packaged dictation helper emitted invalid JSON"));
           return;
         }
-        if (message.type === "ready" && message.protocolVersion === 2) {
+        if (message.type === "ready") {
+          if (message.protocolVersion !== MAC_DICTATION_HELPER_PROTOCOL_VERSION) {
+            fail(
+              new Error(
+                `Packaged dictation helper protocol is ${String(message.protocolVersion)}, expected ${MAC_DICTATION_HELPER_PROTOCOL_VERSION}`,
+              ),
+            );
+            return;
+          }
           ready = true;
           child.stdin.write(
             `${JSON.stringify({

--- a/src/main/dictation/mac-dictation-native-helper-client.ts
+++ b/src/main/dictation/mac-dictation-native-helper-client.ts
@@ -8,7 +8,7 @@ const MAXIMUM_LINE_BYTES = 64 * 1024;
 const MAXIMUM_STDERR_BYTES = 8 * 1024;
 const REQUEST_TIMEOUT_MS = 12_000;
 const READY_TIMEOUT_MS = 3_000;
-const MAC_DICTATION_HELPER_PROTOCOL_VERSION = 3;
+export const MAC_DICTATION_HELPER_PROTOCOL_VERSION = 3;
 
 export interface MacDictationForegroundTarget {
   readonly pid: number;


### PR DESCRIPTION
Nightly now passes signed package structure verification, but its dictation smoke still expects protocol 2 while the packaged helper and production client use protocol 3. The valid ready message is ignored until the smoke times out.

Use the production client's protocol version in the helper build stamp and packaged smoke. Reject incompatible handshakes immediately with the observed and expected versions. Keep empty binding replacement, capability validation and clean helper exit checks unchanged.

Validation:
- 12 packaged-native verification tests passed, including subprocess handshake/request/exit and incompatible-version regressions.
- The same smoke passed against the actual compiled macOS Swift helper.
- 5 production dictation client tests passed through the Main runner.
- Full typecheck/lint and formatting passed.
- Standards review: no findings. Spec review: no findings.

The release runbook records this protocol ownership boundary. Actual protected-main publication remains the final acceptance check. No duplicate changelog entry for the existing Unreleased Nightly addition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS dictation helper validation to detect incompatible protocol versions immediately and report the observed version instead of timing out.
  * Added checks for successful handshakes, capability exchanges, empty binding replacement, permission reads without prompts, and clean helper shutdown.

* **Documentation**
  * Updated the macOS release runbook with the latest dictation helper release checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->