### PR TITLE
fix(release): publish updates across package format changes

### DIFF
--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -245,6 +245,12 @@ release, it proves the protected private key matches the reviewed public key
 and that the extracted App plist/runtime carry that key; both architectures
 must also use the pinned Developer ID Team ID `8HGUT3HC4Z`.
 
+Update targets use the package-provenance module’s current format. History selection
+verifies the immutable Release Bundle and update-manifest digests before checking
+package-format compatibility. Older package formats are excluded before downloading
+full ZIPs; malformed or invalid current candidates fail closed. An empty compatible
+history publishes a full update without deltas.
+
 Compatible history moves between fetch and finalization as a JSON manifest of
 absolute directory paths. Task-runner stdout is diagnostic output, never the
 machine-readable directory list. Empty history is an empty array; paths do not

--- a/scripts/package-provenance.d.mts
+++ b/scripts/package-provenance.d.mts
@@ -1,5 +1,7 @@
 import type { TestedBrowserAppServerPair } from "../src/shared/browser-app-server-compatibility.mjs";
 
+export const PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION: 6;
+
 export interface PackagedAgentRuntimeIdentity {
   readonly archiveSha256: string;
   readonly archiveSize: number;
@@ -15,6 +17,7 @@ export interface PackagedAgentRuntimeIdentity {
 }
 
 export interface PackagedBuildProvenance {
+  readonly schemaVersion: typeof PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION;
   readonly agentRuntime: PackagedAgentRuntimeIdentity;
   readonly product: {
     readonly name: string;

--- a/scripts/package-provenance.mjs
+++ b/scripts/package-provenance.mjs
@@ -29,7 +29,7 @@ import {
   parseCodexAppServerReleaseLock,
 } from "../src/shared/codex-app-server-release-lock.mjs";
 
-const PROVENANCE_SCHEMA_VERSION = 6;
+export const PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION = 6;
 const PREPARED_SCHEMA_VERSION = 4;
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const canonicalAgentRuntimeLockPath = path.join(
@@ -498,7 +498,7 @@ export const writePackagedBuildProvenance = (appPath, options = {}) => {
   }
 
   const body = {
-    schemaVersion: PROVENANCE_SCHEMA_VERSION,
+    schemaVersion: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
     product: {
       name: prepared.product.name,
       version: prepared.product.version,
@@ -568,7 +568,7 @@ export const verifyPackagedBuildProvenance = (appPath, options = {}) => {
     ],
     "Packaged build provenance",
   );
-  if (value.schemaVersion !== PROVENANCE_SCHEMA_VERSION) {
+  if (value.schemaVersion !== PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION) {
     throw new Error("Packaged build provenance schema is unsupported");
   }
   const { provenanceId, ...body } = value;

--- a/scripts/package-provenance.test.ts
+++ b/scripts/package-provenance.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/shared/browser-app-server-compatibility";
 
 import {
+  PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
   verifyPackagedBuildProvenance,
   writePackagedBuildProvenance,
 } from "./package-provenance.mjs";
@@ -421,6 +422,7 @@ describe("packaged build provenance", () => {
       expectedPreparedManifestPath: fixture.currentPreparedPath,
     });
 
+    expect(written.schemaVersion).toBe(PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION);
     expect(verified.provenanceId).toBe(written.provenanceId);
     const lock = readCodexAppServerReleaseLock(fixture.lockPath);
     expect(verified.agentRuntime).toMatchObject({

--- a/scripts/release/bundle.test.ts
+++ b/scripts/release/bundle.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, expect, test } from "vite-plus/test";
 
+import { PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION } from "../package-provenance.mjs";
 import {
   assembleReleaseBundle,
   parseArchitectureBuildManifest,
@@ -166,7 +167,7 @@ const makeUpdate = (
     target: {
       buildVersion: BUILD_VERSION,
       bundleId: "app.jyu.nodex",
-      packageProvenanceSchema: 5,
+      packageProvenanceSchema: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
       teamIdentifier: NODEX_MACOS_TEAM_IDENTIFIER,
       version: VERSION,
     },

--- a/scripts/release/sparkle-history.test.ts
+++ b/scripts/release/sparkle-history.test.ts
@@ -1,0 +1,189 @@
+import { expect, test } from "vite-plus/test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION } from "../package-provenance.mjs";
+import { fetchSparkleHistory } from "./sparkle";
+import { sha256File } from "./model";
+
+const VERSION = "0.2.3-nightly.20260820.1185";
+const TAG = `v${VERSION}`;
+const SHA = "a".repeat(40);
+const DIGEST = "b".repeat(64);
+
+const makeHistory = (root: string, schema: number, corruptDigest: boolean) => {
+  const source = path.join(root, "source");
+  mkdirSync(source);
+  const fullName = `Nodex-${VERSION}-arm64.zip`;
+  const appcastName = `Nodex-${VERSION}-appcast-arm64.xml`;
+  const updateName = `Nodex-${VERSION}-update-arm64.json`;
+  const fullUrl = `https://github.com/junyudev/nodex/releases/download/${TAG}/${fullName}`;
+  const signature = `${"A".repeat(86)}==`;
+  writeFileSync(path.join(source, fullName), "full-update");
+  const identity = (name: string) => ({
+    bytes: readFileSync(path.join(source, name)).byteLength,
+    name,
+    sha256: sha256File(path.join(source, name)),
+  });
+  const full = { ...identity(fullName), edSignature: signature, url: fullUrl };
+  writeFileSync(
+    path.join(source, appcastName),
+    `<?xml version="1.0"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"><channel><item>
+<sparkle:version>1.11.85</sparkle:version><sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+<sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+<enclosure url="${fullUrl}" length="${full.bytes}" sparkle:edSignature="${signature}" />
+</item></channel></rss>`,
+  );
+  writeFileSync(
+    path.join(source, updateName),
+    JSON.stringify({
+      architecture: "arm64",
+      channel: "nightly",
+      schemaVersion: 2,
+      sourceSha: SHA,
+      tag: TAG,
+      appcast: { ...identity(appcastName), feedPath: "updates/nightly/arm64/appcast.xml" },
+      full,
+      deltas: [],
+      target: {
+        buildVersion: "1.11.85",
+        bundleId: "app.jyu.nodex",
+        packageProvenanceSchema: schema,
+        teamIdentifier: "8HGUT3HC4Z",
+        version: VERSION,
+      },
+    }),
+  );
+  const assets = [
+    ...(["arm64", "x64"] as const).flatMap((architecture) =>
+      [
+        [`Nodex-${VERSION}-${architecture}.dmg`, "dmg"],
+        [`Nodex-${VERSION}-${architecture}.zip`, "sparkle-full"],
+        [`Nodex-${VERSION}-appcast-${architecture}.xml`, "sparkle-appcast"],
+        [`Nodex-${VERSION}-update-${architecture}.json`, "sparkle-update-manifest"],
+      ].map(([name, role]) => ({
+        architecture,
+        role,
+        ...(existsSync(path.join(source, name))
+          ? identity(name)
+          : { name, bytes: 1, sha256: DIGEST }),
+      })),
+    ),
+    { name: "release-identity.json", role: "release-identity", bytes: 1, sha256: DIGEST },
+  ];
+  const architecture = {
+    manifestSha256: DIGEST,
+    preparedBuildGeneration: DIGEST,
+    updateManifestSha256: DIGEST,
+  };
+  writeFileSync(
+    path.join(source, "release-bundle.json"),
+    JSON.stringify({
+      schemaVersion: 2,
+      sourceSha: SHA,
+      sourceTree: SHA,
+      version: VERSION,
+      tag: TAG,
+      assets,
+      agentSkills: { manifestSha256: DIGEST, treeSha256: DIGEST },
+      architectures: { arm64: architecture, x64: architecture },
+      runtimeLocks: { agentSha256: DIGEST, browserSha256: DIGEST, sparkleSha256: DIGEST },
+      releaseIdentity: {
+        schemaVersion: 1,
+        channel: "nightly",
+        sourceSha: SHA,
+        sourceTree: SHA,
+        sourceVersion: "0.2.2",
+        version: VERSION,
+        buildVersion: "1.11.85",
+        tag: TAG,
+        mainlineOrdinal: 1185,
+        sourceDate: "2026-08-20",
+      },
+    }),
+  );
+  writeFileSync(
+    path.join(root, "release.json"),
+    JSON.stringify({
+      tag_name: TAG,
+      draft: false,
+      immutable: true,
+      prerelease: true,
+      published_at: "2026-08-20",
+      assets: ["release-bundle.json", updateName, fullName, appcastName].map((name) => ({
+        name,
+        size: identity(name).bytes,
+        digest: `sha256:${corruptDigest && name === updateName ? DIGEST : identity(name).sha256}`,
+      })),
+    }),
+  );
+  const bin = path.join(root, "bin");
+  mkdirSync(bin);
+  writeFileSync(
+    path.join(bin, "gh"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const root = path.dirname(__dirname);
+const args = process.argv.slice(2);
+if (args[0] === "api") {
+  console.log(args[1].includes("/commits/") ? ${JSON.stringify(SHA)} : "[" + fs.readFileSync(path.join(root, "release.json"), "utf8") + "]");
+} else if (args[0] === "release" && args[1] === "download") {
+  const name = args[args.indexOf("--pattern") + 1];
+  fs.appendFileSync(path.join(root, "downloads.jsonl"), JSON.stringify(name) + "\\n");
+  fs.copyFileSync(path.join(root, "source", name), path.join(args[args.indexOf("--dir") + 1], name));
+} else { throw new Error("Unexpected gh invocation"); }
+`,
+    { mode: 0o755 },
+  );
+  return { bin, updateName, fullName, appcastName };
+};
+
+test.each([
+  { schema: 4, corruptDigest: false },
+  { schema: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION, corruptDigest: false },
+  { schema: 4, corruptDigest: true },
+])(
+  "fetches only compatible, digest-verified history: $schema / $corruptDigest",
+  ({ schema, corruptDigest }) => {
+    const root = mkdtempSync(path.join(tmpdir(), "nodex-sparkle-history-"));
+    const previousPath = process.env.PATH;
+    try {
+      const fixture = makeHistory(root, schema, corruptDigest);
+      process.env.PATH = `${fixture.bin}${path.delimiter}${previousPath}`;
+      const output = path.join(root, "history");
+      const fetch = () =>
+        fetchSparkleHistory({
+          architecture: "arm64",
+          channel: "nightly",
+          currentVersion: "0.2.3-nightly.20260909.1425",
+          currentBuildVersion: "1.14.25",
+          outputDirectory: output,
+          repository: "junyudev/nodex",
+        });
+      if (corruptDigest) {
+        expect(fetch).toThrow("digest verification");
+        return;
+      }
+      const compatible = schema === PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION;
+      expect(fetch()).toEqual(compatible ? [path.join(output, VERSION)] : []);
+      expect(existsSync(path.join(output, VERSION))).toBe(compatible);
+      expect(
+        readFileSync(path.join(root, "downloads.jsonl"), "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line)),
+      ).toEqual([
+        "release-bundle.json",
+        fixture.updateName,
+        ...(compatible ? [fixture.fullName, fixture.appcastName] : []),
+      ]);
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/scripts/release/sparkle-manifest.test.ts
+++ b/scripts/release/sparkle-manifest.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "vite-plus/test";
 
+import { PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION } from "../package-provenance.mjs";
 import {
   NODEX_MACOS_TEAM_IDENTIFIER,
   parseSparkleArchitectureUpdateManifest,
+  parseCompatibleSparkleHistoryUpdateManifest,
 } from "./sparkle-manifest";
 
 const VERSION = "0.2.2";
@@ -43,7 +45,7 @@ const manifest = () => ({
   target: {
     buildVersion: VERSION,
     bundleId: "app.jyu.nodex",
-    packageProvenanceSchema: 5,
+    packageProvenanceSchema: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
     teamIdentifier: NODEX_MACOS_TEAM_IDENTIFIER,
     version: VERSION,
   },
@@ -104,4 +106,32 @@ test("accepts a nightly feed identity and rejects a stable feed path", () => {
     appcast: { ...nightly.appcast, feedPath: "updates/stable/arm64/appcast.xml" },
   };
   expect(() => parseSparkleArchitectureUpdateManifest(mismatched)).toThrow("projection identity");
+});
+
+test("excludes older package formats only from history, never current release validation", () => {
+  for (const schema of [4, 5]) {
+    const candidate = {
+      ...manifest(),
+      target: { ...manifest().target, packageProvenanceSchema: schema },
+    };
+    expect(parseCompatibleSparkleHistoryUpdateManifest(candidate)).toBeNull();
+    expect(() => parseSparkleArchitectureUpdateManifest(candidate)).toThrow("target identity");
+  }
+  expect(parseCompatibleSparkleHistoryUpdateManifest(manifest())).toEqual(
+    parseSparkleArchitectureUpdateManifest(manifest()),
+  );
+});
+
+test("fails closed on malformed, future, and invalid current history identities", () => {
+  for (const schema of [undefined, "4", 0, -1, 4.5, PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION + 1]) {
+    expect(() =>
+      parseCompatibleSparkleHistoryUpdateManifest({
+        ...manifest(),
+        target: { ...manifest().target, packageProvenanceSchema: schema },
+      }),
+    ).toThrow();
+  }
+  const candidate = manifest();
+  candidate.target.teamIdentifier = "OTHERTEAM1";
+  expect(() => parseCompatibleSparkleHistoryUpdateManifest(candidate)).toThrow("target identity");
 });

--- a/scripts/release/sparkle-manifest.ts
+++ b/scripts/release/sparkle-manifest.ts
@@ -1,5 +1,6 @@
 import { basename } from "node:path";
 
+import { PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION } from "../package-provenance.mjs";
 import {
   compareBuildVersions,
   normalizeAppleBuildVersion,
@@ -41,7 +42,7 @@ export interface SparkleArchitectureUpdateManifest {
   readonly target: {
     readonly buildVersion: string;
     readonly bundleId: "app.jyu.nodex";
-    readonly packageProvenanceSchema: 5;
+    readonly packageProvenanceSchema: typeof PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION;
     readonly teamIdentifier: string;
     readonly version: string;
   };
@@ -209,7 +210,7 @@ export function parseSparkleArchitectureUpdateManifest(
   if (
     value.tag !== tag ||
     value.target.bundleId !== "app.jyu.nodex" ||
-    value.target.packageProvenanceSchema !== 5 ||
+    value.target.packageProvenanceSchema !== PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION ||
     value.target.teamIdentifier !== NODEX_MACOS_TEAM_IDENTIFIER
   ) {
     throw new Error("Sparkle update target identity is invalid.");
@@ -257,9 +258,26 @@ export function parseSparkleArchitectureUpdateManifest(
     target: {
       buildVersion: targetBuildVersion,
       bundleId: "app.jyu.nodex",
-      packageProvenanceSchema: 5,
+      packageProvenanceSchema: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
       teamIdentifier: value.target.teamIdentifier,
       version,
     },
   };
+}
+
+/** Older package formats are excluded from delta history; current candidates stay strict. */
+export function parseCompatibleSparkleHistoryUpdateManifest(
+  value: unknown,
+): SparkleArchitectureUpdateManifest | null {
+  const schema =
+    isRecord(value) && isRecord(value.target) ? value.target.packageProvenanceSchema : undefined;
+  if (
+    typeof schema === "number" &&
+    Number.isSafeInteger(schema) &&
+    schema > 0 &&
+    schema < PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION
+  ) {
+    return null;
+  }
+  return parseSparkleArchitectureUpdateManifest(value);
 }

--- a/scripts/release/sparkle.ts
+++ b/scripts/release/sparkle.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 
 import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 
+import { PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION } from "../package-provenance.mjs";
 import { materializeSparkleRuntime } from "../materialize-sparkle-runtime";
 import {
   compareStableVersions,
@@ -31,6 +32,7 @@ import {
 } from "./model";
 import {
   parseSparkleArchitectureUpdateManifest,
+  parseCompatibleSparkleHistoryUpdateManifest,
   type SparkleArchitectureUpdateManifest,
   type SparkleDeltaIdentity,
   type SparkleFileIdentity,
@@ -469,7 +471,7 @@ export async function finalizeSparkleArchitectureUpdate(
     if (
       identity.version !== version ||
       identity.bundleId !== PRODUCT_BUNDLE_ID ||
-      identity.packageProvenanceSchema !== 5 ||
+      identity.packageProvenanceSchema !== PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION ||
       identity.publicKey !== publicKey ||
       identity.runtimePublicKey !== publicKey
     ) {
@@ -539,7 +541,7 @@ export async function finalizeSparkleArchitectureUpdate(
       target: {
         buildVersion: identity.buildVersion,
         bundleId: PRODUCT_BUNDLE_ID,
-        packageProvenanceSchema: 5,
+        packageProvenanceSchema: PACKAGED_BUILD_PROVENANCE_SCHEMA_VERSION,
         teamIdentifier: identity.teamIdentifier,
         version,
       },
@@ -749,7 +751,7 @@ export function fetchSparkleHistory(options: {
         `${release.tag_name} does not contain one complete ${options.architecture} update set.`,
       );
     }
-    for (const asset of selected) {
+    const downloadAsset = (asset: (typeof selected)[number]): void => {
       gh([
         "release",
         "download",
@@ -766,15 +768,22 @@ export function fetchSparkleHistory(options: {
       if (statSync(assetPath).size !== asset.bytes || sha256File(assetPath) !== asset.sha256) {
         throw new Error(`${release.tag_name}/${asset.name} does not match release-bundle.json.`);
       }
-    }
-    const updateName = `Nodex-${version}-update-${options.architecture}.json`;
-    const update = parseSparkleArchitectureUpdateManifest(
-      JSON.parse(readFileSync(path.join(releaseRoot, updateName), "utf8")) as unknown,
+    };
+    const updateAsset = selected.find(({ role }) => role === "sparkle-update-manifest");
+    if (!updateAsset) throw new Error(`${release.tag_name} is missing its update manifest.`);
+    downloadAsset(updateAsset);
+    const update = parseCompatibleSparkleHistoryUpdateManifest(
+      JSON.parse(readFileSync(path.join(releaseRoot, updateAsset.name), "utf8")) as unknown,
     );
+    if (!update) {
+      rmSync(releaseRoot, { force: true, recursive: true });
+      continue;
+    }
     const fullAsset = selected.find(({ role }) => role === "sparkle-full");
     const appcastAsset = selected.find(({ role }) => role === "sparkle-appcast");
     if (
-      update.target.packageProvenanceSchema !== 5 ||
+      update.architecture !== options.architecture ||
+      update.target.buildVersion !== bundle.releaseIdentity.buildVersion ||
       update.channel !== channel ||
       update.sourceSha !== bundle.sourceSha ||
       update.tag !== bundle.tag ||
@@ -790,6 +799,8 @@ export function fetchSparkleHistory(options: {
     ) {
       throw new Error(`${release.tag_name} is not a Sparkle-capable provenance release.`);
     }
+    downloadAsset(fullAsset);
+    downloadAsset(appcastAsset);
     verifySparkleAppcastContract(
       readFileSync(path.join(releaseRoot, update.appcast.name), "utf8"),
       update,


### PR DESCRIPTION
Nightly publication stopped while loading older update history because Sparkle required a package format that no longer matched either the historical releases or the current package producer.

Sparkle now uses the package-provenance module’s current version. History selection verifies the immutable Release Bundle and update-manifest digests, excludes older package formats before downloading full ZIPs, and keeps strict validation for current or unknown formats. Releases without compatible history publish a full update without deltas.

Validation:
- All 57 release-module tests passed.
- 39 focused provenance, manifest, history, and bundle tests passed, including subprocess download selection and digest rejection.
- Full typecheck/lint and formatting passed.
- Both architecture history fetches succeeded against the actual immutable GitHub releases.
- Standards and Spec reviews: no findings.

The preceding actual Nightly passed every source gate and both signed, notarized distribution jobs. Final acceptance will include another complete protected-main Nightly and remote feed verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS update history now supports the current package-provenance format.
  * Compatible release candidates are validated before downloads begin, including bundle and manifest integrity checks.
  * Older or invalid candidates are skipped safely, reducing unnecessary downloads.
  * If no compatible delta updates are available, a complete update is published instead.

* **Documentation**
  * Updated the macOS release runbook with the revised update-history validation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->